### PR TITLE
chore: upgrade filigree integration to v1.5.0

### DIFF
--- a/.agents/skills/filigree-workflow/SKILL.md
+++ b/.agents/skills/filigree-workflow/SKILL.md
@@ -160,6 +160,73 @@ filigree metrics          # cycle time, lead time, throughput
 filigree events <id>      # audit trail for a specific issue
 ```
 
+## Observations — Ambient Note-Taking
+
+Observations are a scratchpad for things you notice *while doing other work*. They
+are not issues — they're lightweight, expiring notes that let you capture a thought
+without breaking flow.
+
+### When to Observe
+
+Use `observe` (MCP) or `filigree observe` (CLI) whenever you notice something in
+passing that doesn't warrant stopping your current task. The core use case is:
+"I don't have time to investigate this right now, but I want to come back to it."
+Examples:
+
+- A code smell or design concern in a file you're reading
+- A missing test for an edge case you spotted
+- A potential bug that isn't related to your current work
+- A TODO or FIXME that looks stale
+- A dependency that might be outdated
+
+**Always include `file_path` and `line`** when the observation is about specific code.
+This anchors it for whoever triages it later.
+
+**Don't observe things that are clearly issues.** If you're confident something is a
+bug or a needed feature, create an issue directly. Observations are for "hmm, this
+might be worth looking at" — the uncertain middle ground.
+
+### Triage Workflow
+
+Observations expire after 14 days. Triage them before they rot:
+
+1. **At session end:** run `list_observations` and quickly scan what's accumulated
+2. **For each observation, decide:**
+   - **Dismiss** — not actionable, already fixed, or not worth tracking. Use
+     `dismiss_observation` with a brief reason for the audit trail.
+   - **Promote** — deserves to be tracked as an issue. Use `promote_observation`
+     which atomically creates an issue and labels it `from-observation`. Choose
+     the right issue type:
+     - `type='bug'` — something is broken or produces wrong results
+     - `type='task'` (default) — cleanup, improvement, or "this works but is shitty"
+     - `type='feature'` — a missing capability that should exist
+     - `type='requirement'` — a formal requirement to be reviewed, approved, and verified
+   - **Leave it** — still uncertain. Let it age. If it survives a few sessions
+     without being promoted, it's probably a dismiss.
+
+3. **Batch cleanup:** use `batch_dismiss_observations` when several observations
+   have gone stale together.
+
+### Promote vs Dismiss
+
+| Signal | Action |
+|--------|--------|
+| You noticed it twice in separate sessions | Promote |
+| It's in a hot code path or critical module | Promote |
+| It has a clear fix or next step | Promote |
+| It was about code that's since been refactored | Dismiss |
+| It's a style/taste preference, not a defect | Dismiss |
+| You can't articulate what the fix would be | Leave it (or dismiss if > 7 days old) |
+
+### Tracking the Pipeline
+
+Promoted observations get the `from-observation` label. To see the pipeline output:
+
+```bash
+filigree list --label=from-observation     # All promoted observations
+filigree search "from-observation"         # Search with context
+```
+
 ## Quick Decision Guide
 
 | Situation | Action |
@@ -171,3 +238,5 @@ filigree events <id>      # audit trail for a specific issue
 | "This task is bigger than expected" | Create sub-tasks, add deps |
 | "I'm done" | Comment, close with reason, check `ready` |
 | "Something changed while I worked" | `filigree changes --since <timestamp>` |
+| "I noticed something odd in this file" | `observe` with file_path and line — keep working |
+| "These observations are piling up" | `list_observations`, then dismiss or promote each |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -qE '\"command\"\\s*:\\s*\"[^\"]*git\\s+stash'; then echo 'BLOCKED: git stash is BANNED in this project — no exceptions, no workarounds, no excuses. Read the fucking CLAUDE.md. Pre-commit hooks cause data loss on stash pop conflicts. Commit to a branch instead. And stop being so fucking lazy — pre-existing faults still need to be fixed properly, not worked around with stash hacks.' >&2; exit 2; fi; if echo \"$TOOL_INPUT\" | grep -qE '\"command\"\\s*:\\s*\"[^\"]*git\\s+worktree'; then echo 'BLOCKED: git worktree is BANNED in this project — no exceptions. Read the fucking CLAUDE.md. Use regular branches instead. And stop being so fucking lazy — pre-existing faults still need to be fixed properly, not dodged with worktree isolation.' >&2; exit 2; fi",
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE '\"command\"\\s*:\\s*\"[^\"]*git\\s+stash'; then echo 'BLOCKED: git stash is BANNED in this project \u2014 no exceptions, no workarounds, no excuses. Read the fucking CLAUDE.md. Pre-commit hooks cause data loss on stash pop conflicts. Commit to a branch instead. And stop being so fucking lazy \u2014 pre-existing faults still need to be fixed properly, not worked around with stash hacks.' >&2; exit 2; fi; if echo \"$TOOL_INPUT\" | grep -qE '\"command\"\\s*:\\s*\"[^\"]*git\\s+worktree'; then echo 'BLOCKED: git worktree is BANNED in this project \u2014 no exceptions. Read the fucking CLAUDE.md. Use regular branches instead. And stop being so fucking lazy \u2014 pre-existing faults still need to be fixed properly, not dodged with worktree isolation.' >&2; exit 2; fi",
             "timeout": 1000
           }
         ]

--- a/.claude/skills/filigree-workflow/SKILL.md
+++ b/.claude/skills/filigree-workflow/SKILL.md
@@ -160,6 +160,73 @@ filigree metrics          # cycle time, lead time, throughput
 filigree events <id>      # audit trail for a specific issue
 ```
 
+## Observations — Ambient Note-Taking
+
+Observations are a scratchpad for things you notice *while doing other work*. They
+are not issues — they're lightweight, expiring notes that let you capture a thought
+without breaking flow.
+
+### When to Observe
+
+Use `observe` (MCP) or `filigree observe` (CLI) whenever you notice something in
+passing that doesn't warrant stopping your current task. The core use case is:
+"I don't have time to investigate this right now, but I want to come back to it."
+Examples:
+
+- A code smell or design concern in a file you're reading
+- A missing test for an edge case you spotted
+- A potential bug that isn't related to your current work
+- A TODO or FIXME that looks stale
+- A dependency that might be outdated
+
+**Always include `file_path` and `line`** when the observation is about specific code.
+This anchors it for whoever triages it later.
+
+**Don't observe things that are clearly issues.** If you're confident something is a
+bug or a needed feature, create an issue directly. Observations are for "hmm, this
+might be worth looking at" — the uncertain middle ground.
+
+### Triage Workflow
+
+Observations expire after 14 days. Triage them before they rot:
+
+1. **At session end:** run `list_observations` and quickly scan what's accumulated
+2. **For each observation, decide:**
+   - **Dismiss** — not actionable, already fixed, or not worth tracking. Use
+     `dismiss_observation` with a brief reason for the audit trail.
+   - **Promote** — deserves to be tracked as an issue. Use `promote_observation`
+     which atomically creates an issue and labels it `from-observation`. Choose
+     the right issue type:
+     - `type='bug'` — something is broken or produces wrong results
+     - `type='task'` (default) — cleanup, improvement, or "this works but is shitty"
+     - `type='feature'` — a missing capability that should exist
+     - `type='requirement'` — a formal requirement to be reviewed, approved, and verified
+   - **Leave it** — still uncertain. Let it age. If it survives a few sessions
+     without being promoted, it's probably a dismiss.
+
+3. **Batch cleanup:** use `batch_dismiss_observations` when several observations
+   have gone stale together.
+
+### Promote vs Dismiss
+
+| Signal | Action |
+|--------|--------|
+| You noticed it twice in separate sessions | Promote |
+| It's in a hot code path or critical module | Promote |
+| It has a clear fix or next step | Promote |
+| It was about code that's since been refactored | Dismiss |
+| It's a style/taste preference, not a defect | Dismiss |
+| You can't articulate what the fix would be | Leave it (or dismiss if > 7 days old) |
+
+### Tracking the Pipeline
+
+Promoted observations get the `from-observation` label. To see the pipeline output:
+
+```bash
+filigree list --label=from-observation     # All promoted observations
+filigree search "from-observation"         # Search with context
+```
+
 ## Quick Decision Guide
 
 | Situation | Action |
@@ -171,3 +238,5 @@ filigree events <id>      # audit trail for a specific issue
 | "This task is bigger than expected" | Create sub-tasks, add deps |
 | "I'm done" | Comment, close with reason, check `ready` |
 | "Something changed while I worked" | `filigree changes --since <timestamp>` |
+| "I noticed something odd in this file" | `observe` with file_path and line — keep working |
+| "These observations are piling up" | `list_observations`, then dismiss or promote each |

--- a/.mcp.json
+++ b/.mcp.json
@@ -14,8 +14,7 @@
       "args": [
         "--project",
         "/home/john/elspeth"
-      ],
-      "env": {}
+      ]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- filigree:instructions:v1.4.1:c706f2df -->
+<!-- filigree:instructions:v1.5.0:bcb039c9 -->
 ## Filigree Issue Tracker
 
 Use `filigree` for all task tracking in this project. Data lives in `.filigree/`.
@@ -16,6 +16,18 @@ faster and return structured data. Key tools:
 - `create_plan` / `get_plan` — milestone planning
 - `get_stats` / `get_metrics` — project health
 - `get_valid_transitions` — workflow navigation
+- `observe` / `list_observations` / `dismiss_observation` / `promote_observation` — agent scratchpad
+
+Observations are fire-and-forget notes that expire after 14 days. Use `list_issues --label=from-observation` to find promoted observations.
+
+**Observations are ambient.** While doing other work, use `observe` whenever you
+notice something worth noting — a code smell, a potential bug, a missing test, a
+design concern. Don't stop what you're doing; just fire off the observation and
+carry on. They're ideal for "I don't have time to investigate this right now, but
+I want to come back to it." Include `file_path` and `line` when relevant so the
+observation is anchored to code. At session end, skim `list_observations` and
+either `dismiss` (not worth tracking) or `promote` (deserves an issue) anything
+that's accumulated.
 
 Fall back to CLI (`filigree <command>`) when MCP is unavailable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -887,7 +887,7 @@ if result.rowcount == 0:
 | Am I adding this because "something might be None"? | — | ❌ Fix the root cause |
 | Am I silently swallowing an error with a default value? | — | ❌ That's defensive — forbidden |
 
-<!-- filigree:instructions:v1.4.1:c706f2df -->
+<!-- filigree:instructions:v1.5.0:bcb039c9 -->
 ## Filigree Issue Tracker
 
 Use `filigree` for all task tracking in this project. Data lives in `.filigree/`.
@@ -905,6 +905,18 @@ faster and return structured data. Key tools:
 - `create_plan` / `get_plan` — milestone planning
 - `get_stats` / `get_metrics` — project health
 - `get_valid_transitions` — workflow navigation
+- `observe` / `list_observations` / `dismiss_observation` / `promote_observation` — agent scratchpad
+
+Observations are fire-and-forget notes that expire after 14 days. Use `list_issues --label=from-observation` to find promoted observations.
+
+**Observations are ambient.** While doing other work, use `observe` whenever you
+notice something worth noting — a code smell, a potential bug, a missing test, a
+design concern. Don't stop what you're doing; just fire off the observation and
+carry on. They're ideal for "I don't have time to investigate this right now, but
+I want to come back to it." Include `file_path` and `line` when relevant so the
+observation is anchored to code. At session end, skim `list_observations` and
+either `dismiss` (not worth tracking) or `promote` (deserves an issue) anything
+that's accumulated.
 
 Fall back to CLI (`filigree <command>`) when MCP is unavailable.
 


### PR DESCRIPTION
## Summary
- Install filigree 1.5.0 into project venv, update MCP server and hook paths
- Inject v1.5.0 instruction blocks into CLAUDE.md and AGENTS.md (adds observations/ambient note-taking feature)
- Update skill packs for Claude Code and Codex integrations

## Test plan
- [x] `filigree doctor` passes (15/15)
- [x] MCP server responds to `get_stats` call
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)