### PR TITLE
feat(composer): guided-mode wizard — Phases 1-10 umbrella PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,37 @@ jobs:
             --allowlist config/cicd/enforce_tier_1_decoration
 
   # ===========================================================================
+  # Stage 2a: SlotType / guided.ts cross-language mirror check
+  # ===========================================================================
+  check-slot-type-cross-language:
+    name: SlotType cross-language mirror check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q libsqlcipher-dev
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Check SlotType / guided.ts mirror consistency
+        run: uv run python scripts/cicd/check_slot_type_cross_language.py
+
+  # ===========================================================================
   # Stage 2b: Contract Enforcement (Settings→Runtime alignment)
   # ===========================================================================
   contract-enforcement:
@@ -174,7 +205,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    needs: [lint, enforce-tier-model, enforce-audit-evidence-nominal, enforce-tier-1-decoration, contract-enforcement]
+    needs: [lint, enforce-tier-model, enforce-audit-evidence-nominal, enforce-tier-1-decoration, contract-enforcement, check-slot-type-cross-language]
     strategy:
       fail-fast: false
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,3 +111,11 @@ repos:
         types: [python]
         pass_filenames: false
         files: ^(src/elspeth/|scripts/cicd/enforce_contract_manifest\.py|config/cicd/enforce_contract_manifest/)
+
+      - id: check-slot-type-cross-language
+        name: SlotType / guided.ts mirror consistency check
+        entry: .venv/bin/python scripts/cicd/check_slot_type_cross_language.py
+        language: system
+        pass_filenames: false
+        # Run when either the Python Literal definition or its TypeScript mirror changes.
+        files: ^(src/elspeth/web/composer/recipes\.py|src/elspeth/web/frontend/src/types/guided\.ts)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to ELSPETH are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Composer guided mode** — new structured-protocol wizard for first-time
+  pipeline authors. Source → sink → transforms in three steps; closed
+  six-turn taxonomy; deterministic recipe pre-match; LLM-read-only with
+  respect to pipeline state. Ships alongside the unmodified freeform
+  composer; mode transition uses progressive disclosure.
+  See `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md`.
+
+---
+
 ## [0.5.1] - 2026-05-11 (RC-5.1 — Composer Correctness, Validator Hardening, and Audit-Integrity Coverage)
 
 RC-5.1 is a correctness and assurance follow-up to RC-5. The Web Composer's

--- a/config/cicd/contracts-whitelist.yaml
+++ b/config/cicd/contracts-whitelist.yaml
@@ -567,6 +567,8 @@ allowed_dict_patterns:
   - "src/elspeth/web/composer/guided/state_machine.py:SinkOutputResolved.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.to_dict:return"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:SourceIntent.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:SourceIntent.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkIntent.to_dict:return"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkIntent.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.to_dict:return"

--- a/config/cicd/contracts-whitelist.yaml
+++ b/config/cicd/contracts-whitelist.yaml
@@ -567,6 +567,8 @@ allowed_dict_patterns:
   - "src/elspeth/web/composer/guided/state_machine.py:SinkOutputResolved.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.to_dict:return"
   - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkIntent.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkIntent.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.to_dict:return"
   - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:GuidedSession.to_dict:return"

--- a/config/cicd/contracts-whitelist.yaml
+++ b/config/cicd/contracts-whitelist.yaml
@@ -575,6 +575,11 @@ allowed_dict_patterns:
   - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.from_dict:d"
   - "src/elspeth/web/composer/guided/state_machine.py:GuidedSession.to_dict:return"
   - "src/elspeth/web/composer/guided/state_machine.py:GuidedSession.from_dict:d"
+  # RecipeMatch serialization — staged offer persisted in GuidedSession.step_2_5_recipe_offer.
+  # to_dict() / from_dict() follow the same Tier-1-strict pattern as the rest of the
+  # guided state-machine types (direct key access, KeyError/ValueError chained via `from exc`).
+  - "src/elspeth/web/composer/guided/recipe_match.py:RecipeMatch.to_dict:return"
+  - "src/elspeth/web/composer/guided/recipe_match.py:RecipeMatch.from_dict:d"
 
   # YAML generator — strips web-specific metadata from plugin options dicts
   # Options are dynamic (vary by plugin) so dict[str, Any] is the correct type

--- a/config/cicd/contracts-whitelist.yaml
+++ b/config/cicd/contracts-whitelist.yaml
@@ -549,6 +549,29 @@ allowed_dict_patterns:
   - "src/elspeth/web/composer/state.py:CompositionState.from_dict:d"
   - "src/elspeth/web/composer/state.py:CompositionState.with_metadata:patch"
   - "src/elspeth/web/composer/state.py:CompositionState.to_dict:return"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # WEB COMPOSER — GuidedSession state-machine serialization (Tier 1 audit)
+  # from_dict() accepts plain dicts from JSON deserialization (Tier 1 read).
+  # to_dict() returns plain dicts for SQLite JSON-column serialization.
+  # All from_dict() implementations are strict: direct key access, enum
+  # construction, KeyError/ValueError chained via `from exc`.
+  # ═══════════════════════════════════════════════════════════════════════════
+  - "src/elspeth/web/composer/guided/state_machine.py:TerminalState.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:TerminalState.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:TurnRecord.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:TurnRecord.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:SourceResolved.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:SourceResolved.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkOutputResolved.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkOutputResolved.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:SinkResolved.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:ChainProposal.from_dict:d"
+  - "src/elspeth/web/composer/guided/state_machine.py:GuidedSession.to_dict:return"
+  - "src/elspeth/web/composer/guided/state_machine.py:GuidedSession.from_dict:d"
+
   # YAML generator — strips web-specific metadata from plugin options dicts
   # Options are dynamic (vary by plugin) so dict[str, Any] is the correct type
   - "src/elspeth/web/composer/yaml_generator.py:_strip_web_metadata:options"

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -366,7 +366,7 @@ allow_hits:
   reason: Tier 3 boundary — JWT claims dict .get() for optional iat claim
   safety: Missing iat returns None; no fabrication
   expires: null
-- key: web/composer/state.py:R5:_declared_input_fields_option:fp=fb4067e05511aaff
+- key: web/composer/state.py:R5:_declared_input_fields_option:fp=502f741cded36b7f
   owner: web-composer
   reason: Composer state options are Tier 3 LLM/user-supplied plugin config; wrapper-shaped
     aggregation options may carry an optional nested options mapping that must be
@@ -375,7 +375,7 @@ allow_hits:
     validation reports malformed aggregation wrapper options as blocking ValidationEntry
     results, while top-level required_input_fields is still rejected
   expires: null
-- key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=c74f6ddd778da661
+- key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=d1a169d5f9065034
   owner: web-composer
   reason: Composer state options are Tier 3 LLM/user-supplied plugin config; the rule
     inspects web_scrape's options.http.abuse_contact at composer-validate time,
@@ -399,7 +399,7 @@ allow_hits:
     shape matches and the domain is reserved, returns a high-severity blocking
     ValidationEntry naming the node and field, rendering the pipeline invalid.
   expires: null
-- key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=37164e1dc3371406
+- key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=1506b9194afa9cb9
   owner: web-composer
   reason: Same Tier-3 boundary as the paired R5 entry above; the helper uses
     options.get('http') and http.get('abuse_contact') because the composer
@@ -415,7 +415,7 @@ allow_hits:
     defect. The rule's own error path fires only when the value is shape-valid
     AND the domain is reserved.
   expires: null
-- key: web/composer/state.py:R5:_check_schema_contracts:_is_config_probe_exception:fp=2362eadcc48b831e
+- key: web/composer/state.py:R5:_check_schema_contracts:_is_config_probe_exception:fp=26c535468a0fea7b
   owner: web-composer
   reason: Composer preview classifies only known plugin config/probe exception types
     while probing plugin-computed output contracts for shape-changing transforms.
@@ -429,7 +429,7 @@ allow_hits:
     for known pass-through plugins, which then forces Stage 1 rejection) instead of
     crashing or fabricating a stronger contract
   expires: null
-- key: web/composer/state.py:R1:_check_schema_contracts:_producer_emit_set:fp=db82467039a016c0
+- key: web/composer/state.py:R1:_check_schema_contracts:_producer_emit_set:fp=a7ff000684d2eac3
   owner: web-composer
   reason: _producer_emit_set looks up a producer's NodeSpec in node_by_id; sources
     have producer_id == "source" which is not a node, so the lookup may legitimately
@@ -456,7 +456,7 @@ allow_hits:
     translates to SemanticOutcome.UNKNOWN; FAIL-policy consumers then emit a structured
     error naming only the requirement_code and plugin names, never the exception text.
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=9b74c6ec125d8740
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=1125db8205b802bf
   owner: web-composer
   reason: Contract helper ValueError (consumer required-fields parse) is intentionally
     converted into a blocking ValidationEntry on the consumer node instead of raising
@@ -464,7 +464,7 @@ allow_hits:
   safety: The pipeline remains invalid; no contract telemetry is fabricated for that
     consumer edge
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=2f7d16a3b98bb83e
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=fe41814a7ca029fc
   owner: web-composer
   reason: _consumer_locked_input_set ValueError (consumer schema parse) is intentionally
     converted into a blocking ValidationEntry on the consumer node instead of raising
@@ -474,14 +474,14 @@ allow_hits:
   safety: The pipeline remains invalid; no contract telemetry is fabricated for that
     consumer edge and Rule A is short-circuited for that consumer
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=adc1dd434b1fd56b
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=0515578db03f0f64
   owner: web-composer
   reason: Producer contract parse failures are intentionally converted into blocking
     ValidationEntry results and the producer is marked uncheckable
   safety: The invalid producer blocks validation and suppresses downstream edge contracts
     instead of silently continuing
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=65ab7638ce2f6df1
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=abc96077d0216880
   owner: web-composer
   reason: Rule A producer-emit ValueError swallowed silently because _effective_producer_guarantees
     has already raised the same producer parse error above and surfaced it as a blocking
@@ -490,14 +490,14 @@ allow_hits:
   safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees
     call; pipeline remains invalid; Rule A is correctly skipped for this edge
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=7ec00da0ef61c90a
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=6cc4d5a150857308
   owner: web-composer
   reason: Sink contract parse failures are intentionally converted into blocking ValidationEntry
     results on the output
   safety: The pipeline remains invalid and the sink edge contract is skipped rather
     than fabricated
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=8e75d0a874bd2398
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=1051492e9c40cb3c
   owner: web-composer
   reason: _sink_locked_input_set ValueError (sink schema parse) is intentionally converted
     into a blocking ValidationEntry on the output. Mirrors the sink required-fields
@@ -506,14 +506,14 @@ allow_hits:
   safety: The pipeline remains invalid; no contract telemetry is fabricated for that
     sink and Rule B is short-circuited for that output
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=47a8ea15bb1f8a69
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=43b5b8f01a4c357f
   owner: web-composer
   reason: Sink-side producer parse failures are intentionally converted into blocking
     ValidationEntry results and the producer is marked uncheckable
   safety: The pipeline remains invalid and downstream sink contract evidence is suppressed
     for the bad producer
   expires: null
-- key: web/composer/state.py:R6:_check_schema_contracts:fp=6e3a1b6e628fd390
+- key: web/composer/state.py:R6:_check_schema_contracts:fp=27259f3e3d303e40
   owner: web-composer
   reason: 'Rule B producer-emit ValueError swallowed silently because _effective_producer_guarantees
     has already raised the same producer parse error above and surfaced it as a blocking
@@ -523,7 +523,7 @@ allow_hits:
   safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees
     call; pipeline remains invalid; Rule B is correctly skipped for this edge
   expires: null
-- key: web/composer/state.py:R1:_check_schema_contracts:fp=7f788bd20677fb7e
+- key: web/composer/state.py:R1:_check_schema_contracts:fp=f69bad753b005c9c
   owner: web-composer
   reason: Rule C reads field_mapper's select_only flag from raw Tier-3 user/LLM-supplied
     options. dict.get with default False matches FieldMapperConfig.select_only's pydantic
@@ -534,7 +534,7 @@ allow_hits:
     because select_only=False puts field_mapper into the additive/loose-bound regime
     that Rule C explicitly does not adjudicate
   expires: null
-- key: web/composer/state.py:R6:CompositionState:validate:fp=9bde8ab7cd932a09
+- key: web/composer/state.py:R6:CompositionState:validate:fp=c26ba18c5c5ef7c2
   owner: web-composer
   reason: Aggregation trigger PydanticValidationError is intentionally converted into
     a blocking ValidationEntry so composer rejects malformed trigger.condition values
@@ -2063,7 +2063,7 @@ allow_hits:
   safety: Only suppresses signal exceptions; all other exceptions logged as last-resort
     diagnostic
   expires: null
-- key: web/composer/state.py:R5:_is_static_contract_probe_exception:fp=ba1a951f96628d16
+- key: web/composer/state.py:R5:_is_static_contract_probe_exception:fp=df312727f02279b0
   owner: web-composer
   reason: Composer static-contract probes instantiate draft plugins while the user/LLM
     may still be filling options. Known config/probe exception classes are classified
@@ -2608,7 +2608,7 @@ allow_hits:
     Download button. The audit trail still shows the artifact's recorded path_or_uri,
     exists_now, and content_hash. No bytes are served on a False result.
   expires: null
-- key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=320551bb03e05601
+- key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=b18e4e501177b46d
   owner: web-composer
   reason: Tier 3 boundary — LLM/operator-supplied node options may shape `http` as
     a non-Mapping (e.g., null, list). Validator returns None on shape mismatch and
@@ -2617,7 +2617,7 @@ allow_hits:
   safety: Returns None; downstream plugin schema rule reports the malformed http block
     as a separate ValidationEntry.
   expires: null
-- key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=9158c77d7a443d63
+- key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=54928459e9ddb422
   owner: web-composer
   reason: Tier 3 boundary — abuse_contact is an optional sub-key of the operator-supplied
     http options block. Missing key is a documented optional configuration, not an

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1,10 +1,40 @@
 allow_hits:
-- key: web/composer/guided/protocol.py:R5:validate_payload:fp=57d0a263a79cd691
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=66d6dab65ff1dca8
   owner: composer-guided
   reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry point where untrusted payloads arrive
     from client, distinguishes valid TurnType enum member from arbitrary string to reject malformed protocol messages early
   safety: Raises ValueError if turn_type is not a known TurnType; callers are expected to handle this exception or pass verified
     types only
+  expires: null
+- key: web/composer/guided/protocol.py:R1:validate_payload:fp=0aaf84e80b0f3a16
+  owner: composer-guided
+  reason: _NESTED_SHAPES.get(turn_type, ()) — TurnTypes without nested shapes are not in the mapping; default-empty-tuple is
+    idiomatic and correct here (not an error-suppressing defensive get on arbitrary data)
+  safety: Returns empty tuple when no nested shapes defined; outer loop is a no-op; no data loss or fabrication
+  expires: null
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=5d05d1a4d8ee3767
+  owner: composer-guided
+  reason: Tier 3 nested payload validator — isinstance(field_value, Mapping) validates that a nested payload field is the
+    expected type; this is an offensive Tier 3 boundary check that produces a human-readable error string, not silent suppression
+  safety: Returns path-rooted error string on type mismatch; does not coerce or fabricate; caller handles the returned error
+  expires: null
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=b1c238e1d15c64c6
+  owner: composer-guided
+  reason: Tier 3 nested payload validator — isinstance(field_value, Sequence) validates that a sequence-of-mappings field
+    is a Sequence; this is an offensive Tier 3 boundary check that produces a human-readable error string
+  safety: Returns path-rooted error string on type mismatch; does not coerce or fabricate; caller handles the returned error
+  expires: null
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=7b58a70a6bb73778
+  owner: composer-guided
+  reason: Tier 3 nested payload validator — isinstance(field_value, str) excludes bare strings from being accepted as a
+    Sequence (strings are Sequences but not valid slot-list payloads); this is an offensive boundary guard
+  safety: Returns path-rooted error string when string used where sequence-of-mappings expected; no coercion or fabrication
+  expires: null
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=7735328c4307cec9
+  owner: composer-guided
+  reason: Tier 3 nested payload validator — isinstance(item, Mapping) validates that each element of a sequence-of-mappings
+    field is a Mapping; offensive Tier 3 boundary check producing a human-readable error string
+  safety: Returns path-rooted error string on type mismatch; does not coerce or fabricate; caller handles the returned error
   expires: null
 - key: web/catalog/routes.py:R1:get_schema:fp=bc80b0854f0cb34e
   owner: web-catalog

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1201,71 +1201,70 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1be1c129fa92774d
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=ffca897cb790a9e0
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values plugin must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper inserted before
-    _dispatch_guided_respond.
+    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2a0fea9e6ceb3e51
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=f69c066d8c437cfd
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values options must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=69411a55206a1442
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=94c6948da36d1f56
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values observed_columns must be a list per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=98a6c55320ec0c28
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=262903a398ce0427
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values sample_rows must be a list per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c91cf38fd80079d8
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=81eddbbbce09762f
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values columns must be a list
     per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=15014ebb01dd4f1f
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=8713c6f133e1ea37
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values plugin must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=bed58ea3edf7011d
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=7f22117713d754be
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values options must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=35ed7971402f2bc8
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=9e57548fcf473ec9
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values recipe_name must be a non-empty
     string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
-    contract-citing detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    contract-citing detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=075a3c0199d8228d
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=806ff20539ad565e
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values slots must be a Mapping per
     the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=684ae8a3c5af57d9
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=86a979dd4b4f794a
   owner: web-sessions
   reason: >-
     HTTP-boundary trust-boundary validation (Codex 16) - each element of Step-1 SCHEMA_FORM edited_values sample_rows
@@ -1468,88 +1467,88 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=08507e15a67e9819
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=b9a0bb90301e091a
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps shielded
-    cancelled-LLM-call audit persistence. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    cancelled-LLM-call audit persistence. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as the prior entry; shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4bf21bb63e3513fa
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=81759b68464086d0
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps the shielded
-    progress publish. FP rotated by Codex 12 _validate_control_signal helper insertion.
+    progress publish. FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as the prior entry; shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=7707cb6ca62307e6
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=418edb1896282fff
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of cancelled-LLM-call audit persistence suppress.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=ac0f5a5738328c42
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=da65992455fd4fdb
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of shielded-publish suppress.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=4f6cd12f991f1575
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=d12ff64e3b96a327
   owner: web-sessions
   reason: isinstance check on deserialized composition state source; Tier 3 boundary.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=93517ea08146d4bb
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=fe9a31c9e9bd1def
   owner: web-sessions
   reason: source_dict.get("options") on Tier 3 composition state; optional source options.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=431b4edc07c31793
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=0f3482bdfe3655a4
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating nested fields.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=bdda27355a72c072
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=5a98e326432be931
   owner: web-sessions
   reason: options.get("blob_ref") on Tier 3 state source; blob_ref is optional.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=8602354191c100ec
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cce861498cefe919
   owner: web-sessions
   reason: isinstance(old_ref, str); blob_ref may be str or UUID from persisted state.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Tier 3 boundary; persisted blob_ref type is not guaranteed.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2a8e1609b0a8e349
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=84832fa0551fbfe5
   owner: web-sessions
   reason: blob_map.get(old_uuid); not every source reference is guaranteed to have a copied blob target.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=7c2e2a4eb5a02d69
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=ae136c2c1ec52e86
   owner: web-sessions
   reason: options.get(path_key) on persisted source options; path/file keys are optional.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: None result skips that key; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=910f1cff92369aea
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=c05f800ea7195fac
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted values.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e960860608dc63ed
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=4c8cfd127804fd7a
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=b801a89e19a756ae
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=94d90532f2afb3db
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path.
-    FP rotated by Codex 12 _validate_control_signal helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
 - key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=edd58c4a70f20c34

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1203,35 +1203,13 @@ allow_hits:
     pattern which would have crashed deep in the comprehension on a non-iterable.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=eafccf78781770d8
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c62857823fd15c3b
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['plugin'] must be a non-empty
-    string per the server-side state_machine contract (see test_state_machine.test_initial_session_advances_after_source_confirmed);
-    isinstance here is offensive validation (raises HTTPException 400 with the offending value in the detail), not error
-    suppression. Replaces the previous silent str(edited['plugin']) coercion.
-  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
-  expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d4d75e0f7d0db601
-  owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['options'] must be a Mapping
-    per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400 with the
-    actual type in the detail), not error suppression. Replaces the previous silent dict(edited.get("options", {})) default.
-  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
-  expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=4be385491212b4dd
-  owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['observed_columns'] must
-    be a list per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400
-    with the actual type in the detail), not error suppression. Replaces the previous silent tuple(edited.get("observed_columns", []))
-    default.
-  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
-  expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2230df199fe835a4
-  owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['sample_rows'] must be a
-    list per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400 with
-    the actual type in the detail), not error suppression. Replaces the previous silent tuple(dict(r) for r in edited.get("sample_rows", []))
-    pattern.
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['columns'] must be a list
+    per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
+    type in the detail), not error suppression. The guard is HTTP-reachable as 400 because _advance_step_1's
+    ``tuple(str(c) for c in columns_raw)`` coercion would silently accept a scalar string (iterating its characters), so the
+    dispatcher catches non-list here before that coercion runs. Resolves elspeth-obs-57451bbaa6.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=690a1fa6374c17d1

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1,4 +1,12 @@
 allow_hits:
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=1c7c9f6e216882eb
+  owner: composer-guided
+  reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry
+    point where untrusted payloads arrive from client, distinguishes valid TurnType
+    enum member from arbitrary string to reject malformed protocol messages early
+  safety: Raises ValueError if turn_type is not a known TurnType; callers are expected
+    to handle this exception or pass verified types only
+  expires: null
 - key: web/catalog/routes.py:R1:get_schema:fp=bc80b0854f0cb34e
   owner: web-catalog
   reason: Tier 3 boundary — plugin_type from URL path parameter, lookup in constant

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1206,17 +1206,21 @@ allow_hits:
     be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=5c6bd309ba8475d8
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=93b211a4e6a30476
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
+  reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['recipe_name'] must be a non-empty
+    string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
+    contract-citing detail), not error suppression. Replaces the previous silent str(edited.get("recipe_name", "")) default
+    which masked protocol drift as a downstream "unknown recipe ''" error.
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=7ced99282cc4454b
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=cc6841deb1d46d38
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
+  reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['slots'] must be a Mapping per
+    the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
+    type in the detail), not error suppression. Replaces the previous silent dict(edited.get("slots", {})) default which
+    would have collapsed null/list/scalar payloads into an empty dict.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
   owner: web-validation

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1265,6 +1265,15 @@ allow_hits:
     type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=684ae8a3c5af57d9
+  owner: web-sessions
+  reason: >-
+    HTTP-boundary trust-boundary validation (Codex 16) - each element of Step-1 SCHEMA_FORM edited_values sample_rows
+    must be a Mapping before dict(r) is called; isinstance here is offensive validation (raises HTTPException 400 naming
+    the offending index), not error suppression. Without this guard a non-Mapping element (int, str, list) triggers
+    TypeError inside the tuple comprehension, yielding an uncontrolled 500 instead of a deterministic 400.
+  safety: Contract violation raises HTTPException 400 with the offending index and type name in the detail; no fall-through, no fabrication.
+  expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
   owner: web-validation
   reason: Union type dispatch — function receives PluginNotFoundError | PluginConfigError, isinstance needed to read component_type

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1,5 +1,5 @@
 allow_hits:
-- key: web/composer/guided/protocol.py:R5:validate_payload:fp=1c7c9f6e216882eb
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=b5b1d34b5d81a046
   owner: composer-guided
   reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry point where untrusted payloads arrive
     from client, distinguishes valid TurnType enum member from arbitrary string to reject malformed protocol messages early
@@ -2271,27 +2271,27 @@ allow_hits:
     step_1_result is stored unchanged. The enrichment is opportunistic — absence of path leaves recipe match in the correct
     no-blob_ref state.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=3b92b7e07cfd1037
+- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=c9e0d4caec92d135
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. FP rotated from a6c6f31ab3c80323 by blob_id→blob_ref conversion (classify resolver rewrite).
+    operator confirmation. FP rotated from 3b92b7e07cfd1037 by Gap 6 unsatisfied_slots threading (Task 10.0).
   safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"]; operator confirms or
     overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=aceba16af59b73b5
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=c9fd2f14c6c34847
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. FP rotated from 04eea8af1e9b234a by blob_id→blob_ref conversion (threshold resolver rewrite).
+    operator confirmation. FP rotated from aceba16af59b73b5 by Gap 6 unsatisfied_slots threading (Task 10.0).
   safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"]; operator confirms
     or overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=3e175261cb3f249d
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=c2b794bf9adad12d
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. FP rotated from 6c8bcb44b83e0e72 by blob_id→blob_ref conversion (threshold resolver rewrite).
+    operator confirmation. FP rotated from 3e175261cb3f249d by Gap 6 unsatisfied_slots threading (Task 10.0).
   safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["below_output_path"]; operator confirms
     or overrides via recipe_offer turn.
   expires: null

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1197,7 +1197,7 @@ allow_hits:
     periodic orphan cleanup task
   safety: Clean cancellation during app shutdown; no error suppression
   expires: null
-- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=f27d833f9650dafd
+- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=617365ac6c45895a
   owner: composer-audit
   reason: Audit-system-failure exemption (logging-telemetry-policy permits slog when
     audit DB itself fails). Per-tool-call audit row persistence is best-effort — a
@@ -1209,7 +1209,7 @@ allow_hits:
     gap is observable on read-back by comparing tool-row count against the parent
     assistant message's reported tool_invocations count.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=7f671a896e0e7fff
+- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=61d4cc6981e69907
   owner: composer-audit
   reason: Audit-system-failure exemption (logging-telemetry-policy permits slog when
     audit DB itself fails). Per-LLM-call audit row persistence is best-effort — a
@@ -1383,7 +1383,7 @@ allow_hits:
     by check-and-crash
   safety: Missing key raises RuntimeError immediately; no silent default
   expires: null
-- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=0bff594ec03859a4
+- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=12379b77e06e61bf
   owner: web-sessions
   reason: Convergence partial-state save may fail — catch covers the full SQLAlchemyError
     family (IntegrityError, OperationalError for lock timeout or pool disconnect,
@@ -1399,7 +1399,7 @@ allow_hits:
     carry the exception class name only — no SQL statement, no bound parameters, no
     __cause__ text.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=8d657157fdaa9ead
+- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=37cf20ba4b750216
   owner: web-sessions
   reason: Plugin-crash partial-state save may fail — catch covers the full SQLAlchemyError
     family. A narrow IntegrityError catch would let OperationalError, ProgrammingError,
@@ -1413,7 +1413,7 @@ allow_hits:
     policy as the convergence path). Original plugin crash still propagates via the
     outer `raise HTTPException(...) from crash.original_exc`.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=e9908b3f36af186f
+- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=ed956ce449f63a48
   owner: web-sessions
   reason: Runtime-preflight partial-state save may fail — catch covers the full SQLAlchemyError
     family, structurally identical to the sibling _handle_plugin_crash and _handle_convergence_error
@@ -1430,46 +1430,46 @@ allow_hits:
     Original runtime-preflight cause still propagates via the outer `raise HTTPException(...)
     from rpf_exc.original_exc` at the call site.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=17333444fb57e819
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=1a1b2d1f29569684
   owner: web-sessions
   reason: isinstance check on deserialized composition state source — Tier 3 boundary.
   safety: Validates structure from persisted state
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=5d9b35be30667109
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=24aa5d23430343e0
   owner: web-sessions
   reason: source_dict.get() on Tier 3 composition state — optional source options.
   safety: Returns None on miss, and the blob rewrite path is skipped
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=16b9b2e125fe99f8
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=db78fbcacf1075f0
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating
     nested fields during fork blob rewrite
   safety: Non-dict raises AuditIntegrityError immediately; no silent skip or coercion
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=a3b85c271c321d75
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=76ebef5c0af14703
   owner: web-sessions
   reason: options.get() on Tier 3 state source — blob_ref is optional.
   safety: Returns None on miss, handled by conditional below
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=a2b66d5064762486
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=390c0356ee6e5e8c
   owner: web-sessions
   reason: isinstance check on blob_ref — may be str or UUID from persisted state.
   safety: Tier 3 boundary — persisted blob_ref type is not guaranteed
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=6c5cdc4243cb89ca
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2f77d7a0421ee569
   owner: web-sessions
   reason: blob_map.get() on copied blob UUID — not every source reference is guaranteed
     to have a copied blob target, so fork rewrite falls back to path/file matching
   safety: None result only triggers the secondary path/file rewrite probe; no fabricated
     blob mapping is introduced
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=f4dcdbc81dc03ba8
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=71ff014a59a9ca5c
   owner: web-sessions
   reason: options.get(path_key) on persisted source options — path/file keys are optional
     and used only for fallback blob rewrite
   safety: None result skips that fallback key and continues scanning remaining candidates
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=39150539f64a5590
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=a468266561e25f69
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string
     persisted path/file values
@@ -1477,7 +1477,7 @@ allow_hits:
     remain unchanged and can still fail later validation instead of being silently
     coerced
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=8e9d56460634cd2b
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=c7e3e5350cf2de96
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in
     the BlobQuotaExceededError path — DB/IO faults expected during cleanup; programmer
@@ -1486,7 +1486,7 @@ allow_hits:
     that propagates; orphan sessions.id flagged for manual cleanup; user-facing 413
     response remains intact even when cleanup fails
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=b23d0900b09f19a7
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=4164e16b5f52e001
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in
     the generic except Exception path — DB/IO faults expected during cleanup; programmer
@@ -1529,14 +1529,14 @@ allow_hits:
     Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=5b5a0d95b7682fd0
+- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=2678dd33866365b8
   owner: web-sessions
   reason: App-scoped compose lock registry is initialized lazily on first session-router
     use rather than being required at startup
   safety: Missing attribute allocates and stores a new _SessionComposeLockRegistry
     on request.app.state; subsequent calls reuse the same object
   expires: null
-- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=9f82f6b420faaa2d
+- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=9c2cf533334f7c5d
   owner: web-sessions
   reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed
     on every provider error object, and this helper only surfaces it in explicit staging/debug
@@ -1544,14 +1544,14 @@ allow_hits:
   safety: Missing status_code omits provider_status_code from the response; no fabricated
     status is emitted, and the stable redacted detail still uses type(exc).__name__.
   expires: null
-- key: web/sessions/routes.py:R1:_state_response:fp=b1eed0e9f8f2d21b
+- key: web/sessions/routes.py:R1:_state_response:fp=0340a4ef021a8c9c
   owner: web-sessions
   reason: Unwrapping redact_source_storage_path() output — helper returns dict with
     "source" key; .get() with fallback to original is defensive against helper contract
     change
   safety: Falls back to unredacted source_data (less privacy, not less safety)
   expires: null
-- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=7550128d639f0273
+- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=f3e7f1107ced0b46
   owner: web-sessions
   reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome
     union type — sentinel, ValidationResult, and None are the three legal values;
@@ -1560,7 +1560,7 @@ allow_hits:
   safety: Exhaustive dispatch with ValueError for invalid combinations; no silent
     default
   expires: null
-- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=555266b38fd7bd01
+- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=048a7103542e87c1
   owner: web-sessions
   reason: state.validate() may fail on structurally damaged partial-state from LLM
     convergence/crash — catch (ValueError, TypeError, KeyError) mirrors the pre-existing
@@ -1569,7 +1569,7 @@ allow_hits:
   safety: Falls back to ValidationSummary(is_valid=False) with a generic error entry;
     does not swallow the damage, just allows persistence to proceed
   expires: null
-- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=f2253230e2d45ff7
+- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=198b85f2e78b5b2e
   owner: web-sessions
   reason: isinstance(runtime, ValidationResult) dispatches the _RuntimePreflightOutcome
     union type to emit telemetry — sentinel and ValidationResult must be distinguished
@@ -1813,7 +1813,7 @@ allow_hits:
     future's eventual exception via add_done_callback so asyncio's GC handler cannot
     fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=1c4e54a89f43f66f
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=a37dcabbfe22fc90
   owner: web-sessions
   reason: contextlib.suppress(asyncio.CancelledError) wraps the shielded cancelled-LLM-call
     audit persistence in the send_message cancellation handler. asyncio.shield re-raises
@@ -1825,7 +1825,7 @@ allow_hits:
     with class-name-only slog. The explicit raise after the progress publish preserves
     the cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=39dfcb6381860680
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=13a5f800c2fa367c
   owner: web-sessions
   reason: contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
     publish in the send_message cancellation handler — asyncio.shield re-raises CancelledError
@@ -1838,7 +1838,7 @@ allow_hits:
     is preserved by the explicit ``raise`` that follows, so no real cancellation is
     silently dropped — only the duplicate re-raise from the shield is suppressed.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=759d0321844796a0
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=553aa51d778c8e12
   owner: web-sessions
   reason: Mirror of the send_message cancelled-LLM-call audit persistence suppress
     above — recompose has the same cancellation and audit-sidecar contract.
@@ -1846,7 +1846,7 @@ allow_hits:
     is best-effort, sanitized, and followed by an explicit re-raise that preserves
     cancellation semantics.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=47395e8d06359ae1
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=c9dd3de7ce2dcd5f
   owner: web-sessions
   reason: Mirror of the send_message cancellation handler above — same shielded-publish
     pattern in the recompose route so cancellation behaviour cannot drift between

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1411,16 +1411,18 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=7b716b48f0be464b
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4f394ff64e8b1291
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
-    audit persistence; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted routes.py when post_guided_respond was added.
+    audit persistence; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed flip logic
+    before the CancelledError handler in send_message.
   safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d751dcfc9fa4c949
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d62b85dbb726d15a
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
-    publish in the cancellation handler; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted routes.py when post_guided_respond was added.
+    publish in the cancellation handler; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed
+    flip logic before the CancelledError handler in send_message.
   safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
 - key: web/sessions/routes.py:R7:create_session_router:recompose:fp=cd95569a81303ada

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1201,77 +1201,68 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d48a5a2d814e4af5
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1be1c129fa92774d
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values plugin must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. Replaces the previous silent str(edited['plugin']) coercion that masked
-    contract drift.
+    value in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper inserted before
+    _dispatch_guided_respond.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=b4b49b523cc3a013
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2a0fea9e6ceb3e51
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['options'] must be a Mapping per the
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values options must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. Replaces the previous silent dict(edited.get("options", {})) default which would
-    have collapsed null/list/scalar payloads into an empty dict and fabricated upstream contract conformance.
+    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1fe3412bcd84bd85
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=69411a55206a1442
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['observed_columns'] must be a list per
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values observed_columns must be a list per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. Replaces the previous silent tuple(edited.get("observed_columns", [])) default
-    which would have silently accepted scalars and yielded character-wise tuples (e.g. tuple("abc") → ('a','b','c')).
+    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1d46f8b9f9d4684f
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=98a6c55320ec0c28
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['sample_rows'] must be a list per the
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values sample_rows must be a list per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. Replaces the previous silent tuple(dict(r) for r in edited.get("sample_rows", []))
-    pattern which would have crashed deep in the comprehension on a non-iterable.
+    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=4d81c5e48f62089b
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c91cf38fd80079d8
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['columns'] must be a list
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values columns must be a list
     per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. The guard is HTTP-reachable as 400 because _advance_step_1's
-    ``tuple(str(c) for c in columns_raw)`` coercion would silently accept a scalar string (iterating its characters), so the
-    dispatcher catches non-list here before that coercion runs. Resolves elspeth-obs-57451bbaa6.
+    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=7ab395b1d9772442
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=15014ebb01dd4f1f
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values plugin must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. Replaces the previous str(edited['plugin']) coercion that would have stringified
-    any payload (including None).
+    value in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d43305a68bd1dcd9
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=bed58ea3edf7011d
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['options'] must be a Mapping per the
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values options must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. Replaces the previous dict(edited['options']) call which would have crashed deep
-    on non-mappings.
+    in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c866e7dc93d93ee7
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=35ed7971402f2bc8
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['recipe_name'] must be a non-empty
+  reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values recipe_name must be a non-empty
     string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
-    contract-citing detail), not error suppression. Replaces the previous silent str(edited.get("recipe_name", "")) default
-    which masked protocol drift as a downstream "unknown recipe ''" error.
+    contract-citing detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2e558c1507b6f496
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=075a3c0199d8228d
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['slots'] must be a Mapping per
+  reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values slots must be a Mapping per
     the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. Replaces the previous silent dict(edited.get("slots", {})) default which
-    would have collapsed null/list/scalar payloads into an empty dict.
+    type in the detail), not error suppression. FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
@@ -1468,88 +1459,88 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d66e00138da0f0c4
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=08507e15a67e9819
   owner: web-sessions
-  reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
-    audit persistence; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed flip logic
-    before the CancelledError handler in send_message.
-  safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
+  reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps shielded
+    cancelled-LLM-call audit persistence. FP rotated by Codex 12 _validate_control_signal helper insertion.
+  safety: Same as the prior entry; shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=9bda8dca88eb99ca
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4bf21bb63e3513fa
   owner: web-sessions
-  reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
-    publish in the cancellation handler; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed
-    flip logic before the CancelledError handler in send_message.
-  safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
+  reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps the shielded
+    progress publish. FP rotated by Codex 12 _validate_control_signal helper insertion.
+  safety: Same as the prior entry; shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=72252eb1a66e6d8a
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=7707cb6ca62307e6
   owner: web-sessions
-  reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
-    rotated by guided_terminal / _post_compose_guided block insertion (Task 5.2 fix).
+  reason: Same as the prior recompose R7 entry; mirror of cancelled-LLM-call audit persistence suppress.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=38896944bced28f6
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=ac0f5a5738328c42
   owner: web-sessions
-  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by guided_terminal
-    / _post_compose_guided block insertion (Task 5.2 fix).
+  reason: Same as the prior recompose R7 entry; mirror of shielded-publish suppress.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cda3ae2175a3a50f
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=4f6cd12f991f1575
   owner: web-sessions
-  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
-    routes.py when post_guided_respond was added.
+  reason: isinstance check on deserialized composition state source; Tier 3 boundary.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=a27644806d428952
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=93517ea08146d4bb
   owner: web-sessions
-  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
-    routes.py when post_guided_respond was added.
+  reason: source_dict.get("options") on Tier 3 composition state; optional source options.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=303f527b72cfef63
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=431b4edc07c31793
   owner: web-sessions
-  reason: isinstance(options, dict) validates persisted source.options before mutating nested fields during fork blob rewrite;
-    FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: isinstance(options, dict) validates persisted source.options before mutating nested fields.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=f810695c334095c6
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=bdda27355a72c072
   owner: web-sessions
-  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
-    routes.py when post_guided_respond was added.
+  reason: options.get("blob_ref") on Tier 3 state source; blob_ref is optional.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=0fea32bcbafc94be
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=8602354191c100ec
   owner: web-sessions
-  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Tier 3 boundary — persisted blob_ref type is not guaranteed.
+  reason: isinstance(old_ref, str); blob_ref may be str or UUID from persisted state.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
+  safety: Tier 3 boundary; persisted blob_ref type is not guaranteed.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=91d7ce27c2701fc9
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2a8e1609b0a8e349
   owner: web-sessions
-  reason: blob_map.get(old_uuid) — not every source reference is guaranteed to have a copied blob target; FP changed after
-    ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: blob_map.get(old_uuid); not every source reference is guaranteed to have a copied blob target.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=c5ad0fd939b93a58
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=7c2e2a4eb5a02d69
   owner: web-sessions
-  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: options.get(path_key) on persisted source options; path/file keys are optional.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: None result skips that key; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=bd60cb85fb591735
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=910f1cff92369aea
   owner: web-sessions
-  reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted path/file values; FP
-    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted values.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=5632eb606c04d1bc
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e960860608dc63ed
   owner: web-sessions
-  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path; FP changed
-    after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=d1306e4027bed96c
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=b801a89e19a756ae
   owner: web-sessions
-  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
-    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path.
+    FP rotated by Codex 12 _validate_control_signal helper insertion.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
 - key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=edd58c4a70f20c34

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1467,28 +1467,28 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=b9a0bb90301e091a
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4c7563702ecc116c
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps shielded
-    cancelled-LLM-call audit persistence. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    cancelled-LLM-call audit persistence. FP rotated by I1 InvariantError handler insertion.
   safety: Same as the prior entry; shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=81759b68464086d0
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=50fd21ed36b9a97b
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps the shielded
-    progress publish. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    progress publish. FP rotated by I1 InvariantError handler insertion.
   safety: Same as the prior entry; shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=418edb1896282fff
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=bcbd2b6f13602433
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of cancelled-LLM-call audit persistence suppress.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by I1 InvariantError handler insertion.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=da65992455fd4fdb
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=a3647707c431903e
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of shielded-publish suppress.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by I1 InvariantError handler insertion.
   safety: Same as the prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=d12ff64e3b96a327

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1205,72 +1205,72 @@ allow_hits:
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values plugin must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=f69c066d8c437cfd
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values options must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=94c6948da36d1f56
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values observed_columns must be a list per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=262903a398ce0427
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values sample_rows must be a list per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=86a979dd4b4f794a
+  owner: web-sessions
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values columns must be a list
+    per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=81eddbbbce09762f
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values columns must be a list
-    per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
-  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values plugin must be a non-empty string per
+    the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
+    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=8713c6f133e1ea37
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values plugin must be a non-empty string per
-    the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
-    value in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
-  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values options must be a Mapping per the
+    SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
+    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=7f22117713d754be
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values options must be a Mapping per the
-    SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
-    in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
-  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values recipe_name must be a non-empty
+    string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
+    contract-citing detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=9e57548fcf473ec9
   owner: web-sessions
-  reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values recipe_name must be a non-empty
-    string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
-    contract-citing detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
-  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
-  expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=806ff20539ad565e
-  owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — recipe_offer accept edited_values slots must be a Mapping per
     the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
-    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion.
+    type in the detail), not error suppression. FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=86a979dd4b4f794a
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=806ff20539ad565e
   owner: web-sessions
   reason: >-
     HTTP-boundary trust-boundary validation (Codex 16) - each element of Step-1 SCHEMA_FORM edited_values sample_rows
     must be a Mapping before dict(r) is called; isinstance here is offensive validation (raises HTTPException 400 naming
     the offending index), not error suppression. Without this guard a non-Mapping element (int, str, list) triggers
-    TypeError inside the tuple comprehension, yielding an uncontrolled 500 instead of a deterministic 400.
+    TypeError inside the tuple comprehension, yielding an uncontrolled 500 instead of a deterministic 400. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Contract violation raises HTTPException 400 with the offending index and type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
@@ -1470,144 +1470,144 @@ allow_hits:
 - key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4c7563702ecc116c
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps shielded
-    cancelled-LLM-call audit persistence. FP rotated by I1 InvariantError handler insertion.
+    cancelled-LLM-call audit persistence. FP rotated by I1 InvariantError handler insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as the prior entry; shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
 - key: web/sessions/routes.py:R7:create_session_router:send_message:fp=50fd21ed36b9a97b
   owner: web-sessions
   reason: Same as the prior send_message R7 entry; contextlib.suppress(asyncio.CancelledError) wraps the shielded
-    progress publish. FP rotated by I1 InvariantError handler insertion.
+    progress publish. FP rotated by I1 InvariantError handler insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as the prior entry; shielded publish completes; explicit raise restores cancellation chain.
   expires: null
 - key: web/sessions/routes.py:R7:create_session_router:recompose:fp=bcbd2b6f13602433
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of cancelled-LLM-call audit persistence suppress.
-    FP rotated by I1 InvariantError handler insertion.
+    FP rotated by I1 InvariantError handler insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as the prior entry.
   expires: null
 - key: web/sessions/routes.py:R7:create_session_router:recompose:fp=a3647707c431903e
   owner: web-sessions
   reason: Same as the prior recompose R7 entry; mirror of shielded-publish suppress.
-    FP rotated by I1 InvariantError handler insertion.
+    FP rotated by I1 InvariantError handler insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as the prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=d12ff64e3b96a327
   owner: web-sessions
   reason: isinstance check on deserialized composition state source; Tier 3 boundary.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
 - key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=fe9a31c9e9bd1def
   owner: web-sessions
   reason: source_dict.get("options") on Tier 3 composition state; optional source options.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=0f3482bdfe3655a4
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating nested fields.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
 - key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=5a98e326432be931
   owner: web-sessions
   reason: options.get("blob_ref") on Tier 3 state source; blob_ref is optional.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cce861498cefe919
   owner: web-sessions
   reason: isinstance(old_ref, str); blob_ref may be str or UUID from persisted state.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Tier 3 boundary; persisted blob_ref type is not guaranteed.
   expires: null
 - key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=84832fa0551fbfe5
   owner: web-sessions
   reason: blob_map.get(old_uuid); not every source reference is guaranteed to have a copied blob target.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=ae136c2c1ec52e86
   owner: web-sessions
   reason: options.get(path_key) on persisted source options; path/file keys are optional.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: None result skips that key; same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=c05f800ea7195fac
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted values.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=4c8cfd127804fd7a
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
 - key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=94d90532f2afb3db
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path.
-    FP rotated by Codex 7 _validate_step_indices helper insertion.
+    FP rotated by Codex 7 _validate_step_indices helper insertion. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior fork_from_message R6 entry.
   expires: null
 - key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=edd58c4a70f20c34
   owner: web-sessions
   reason: App-scoped compose lock registry is initialized lazily on first session-router use rather than being required at
-    startup; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+    startup; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _get_session_compose_lock_registry entry.
   expires: null
 - key: web/sessions/routes.py:R2:_litellm_error_detail:fp=d3def3abf63c61e0
   owner: web-sessions
   reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed on every provider error object; FP
-    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _litellm_error_detail entry.
   expires: null
 - key: web/sessions/routes.py:R1:_state_response:fp=94a786ee0bdcaf12
   owner: web-sessions
-  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Falls back to unredacted source_data (less privacy, not less safety); same as prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=297ade1feddcc00d
   owner: web-sessions
   reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome union type; FP changed
-    after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+    after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _composer_persisted_validation entry.
   expires: null
 - key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=77fa2aecae3080b8
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _persist_tool_invocations entry.
   expires: null
 - key: web/sessions/routes.py:R6:_persist_llm_calls:fp=68c8189140f7ae51
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _persist_llm_calls entry.
   expires: null
 - key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=65720fbc32da5171
   owner: web-sessions
-  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _state_data_from_composer_state R6 entry.
   expires: null
 - key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=fc58e94effd4a771
   owner: web-sessions
   reason: isinstance(runtime, ValidationResult) dispatches _RuntimePreflightOutcome union type for telemetry; FP changed after
-    ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+    ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _state_data_from_composer_state R5 entry.
   expires: null
 - key: web/sessions/routes.py:R6:_handle_convergence_error:fp=e97c35544a90e1ee
   owner: web-sessions
-  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _handle_convergence_error entry.
   expires: null
 - key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=11e82bf267f1def2
   owner: web-sessions
-  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _handle_plugin_crash entry.
   expires: null
 - key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1eb57f4115a3b2d3
   owner: web-sessions
-  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish). FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Same as prior _handle_runtime_preflight_failure entry.
   expires: null
 - key: web/app.py:R1:create_app:fp=298d81d738bfa3b0
@@ -1655,7 +1655,7 @@ allow_hits:
     finally so an audit-system failure during exception handling cannot mask the in-flight HTTPException. Python's default
     behaviour is to let a finally-block raise replace the outer exception; allowing that here would surface a generic 500
     instead of the intended 400/409 and lose the original audit trail. The handler must surface the original outcome to
-    the client unchanged.
+    the client unchanged. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Caught exception is logged via slog.error under the audit-system-failure exemption (CLAUDE.md telemetry primacy
     order) with exc_class + frames only (B1 convention — never str(exc) since the exception message may carry Tier-bearing
     strings). The original HTTPException continues to propagate. No silent suppression; operators observe the audit-persist
@@ -1665,7 +1665,7 @@ allow_hits:
   owner: composer-guided
   reason: PR-review B3 finally-block drain — same rationale as get_guided above. The post_guided_respond handler emits
     guided_turn_answered before the dispatcher's try-block can raise 400; the finally-drain ensures that audit event lands
-    even on rejection paths, and the broad except prevents a persist failure from masking the original 400/409/500.
+    even on rejection paths, and the broad except prevents a persist failure from masking the original 400/409/500. FP rotated again by I2 _guided_solve_chain.py module import.
   safety: Caught exception is logged via slog.error under the audit-system-failure exemption with exc_class + frames only
     (B1 convention). The original HTTPException continues to propagate. No silent suppression; operators observe the
     audit-persist failure via the structured log event.

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1,32 +1,28 @@
 allow_hits:
 - key: web/composer/guided/protocol.py:R5:validate_payload:fp=1c7c9f6e216882eb
   owner: composer-guided
-  reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry
-    point where untrusted payloads arrive from client, distinguishes valid TurnType
-    enum member from arbitrary string to reject malformed protocol messages early
-  safety: Raises ValueError if turn_type is not a known TurnType; callers are expected
-    to handle this exception or pass verified types only
+  reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry point where untrusted payloads arrive
+    from client, distinguishes valid TurnType enum member from arbitrary string to reject malformed protocol messages early
+  safety: Raises ValueError if turn_type is not a known TurnType; callers are expected to handle this exception or pass verified
+    types only
   expires: null
 - key: web/catalog/routes.py:R1:get_schema:fp=bc80b0854f0cb34e
   owner: web-catalog
-  reason: Tier 3 boundary — plugin_type from URL path parameter, lookup in constant
-    dict
+  reason: Tier 3 boundary — plugin_type from URL path parameter, lookup in constant dict
   safety: Returns None on miss, handled by 404 response
   expires: null
 - key: web/config.py:R5:WebSettings:_reject_blank_path_strings:fp=a2a02a4cfa344c13
   owner: architecture
-  reason: Pydantic before-validator at Tier 3 config boundary — isinstance(v, str)
-    distinguishes raw YAML string input (which may be all-whitespace) from already-coerced
-    Path values or None, rejecting blank strings before Pydantic's str→Path coercion
-    silently accepts them. Mode=before runs prior to coercion so the type is not yet
-    guaranteed, which is why isinstance rather than direct .strip() is used.
-  safety: Raises ValueError on blank string input; non-string values pass through
-    to Pydantic's normal path validation; no silent coercion
+  reason: Pydantic before-validator at Tier 3 config boundary — isinstance(v, str) distinguishes raw YAML string input (which
+    may be all-whitespace) from already-coerced Path values or None, rejecting blank strings before Pydantic's str→Path coercion
+    silently accepts them. Mode=before runs prior to coercion so the type is not yet guaranteed, which is why isinstance rather
+    than direct .strip() is used.
+  safety: Raises ValueError on blank string input; non-string values pass through to Pydantic's normal path validation; no
+    silent coercion
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_extract_config_fields:fp=b4a0510125abce03
   owner: web-catalog
-  reason: Tier 3 boundary — Pydantic-generated JSON schema 'properties' key may be
-    absent
+  reason: Tier 3 boundary — Pydantic-generated JSON schema 'properties' key may be absent
   safety: Default empty dict; no properties means no config fields
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_extract_config_fields:fp=816144ac56504e6d
@@ -36,23 +32,18 @@ allow_hits:
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_fields_from_discriminated:fp=787f2794ac1e0cec
   owner: web-catalog
-  reason: Tier 3 boundary — JSON Schema oneOf entry may carry inline schema instead
-    of $ref
-  safety: Default empty string fails the startswith(prefix) guard and the branch is
-    skipped
+  reason: Tier 3 boundary — JSON Schema oneOf entry may carry inline schema instead of $ref
+  safety: Default empty string fails the startswith(prefix) guard and the branch is skipped
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_fields_from_discriminated:fp=0593034aa10317db
   owner: web-catalog
-  reason: Tier 3 boundary — variant $defs entry may declare no 'properties' (empty
-    config)
+  reason: Tier 3 boundary — variant $defs entry may declare no 'properties' (empty config)
   safety: Default empty dict; variant contributes no field names to the union
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_fields_from_discriminated:fp=ea2d38196092229b
   owner: web-catalog
-  reason: Tier 3 boundary — variant $defs entry may declare no 'required' list (no
-    mandatory fields)
-  safety: Default empty list; variant's required set is empty; intersection-required
-    handles correctly
+  reason: Tier 3 boundary — variant $defs entry may declare no 'required' list (no mandatory fields)
+  safety: Default empty list; variant's required set is empty; intersection-required handles correctly
   expires: null
 - key: web/catalog/service.py:R1:CatalogServiceImpl:_field_summary:fp=bb6ceaf2795988d5
   owner: web-catalog
@@ -97,114 +88,91 @@ allow_hits:
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:decode_token:fp=593e0af0074215d6
   owner: web-auth
   reason: Tier 3 boundary — JWT header kid field is optional per RFC 7515
-  safety: Missing kid falls through to AuthenticationError path (no matching key);
-    no silent acceptance
+  safety: Missing kid falls through to AuthenticationError path (no matching key); no silent acceptance
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_validate_discovery_document:fp=7b72be83fb8bf0f7
   owner: web-auth
-  reason: Tier 3 boundary — OIDC discovery JSON top-level shape (dict vs. list/string)
-    must be validated before indexing
-  safety: Non-dict raises AuthenticationError with got-type in message; no silent
-    coercion; converts to HTTP 401
+  reason: Tier 3 boundary — OIDC discovery JSON top-level shape (dict vs. list/string) must be validated before indexing
+  safety: Non-dict raises AuthenticationError with got-type in message; no silent coercion; converts to HTTP 401
   expires: null
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:_validate_discovery_document:fp=393627c554a657f9
   owner: web-auth
-  reason: Tier 3 boundary — discovery dict.get('jwks_uri') lets us validate type before
-    use rather than letting KeyError mask malformed JSON
-  safety: Missing or non-string raises AuthenticationError; validated string is returned
-    to caller; no caching before validation
+  reason: Tier 3 boundary — discovery dict.get('jwks_uri') lets us validate type before use rather than letting KeyError mask
+    malformed JSON
+  safety: Missing or non-string raises AuthenticationError; validated string is returned to caller; no caching before validation
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_validate_discovery_document:fp=050deebdeb8bfc07
   owner: web-auth
-  reason: Tier 3 boundary — jwks_uri must be a non-empty string; IdPs have been observed
-    returning integers/nulls for this field
-  safety: Non-string or empty raises AuthenticationError with a specific message;
-    no silent fallback
+  reason: Tier 3 boundary — jwks_uri must be a non-empty string; IdPs have been observed returning integers/nulls for this
+    field
+  safety: Non-string or empty raises AuthenticationError with a specific message; no silent fallback
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_validate_jwks_document:fp=0814d66955701c3e
   owner: web-auth
-  reason: Tier 3 boundary — JWKS JSON top-level shape must be dict before passing
-    to PyJWKSet.from_dict (which raises AttributeError on non-dict)
-  safety: Non-dict raises AuthenticationError before self._jwks is assigned; malformed
-    responses cannot poison the cache
+  reason: Tier 3 boundary — JWKS JSON top-level shape must be dict before passing to PyJWKSet.from_dict (which raises AttributeError
+    on non-dict)
+  safety: Non-dict raises AuthenticationError before self._jwks is assigned; malformed responses cannot poison the cache
   expires: null
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:_validate_jwks_document:fp=000e385cef7d8d09
   owner: web-auth
-  reason: Tier 3 boundary — jwks.get('keys') permits shape-checking the value type
-    before handing off to PyJWKSet
+  reason: Tier 3 boundary — jwks.get('keys') permits shape-checking the value type before handing off to PyJWKSet
   safety: Non-list raises AuthenticationError; validation happens before cache assignment
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_validate_jwks_document:fp=6f55b6f9dc56c36b
   owner: web-auth
-  reason: Tier 3 boundary — 'keys' field must be a list per RFC 7517; IdPs have been
-    observed returning objects or nulls
+  reason: Tier 3 boundary — 'keys' field must be a list per RFC 7517; IdPs have been observed returning objects or nulls
   safety: Non-list raises AuthenticationError; cache not written until shape is verified
   expires: null
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:_get_token_algorithm:fp=e6da8061e94c304e
   owner: web-auth
-  reason: Tier 3 boundary — JWT header alg is external token metadata and may be absent
-    before decode
+  reason: Tier 3 boundary — JWT header alg is external token metadata and may be absent before decode
   safety: Missing alg raises AuthenticationError before jwt.decode selects an algorithm
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_get_token_algorithm:fp=c3d5bff62157490f
   owner: web-auth
   reason: Tier 3 boundary — JWT header alg must be a non-empty string before decode
-  safety: Non-string or blank alg raises AuthenticationError; no silent fallback to
-    another algorithm
+  safety: Non-string or blank alg raises AuthenticationError; no silent fallback to another algorithm
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_get_jwk_algorithm:fp=de17cc341f202e2e
   owner: web-auth
-  reason: Tier 3 boundary — individual JWKS entries may be non-object values even
-    when the top-level keys list is valid
-  safety: Non-dict entries are skipped during kid matching; malformed entries do not
-    crash the auth path
+  reason: Tier 3 boundary — individual JWKS entries may be non-object values even when the top-level keys list is valid
+  safety: Non-dict entries are skipped during kid matching; malformed entries do not crash the auth path
   expires: null
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:_get_jwk_algorithm:fp=f344522ba920a705
   owner: web-auth
-  reason: Tier 3 boundary — JWK kid is optional metadata and must be compared defensively
-    against the token header kid
-  safety: Missing or non-matching kid continues the search; final no-match raises
-    AuthenticationError
+  reason: Tier 3 boundary — JWK kid is optional metadata and must be compared defensively against the token header kid
+  safety: Missing or non-matching kid continues the search; final no-match raises AuthenticationError
   expires: null
 - key: web/auth/oidc.py:R1:JWKSTokenValidator:_get_jwk_algorithm:fp=57935b9d084d5f3c
   owner: web-auth
-  reason: Tier 3 boundary — JWK alg is optional metadata and is only enforced when
-    the matched key advertises one
-  safety: None preserves honest absence; non-empty mismatches raise AuthenticationError
-    before decode
+  reason: Tier 3 boundary — JWK alg is optional metadata and is only enforced when the matched key advertises one
+  safety: None preserves honest absence; non-empty mismatches raise AuthenticationError before decode
   expires: null
 - key: web/auth/oidc.py:R5:JWKSTokenValidator:_get_jwk_algorithm:fp=cddeaf8b7fd695dd
   owner: web-auth
   reason: Tier 3 boundary — matched JWK alg must be a non-empty string if present
-  safety: Invalid alg raises AuthenticationError; malformed IdP metadata is rejected
-    rather than silently ignored
+  safety: Invalid alg raises AuthenticationError; malformed IdP metadata is rejected rather than silently ignored
   expires: null
 - key: web/auth/oidc.py:R1:OIDCAuthProvider:authenticate:fp=3e6bc7ed5a4ac005
   owner: web-auth
-  reason: Tier 3 boundary — preferred_username is optional in OIDC tokens, falls back
-    to sub
-  safety: Default is payload['sub'] which is required; absence of optional claim is
-    expected
+  reason: Tier 3 boundary — preferred_username is optional in OIDC tokens, falls back to sub
+  safety: Default is payload['sub'] which is required; absence of optional claim is expected
   expires: null
 - key: web/auth/oidc.py:R1:OIDCAuthProvider:_optional_profile_claim:fp=9c36a06f27aea4c1
   owner: web-auth
-  reason: Tier 3 boundary — optional OIDC profile claims are looked up generically
-    and may be absent from the external token payload
-  safety: Missing claims return None so callers preserve honest absence instead of
-    fabricating display data
+  reason: Tier 3 boundary — optional OIDC profile claims are looked up generically and may be absent from the external token
+    payload
+  safety: Missing claims return None so callers preserve honest absence instead of fabricating display data
   expires: null
 - key: web/auth/oidc.py:R5:OIDCAuthProvider:_optional_profile_claim:fp=cf33f9c8429e9850
   owner: web-auth
-  reason: Tier 3 boundary — optional cosmetic claims must be visible strings before
-    surfacing in the UI
-  safety: Non-string or blank values return None; malformed IdP data is dropped rather
-    than exposed
+  reason: Tier 3 boundary — optional cosmetic claims must be visible strings before surfacing in the UI
+  safety: Non-string or blank values return None; malformed IdP data is dropped rather than exposed
   expires: null
 - key: web/auth/oidc.py:R1:OIDCAuthProvider:get_user_info:fp=e15cc5f5ab6b3e2d
   owner: web-auth
   reason: Tier 3 boundary — groups claim is optional in OIDC tokens; None = no groups
-  safety: None returns empty groups; non-list raises AuthenticationError; no silent
-    discard
+  safety: None returns empty groups; non-list raises AuthenticationError; no silent discard
   expires: null
 - key: web/auth/oidc.py:R5:OIDCAuthProvider:get_user_info:fp=79d0cdd7f4d823e0
   owner: web-auth
@@ -213,8 +181,7 @@ allow_hits:
   expires: null
 - key: web/auth/oidc.py:R1:OIDCAuthProvider:get_user_info:fp=13fe88b1bd7c9f1e
   owner: web-auth
-  reason: Tier 3 boundary — preferred_username is optional in OIDC tokens, falls back
-    to sub
+  reason: Tier 3 boundary — preferred_username is optional in OIDC tokens, falls back to sub
   safety: Default is payload['sub'] which is required
   expires: null
 - key: web/auth/entra.py:R1:EntraAuthProvider:_extract_groups:fp=268368c0e155cc41
@@ -239,15 +206,12 @@ allow_hits:
   expires: null
 - key: web/auth/entra.py:R1:EntraAuthProvider:authenticate:fp=564181fecfacb986
   owner: web-auth
-  reason: Tier 3 boundary — preferred_username is optional in Entra tokens, falls
-    back to sub
-  safety: Default is payload['sub'] which is required; absence of optional claim is
-    expected
+  reason: Tier 3 boundary — preferred_username is optional in Entra tokens, falls back to sub
+  safety: Default is payload['sub'] which is required; absence of optional claim is expected
   expires: null
 - key: web/auth/entra.py:R1:EntraAuthProvider:get_user_info:fp=656288e79c8eb5cc
   owner: web-auth
-  reason: Tier 3 boundary — preferred_username is optional in Entra tokens, falls
-    back to sub
+  reason: Tier 3 boundary — preferred_username is optional in Entra tokens, falls back to sub
   safety: Default is payload['sub'] which is required
   expires: null
 - key: web/auth/entra.py:R1:EntraAuthProvider:get_user_info:fp=3b33e715a472f615
@@ -267,87 +231,73 @@ allow_hits:
   expires: null
 - key: web/auth/models.py:R5:UserIdentity:__post_init__:fp=085af69aa85f4acc
   owner: web-auth
-  reason: Tier 3 boundary — isinstance check on user_id from external IdP JWT payload
-    (sub claim is Any)
+  reason: Tier 3 boundary — isinstance check on user_id from external IdP JWT payload (sub claim is Any)
   safety: Raises AuthenticationError on non-string; validated at construction time
   expires: null
 - key: web/auth/models.py:R5:UserIdentity:__post_init__:fp=fc1331f656d792bc
   owner: web-auth
-  reason: Tier 3 boundary — isinstance check on username from external IdP JWT payload
-    (preferred_username is Any)
+  reason: Tier 3 boundary — isinstance check on username from external IdP JWT payload (preferred_username is Any)
   safety: Raises AuthenticationError on non-string; validated at construction time
   expires: null
 - key: web/auth/models.py:R5:UserProfile:__post_init__:fp=1e107c02a0aae95c
   owner: web-auth
-  reason: Tier 3 boundary — isinstance check on user_id from external IdP JWT payload
-    (sub claim is Any)
+  reason: Tier 3 boundary — isinstance check on user_id from external IdP JWT payload (sub claim is Any)
   safety: Raises AuthenticationError on non-string; validated at construction time
   expires: null
 - key: web/auth/models.py:R5:UserProfile:__post_init__:fp=94dab5ba5bbf7397
   owner: web-auth
-  reason: Tier 3 boundary — isinstance check on username from external IdP JWT payload
-    (preferred_username is Any)
+  reason: Tier 3 boundary — isinstance check on username from external IdP JWT payload (preferred_username is Any)
   safety: Raises AuthenticationError on non-string; validated at construction time
   expires: null
 - key: web/app.py:R5:_settings_from_env:fp=ca2c85bed12ffe28
   owner: web-app
-  reason: Tier 3 boundary — JSON-parsed env var may be a list; isinstance check classifies
-    for tuple conversion
+  reason: Tier 3 boundary — JSON-parsed env var may be a list; isinstance check classifies for tuple conversion
   safety: isinstance used only for type dispatch; no contract masking
   expires: null
 - key: web/app.py:R6:_settings_from_env:fp=c99426453445d3e1
   owner: web-app
-  reason: Tier 3 boundary — env var value that isn't valid JSON is treated as plain
-    string (the common case)
+  reason: Tier 3 boundary — env var value that isn't valid JSON is treated as plain string (the common case)
   safety: JSONDecodeError caught only to fall back to raw string; no silent data loss
   expires: null
 - key: web/execution/progress.py:R8:ProgressBroadcaster:subscribe:fp=80dd3c1d05f93c94
   owner: web-execution
   reason: Subscriber map creates the per-run queue→state mapping lazily on first subscription
-  safety: Mutation is guarded by the broadcaster lock and only initializes empty internal
-    state
+  safety: Mutation is guarded by the broadcaster lock and only initializes empty internal state
   expires: null
 - key: web/execution/progress.py:R9:ProgressBroadcaster:unsubscribe:fp=d21d1c5a7f779ec1
   owner: web-execution
-  reason: Unsubscribe is idempotent — a queue may be absent because the WS handler
-    already removed it or cleanup_run raced ahead
+  reason: Unsubscribe is idempotent — a queue may be absent because the WS handler already removed it or cleanup_run raced
+    ahead
   safety: Missing entry simply means no state to remove; lock-protected no-op
   expires: null
 - key: web/execution/progress.py:R1:ProgressBroadcaster:broadcast:fp=895f7c6d83b0c1d9
   owner: web-execution
   reason: Broadcast treats an absent run entry as 'no subscribers' for that run
-  safety: A missing subscriber map results in a no-op broadcast, which is the correct
-    behavior
+  safety: A missing subscriber map results in a no-op broadcast, which is the correct behavior
   expires: null
 - key: web/execution/progress.py:R6:ProgressBroadcaster:_safe_put:fp=18e58b3e32b2e5fe
   owner: web-execution
-  reason: QueueFull for terminal events — drains queue and retries (terminal events
-    must never be dropped)
+  reason: QueueFull for terminal events — drains queue and retries (terminal events must never be dropped)
   safety: Terminal events guaranteed delivered; progress events use drop-oldest backpressure
   expires: null
 - key: web/execution/progress.py:R7:ProgressBroadcaster:_safe_put:fp=4148cfe963eb1f65
   owner: web-execution
-  reason: QueueEmpty suppressed during terminal event drain — queue may have been
-    consumed concurrently
+  reason: QueueEmpty suppressed during terminal event drain — queue may have been consumed concurrently
   safety: Race-safe no-op; no data loss
   expires: null
 - key: web/execution/progress.py:R7:ProgressBroadcaster:_safe_put:fp=4082e42d8f7ef55f
   owner: web-execution
-  reason: QueueEmpty suppressed during progress event drop-oldest — queue may have
-    been consumed between full check and drain
+  reason: QueueEmpty suppressed during progress event drop-oldest — queue may have been consumed between full check and drain
   safety: Race-safe no-op; no data loss
   expires: null
 - key: web/execution/progress.py:R6:ProgressBroadcaster:_safe_put:fp=b0813b2652b434b9
   owner: web-execution
-  reason: QueueFull after drop-oldest retry for non-terminal events — event dropped
-    rather than blocking pipeline thread
-  safety: Best-effort delivery for progress events; terminal events use separate drain
-    path
+  reason: QueueFull after drop-oldest retry for non-terminal events — event dropped rather than blocking pipeline thread
+  safety: Best-effort delivery for progress events; terminal events use separate drain path
   expires: null
 - key: web/execution/progress.py:R9:ProgressBroadcaster:cleanup_run:fp=bcf3a714f3cd29f0
   owner: web-execution
-  reason: Run cleanup is idempotent because unsubscribe and explicit cleanup can both
-    remove the same run entry
+  reason: Run cleanup is idempotent because unsubscribe and explicit cleanup can both remove the same run entry
   safety: Missing key simply means there are no remaining subscribers to clean up
   expires: null
 - key: web/auth/middleware.py:R6:get_current_user:fp=ea59abc681792adb
@@ -357,8 +307,7 @@ allow_hits:
   expires: null
 - key: web/auth/middleware.py:R1:get_current_user:fp=27850ac518f1116d
   owner: web-auth
-  reason: Tier 3 boundary — request.headers.get('Authorization') reads untrusted HTTP
-    header
+  reason: Tier 3 boundary — request.headers.get('Authorization') reads untrusted HTTP header
   safety: Missing header returns 401; malformed header returns 401; no default fabrication
   expires: null
 - key: web/auth/routes.py:R1:create_auth_router:refresh_token:fp=c6db2676f6c05f60
@@ -368,492 +317,397 @@ allow_hits:
   expires: null
 - key: web/composer/state.py:R5:_declared_input_fields_option:fp=502f741cded36b7f
   owner: web-composer
-  reason: Composer state options are Tier 3 LLM/user-supplied plugin config; wrapper-shaped
-    aggregation options may carry an optional nested options mapping that must be
-    inspected only when it is actually a mapping
-  safety: Non-mapping wrapper values are not accepted as valid; existing schema-contract
-    validation reports malformed aggregation wrapper options as blocking ValidationEntry
-    results, while top-level required_input_fields is still rejected
+  reason: Composer state options are Tier 3 LLM/user-supplied plugin config; wrapper-shaped aggregation options may carry
+    an optional nested options mapping that must be inspected only when it is actually a mapping
+  safety: Non-mapping wrapper values are not accepted as valid; existing schema-contract validation reports malformed aggregation
+    wrapper options as blocking ValidationEntry results, while top-level required_input_fields is still rejected
   expires: null
 - key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=d1a169d5f9065034
   owner: web-composer
-  reason: Composer state options are Tier 3 LLM/user-supplied plugin config; the rule
-    inspects web_scrape's options.http.abuse_contact at composer-validate time,
-    which means traversing an opaque dict whose internal shape is only constrained
-    by the plugin's own pydantic schema. isinstance(options, Mapping) and
-    isinstance(http, Mapping) and isinstance(abuse_contact, str) are early-return
-    shape guards at this Tier 3 boundary so the rule short-circuits cleanly when
-    plugin schema validation will already reject the malformed shape elsewhere
-    (missing http block, non-string abuse_contact like a {secret_ref:...} dict).
-    The rule fires only when the value is a real-shaped email and exists to reject
-    RFC 2606/6761 reserved-domain emails (example.com/.org/.net, *.test, *.invalid,
-    *.localhost, *.example) as fabricated wire-visible identity values that ship
-    as HTTP headers to scraped third parties — a Tier-1 audit-integrity defect.
-    Backstops the skill-prompt rule in pipeline_composer.md (web_scrape.http
-    section) introduced in commit 848ec5a1; observation obs-69697091d9 predicted
-    the need for this mechanical rule after a fresh dashboard test on session
-    3dda63b9 showed the prompt rule alone was insufficient.
-  safety: All three isinstance early-returns yield None (no error reported); the
-    plugin's pydantic schema is the authoritative reporter for missing/malformed
-    http or abuse_contact, so silence here does not mask any defect. When the
-    shape matches and the domain is reserved, returns a high-severity blocking
-    ValidationEntry naming the node and field, rendering the pipeline invalid.
+  reason: Composer state options are Tier 3 LLM/user-supplied plugin config; the rule inspects web_scrape's options.http.abuse_contact
+    at composer-validate time, which means traversing an opaque dict whose internal shape is only constrained by the plugin's
+    own pydantic schema. isinstance(options, Mapping) and isinstance(http, Mapping) and isinstance(abuse_contact, str) are
+    early-return shape guards at this Tier 3 boundary so the rule short-circuits cleanly when plugin schema validation will
+    already reject the malformed shape elsewhere (missing http block, non-string abuse_contact like a {secret_ref:...} dict).
+    The rule fires only when the value is a real-shaped email and exists to reject RFC 2606/6761 reserved-domain emails (example.com/.org/.net,
+    *.test, *.invalid, *.localhost, *.example) as fabricated wire-visible identity values that ship as HTTP headers to scraped
+    third parties — a Tier-1 audit-integrity defect. Backstops the skill-prompt rule in pipeline_composer.md (web_scrape.http
+    section) introduced in commit 848ec5a1; observation obs-69697091d9 predicted the need for this mechanical rule after a
+    fresh dashboard test on session 3dda63b9 showed the prompt rule alone was insufficient.
+  safety: All three isinstance early-returns yield None (no error reported); the plugin's pydantic schema is the authoritative
+    reporter for missing/malformed http or abuse_contact, so silence here does not mask any defect. When the shape matches
+    and the domain is reserved, returns a high-severity blocking ValidationEntry naming the node and field, rendering the
+    pipeline invalid.
   expires: null
 - key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=1506b9194afa9cb9
   owner: web-composer
-  reason: Same Tier-3 boundary as the paired R5 entry above; the helper uses
-    options.get('http') and http.get('abuse_contact') because the composer
-    state's options dict is an opaque LLM/user-supplied mapping whose internal
-    keys may legitimately be absent (a web_scrape transform under construction
-    may not yet have an http block, or an http block under construction may not
-    yet have abuse_contact set). The plugin's pydantic schema reports the
-    absence elsewhere; this rule short-circuits with None when the key is
-    missing, deferring to that authoritative reporter rather than double-
-    surfacing the same defect.
-  safety: Missing-key paths return None (no error reported), letting the
-    plugin's pydantic schema validator surface the missing-required-field
-    defect. The rule's own error path fires only when the value is shape-valid
-    AND the domain is reserved.
+  reason: Same Tier-3 boundary as the paired R5 entry above; the helper uses options.get('http') and http.get('abuse_contact')
+    because the composer state's options dict is an opaque LLM/user-supplied mapping whose internal keys may legitimately
+    be absent (a web_scrape transform under construction may not yet have an http block, or an http block under construction
+    may not yet have abuse_contact set). The plugin's pydantic schema reports the absence elsewhere; this rule short-circuits
+    with None when the key is missing, deferring to that authoritative reporter rather than double- surfacing the same defect.
+  safety: Missing-key paths return None (no error reported), letting the plugin's pydantic schema validator surface the missing-required-field
+    defect. The rule's own error path fires only when the value is shape-valid AND the domain is reserved.
   expires: null
 - key: web/composer/state.py:R5:_check_schema_contracts:_is_config_probe_exception:fp=26c535468a0fea7b
   owner: web-composer
-  reason: Composer preview classifies only known plugin config/probe exception types
-    while probing plugin-computed output contracts for shape-changing transforms.
-    The caught exception message is NOT surfaced to the UI — only type(exc).__name__
-    is embedded in the contract warning to prevent plugin-option leaks (URLs, credentials,
-    filesystem paths) via the preview response. ADR-007 adds fail-closed handling
-    for known pass-through plugins; non-pass-through plugins retain the v2 fallback
+  reason: Composer preview classifies only known plugin config/probe exception types while probing plugin-computed output
+    contracts for shape-changing transforms. The caught exception message is NOT surfaced to the UI — only type(exc).__name__
+    is embedded in the contract warning to prevent plugin-option leaks (URLs, credentials, filesystem paths) via the preview
+    response. ADR-007 adds fail-closed handling for known pass-through plugins; non-pass-through plugins retain the v2 fallback
     to raw guarantees.
-  safety: Unexpected exceptions are re-raised. Known config/probe exceptions are converted
-    into a warning and preview falls back to raw declared schema guarantees (or frozenset()
-    for known pass-through plugins, which then forces Stage 1 rejection) instead of
-    crashing or fabricating a stronger contract
+  safety: Unexpected exceptions are re-raised. Known config/probe exceptions are converted into a warning and preview falls
+    back to raw declared schema guarantees (or frozenset() for known pass-through plugins, which then forces Stage 1 rejection)
+    instead of crashing or fabricating a stronger contract
   expires: null
 - key: web/composer/state.py:R1:_check_schema_contracts:_producer_emit_set:fp=a7ff000684d2eac3
   owner: web-composer
-  reason: _producer_emit_set looks up a producer's NodeSpec in node_by_id; sources
-    have producer_id == "source" which is not a node, so the lookup may legitimately
-    miss. Direct dict access would crash on every source-as-producer call. The None
-    branch falls back to _effective_producer_guarantees, which is the established
-    source-aware path.
-  safety: Missing-key triggers the established declared-set fallback used by all source/non-transform
-    producers \u2014 Rule A/B membership check then operates on the source's raw guarantee
-    set rather than crashing. No data fabrication; no audit divergence
+  reason: _producer_emit_set looks up a producer's NodeSpec in node_by_id; sources have producer_id == "source" which is not
+    a node, so the lookup may legitimately miss. Direct dict access would crash on every source-as-producer call. The None
+    branch falls back to _effective_producer_guarantees, which is the established source-aware path.
+  safety: Missing-key triggers the established declared-set fallback used by all source/non-transform producers \u2014 Rule
+    A/B membership check then operates on the source's raw guarantee set rather than crashing. No data fabrication; no audit
+    divergence
   expires: null
 - key: web/composer/_semantic_validator.py:R5:_is_config_probe_exception:fp=f4dd333a133b13c6
   owner: web-composer
-  reason: The semantic-contract validator probes producer plugins to read their output_semantics()
-    during draft pipeline composition. Producer construction can fail with known draft/config
-    exceptions (PluginConfigError, PluginNotFoundError, TemplateError, UnknownPluginTypeError,
-    or "Invalid configuration for transform" ValueError) when the user has not finished
-    filling in options. Mirrors the same predicate at web/composer/state.py:_is_config_probe_exception
-    used by the schema-contract probe path. The caught exception text is NEVER embedded
-    in any ValidationEntry or SemanticEdgeContract — the only signal exposed downstream
-    is "no semantic facts" (treated as UNKNOWN by compare_semantic), preventing plugin-option
-    leaks via validator diagnostics.
-  safety: Unexpected exceptions are re-raised (per CLAUDE.md plugin-as-system-code
-    policy). Known draft/config exceptions yield producer_decl=None, which compare_semantic
-    translates to SemanticOutcome.UNKNOWN; FAIL-policy consumers then emit a structured
-    error naming only the requirement_code and plugin names, never the exception text.
+  reason: The semantic-contract validator probes producer plugins to read their output_semantics() during draft pipeline composition.
+    Producer construction can fail with known draft/config exceptions (PluginConfigError, PluginNotFoundError, TemplateError,
+    UnknownPluginTypeError, or "Invalid configuration for transform" ValueError) when the user has not finished filling in
+    options. Mirrors the same predicate at web/composer/state.py:_is_config_probe_exception used by the schema-contract probe
+    path. The caught exception text is NEVER embedded in any ValidationEntry or SemanticEdgeContract — the only signal exposed
+    downstream is "no semantic facts" (treated as UNKNOWN by compare_semantic), preventing plugin-option leaks via validator
+    diagnostics.
+  safety: Unexpected exceptions are re-raised (per CLAUDE.md plugin-as-system-code policy). Known draft/config exceptions
+    yield producer_decl=None, which compare_semantic translates to SemanticOutcome.UNKNOWN; FAIL-policy consumers then emit
+    a structured error naming only the requirement_code and plugin names, never the exception text.
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=1125db8205b802bf
   owner: web-composer
-  reason: Contract helper ValueError (consumer required-fields parse) is intentionally
-    converted into a blocking ValidationEntry on the consumer node instead of raising
-    immediately
-  safety: The pipeline remains invalid; no contract telemetry is fabricated for that
-    consumer edge
+  reason: Contract helper ValueError (consumer required-fields parse) is intentionally converted into a blocking ValidationEntry
+    on the consumer node instead of raising immediately
+  safety: The pipeline remains invalid; no contract telemetry is fabricated for that consumer edge
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=fe41814a7ca029fc
   owner: web-composer
-  reason: _consumer_locked_input_set ValueError (consumer schema parse) is intentionally
-    converted into a blocking ValidationEntry on the consumer node instead of raising
-    immediately. Same pattern as the consumer required-fields parse path above; both
-    feed Rule A's membership check and must surface as a structured validation error
-    rather than a /validate crash.
-  safety: The pipeline remains invalid; no contract telemetry is fabricated for that
-    consumer edge and Rule A is short-circuited for that consumer
+  reason: _consumer_locked_input_set ValueError (consumer schema parse) is intentionally converted into a blocking ValidationEntry
+    on the consumer node instead of raising immediately. Same pattern as the consumer required-fields parse path above; both
+    feed Rule A's membership check and must surface as a structured validation error rather than a /validate crash.
+  safety: The pipeline remains invalid; no contract telemetry is fabricated for that consumer edge and Rule A is short-circuited
+    for that consumer
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=0515578db03f0f64
   owner: web-composer
-  reason: Producer contract parse failures are intentionally converted into blocking
-    ValidationEntry results and the producer is marked uncheckable
-  safety: The invalid producer blocks validation and suppresses downstream edge contracts
-    instead of silently continuing
+  reason: Producer contract parse failures are intentionally converted into blocking ValidationEntry results and the producer
+    is marked uncheckable
+  safety: The invalid producer blocks validation and suppresses downstream edge contracts instead of silently continuing
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=abc96077d0216880
   owner: web-composer
-  reason: Rule A producer-emit ValueError swallowed silently because _effective_producer_guarantees
-    has already raised the same producer parse error above and surfaced it as a blocking
-    ValidationEntry. Re-surfacing here would duplicate the error message; the continue
-    short-circuits Rule A for this consumer-producer pair without losing the diagnostic.
-  safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees
-    call; pipeline remains invalid; Rule A is correctly skipped for this edge
+  reason: Rule A producer-emit ValueError swallowed silently because _effective_producer_guarantees has already raised the
+    same producer parse error above and surfaced it as a blocking ValidationEntry. Re-surfacing here would duplicate the error
+    message; the continue short-circuits Rule A for this consumer-producer pair without losing the diagnostic.
+  safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees call; pipeline
+    remains invalid; Rule A is correctly skipped for this edge
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=6cc4d5a150857308
   owner: web-composer
-  reason: Sink contract parse failures are intentionally converted into blocking ValidationEntry
-    results on the output
-  safety: The pipeline remains invalid and the sink edge contract is skipped rather
-    than fabricated
+  reason: Sink contract parse failures are intentionally converted into blocking ValidationEntry results on the output
+  safety: The pipeline remains invalid and the sink edge contract is skipped rather than fabricated
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=1051492e9c40cb3c
   owner: web-composer
-  reason: _sink_locked_input_set ValueError (sink schema parse) is intentionally converted
-    into a blocking ValidationEntry on the output. Mirrors the sink required-fields
-    parse path above; both feed Rule B's membership check and must surface as a structured
-    error rather than a /validate crash.
-  safety: The pipeline remains invalid; no contract telemetry is fabricated for that
-    sink and Rule B is short-circuited for that output
+  reason: _sink_locked_input_set ValueError (sink schema parse) is intentionally converted into a blocking ValidationEntry
+    on the output. Mirrors the sink required-fields parse path above; both feed Rule B's membership check and must surface
+    as a structured error rather than a /validate crash.
+  safety: The pipeline remains invalid; no contract telemetry is fabricated for that sink and Rule B is short-circuited for
+    that output
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=43b5b8f01a4c357f
   owner: web-composer
-  reason: Sink-side producer parse failures are intentionally converted into blocking
-    ValidationEntry results and the producer is marked uncheckable
-  safety: The pipeline remains invalid and downstream sink contract evidence is suppressed
-    for the bad producer
+  reason: Sink-side producer parse failures are intentionally converted into blocking ValidationEntry results and the producer
+    is marked uncheckable
+  safety: The pipeline remains invalid and downstream sink contract evidence is suppressed for the bad producer
   expires: null
 - key: web/composer/state.py:R6:_check_schema_contracts:fp=27259f3e3d303e40
   owner: web-composer
-  reason: 'Rule B producer-emit ValueError swallowed silently because _effective_producer_guarantees
-    has already raised the same producer parse error above and surfaced it as a blocking
-    ValidationEntry. Same dedup rationale as Rule A''s symmetric path: re-surfacing
-    would duplicate the error message; the continue short-circuits Rule B for this
-    sink-producer pair without losing the diagnostic.'
-  safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees
-    call; pipeline remains invalid; Rule B is correctly skipped for this edge
+  reason: 'Rule B producer-emit ValueError swallowed silently because _effective_producer_guarantees has already raised the
+    same producer parse error above and surfaced it as a blocking ValidationEntry. Same dedup rationale as Rule A''s symmetric
+    path: re-surfacing would duplicate the error message; the continue short-circuits Rule B for this sink-producer pair without
+    losing the diagnostic.'
+  safety: The producer's parse failure is already in errors[] from the previous _effective_producer_guarantees call; pipeline
+    remains invalid; Rule B is correctly skipped for this edge
   expires: null
 - key: web/composer/state.py:R1:_check_schema_contracts:fp=f69bad753b005c9c
   owner: web-composer
-  reason: Rule C reads field_mapper's select_only flag from raw Tier-3 user/LLM-supplied
-    options. dict.get with default False matches FieldMapperConfig.select_only's pydantic
-    default, so missing-key behaviour is documented and identical to the plugin's
-    own config parsing. Direct dict access would falsely reject configs that omit
-    the optional flag (legal per the plugin contract).
-  safety: Missing-key falls back to False (the documented default); Rule C then short-circuits
-    because select_only=False puts field_mapper into the additive/loose-bound regime
-    that Rule C explicitly does not adjudicate
+  reason: Rule C reads field_mapper's select_only flag from raw Tier-3 user/LLM-supplied options. dict.get with default False
+    matches FieldMapperConfig.select_only's pydantic default, so missing-key behaviour is documented and identical to the
+    plugin's own config parsing. Direct dict access would falsely reject configs that omit the optional flag (legal per the
+    plugin contract).
+  safety: Missing-key falls back to False (the documented default); Rule C then short-circuits because select_only=False puts
+    field_mapper into the additive/loose-bound regime that Rule C explicitly does not adjudicate
   expires: null
 - key: web/composer/state.py:R6:CompositionState:validate:fp=c26ba18c5c5ef7c2
   owner: web-composer
-  reason: Aggregation trigger PydanticValidationError is intentionally converted into
-    a blocking ValidationEntry so composer rejects malformed trigger.condition values
-    before runtime settings load
-  safety: The pipeline remains invalid; no trigger config is fabricated and unexpected
-    exception types propagate
+  reason: Aggregation trigger PydanticValidationError is intentionally converted into a blocking ValidationEntry so composer
+    rejects malformed trigger.condition values before runtime settings load
+  safety: The pipeline remains invalid; no trigger config is fabricated and unexpected exception types propagate
   expires: null
 - key: web/composer/tools.py:R6:_execute_update_blob:fp=fd103b0d6c58a62c
   owner: web-composer
-  reason: Narrow OSError around storage_path.write_bytes(old_content) rollback — disk
-    faults during post-replace divergence rollback expected; programmer bugs still
-    propagate
-  safety: Rollback failure attached as add_note() on primary_exc with blob_id and
-    "manual reconciliation required"; primary commit exception remains the headline.  Pre-replace
-    failures bypass the rollback branch entirely (verified by test_primary_db_exception_before_replace_propagates_without_rollback
+  reason: Narrow OSError around storage_path.write_bytes(old_content) rollback — disk faults during post-replace divergence
+    rollback expected; programmer bugs still propagate
+  safety: Rollback failure attached as add_note() on primary_exc with blob_id and "manual reconciliation required"; primary
+    commit exception remains the headline.  Pre-replace failures bypass the rollback branch entirely (verified by test_primary_db_exception_before_replace_propagates_without_rollback
     and test_quota_breach_returns_failure_without_touching_storage).
   expires: null
 - key: web/composer/tools.py:R6:_execute_delete_blob:fp=8ca49fc9b52455e7
   owner: web-composer
-  reason: Narrow OSError around tombstone restore after a failed blob delete — compensation
-    disk faults must not bury the primary DB exception
-  safety: Rollback failure is attached as add_note() on primary_exc and the original
-    delete failure is re-raised unchanged
+  reason: Narrow OSError around tombstone restore after a failed blob delete — compensation disk faults must not bury the
+    primary DB exception
+  safety: Rollback failure is attached as add_note() on primary_exc and the original delete failure is re-raised unchanged
   expires: null
 - key: web/composer/tools.py:R6:_execute_inspect_source:fp=79e74330fe91e1de
   owner: web-composer
-  reason: Tier-3 trust boundary — UUID(blob_id) coercion of caller-supplied string.
-    ValueError is the documented failure mode for malformed UUIDs and falls back to
-    blob_uuid=None (an optional identity field on inspect_blob_content). Failure is
-    NOT silent — a blob_id_not_uuid warning fact is prepended to facts.warnings so
-    the audit trail records why redacted_identity omits blob_id.
-  safety: blob_uuid=None on parse failure; inspection still runs against the resolved
-    blob row (already validated by the _sync_get_blob lookup). The blob_id_not_uuid
-    warning surfaces the offending id (truncated to 64 chars) into the audit-bound
-    facts.warnings tuple; integrity guards (status=ready, hash match) remain authoritative.
+  reason: Tier-3 trust boundary — UUID(blob_id) coercion of caller-supplied string. ValueError is the documented failure mode
+    for malformed UUIDs and falls back to blob_uuid=None (an optional identity field on inspect_blob_content). Failure is
+    NOT silent — a blob_id_not_uuid warning fact is prepended to facts.warnings so the audit trail records why redacted_identity
+    omits blob_id.
+  safety: blob_uuid=None on parse failure; inspection still runs against the resolved blob row (already validated by the _sync_get_blob
+    lookup). The blob_id_not_uuid warning surfaces the offending id (truncated to 64 chars) into the audit-bound facts.warnings
+    tuple; integrity guards (status=ready, hash match) remain authoritative.
   expires: null
 - key: web/composer/source_inspection.py:R6:_inspect_jsonl:fp=02dcba287d1b3ce7
   owner: web-composer
-  reason: Tier-3 trust boundary — JSONL line-by-line parsing of operator-supplied
-    blob content. JSONDecodeError on a single line is the documented Tier-3 failure
-    mode; the line is counted as a parse failure and surfaced via the "N jsonl line(s)
+  reason: Tier-3 trust boundary — JSONL line-by-line parsing of operator-supplied blob content. JSONDecodeError on a single
+    line is the documented Tier-3 failure mode; the line is counted as a parse failure and surfaced via the "N jsonl line(s)
     failed to parse" warning. Subsequent lines still inspected.
-  safety: parse_failures counter accumulates and is reported in warnings; no row is
-    fabricated and the partial sample that did parse is still surfaced.
+  safety: parse_failures counter accumulates and is reported in warnings; no row is fabricated and the partial sample that
+    did parse is still surfaced.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_jsonl:fp=c6f41432cbaf78af
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a parsed JSONL line is a dict (object).
-    External JSONL is zero-trust and may contain top-level non-objects (arrays, scalars).
-    isinstance is the correct Tier-3 coercion gate.
-  safety: Non-dict values are rejected as parse failures; the partial sample that
-    was dict-shaped still surfaces.
+  reason: Tier-3 trust boundary — checking that a parsed JSONL line is a dict (object). External JSONL is zero-trust and may
+    contain top-level non-objects (arrays, scalars). isinstance is the correct Tier-3 coercion gate.
+  safety: Non-dict values are rejected as parse failures; the partial sample that was dict-shaped still surfaces.
   expires: null
 - key: web/composer/source_inspection.py:R6:_inspect_json:fp=2d530f250d4c7266
   owner: web-composer
-  reason: Tier-3 trust boundary — full JSON document parsing of operator-supplied
-    blob content. JSONDecodeError is expected when the 8 KiB peek truncates mid-object
-    on a large file. Surfaced via warning.
-  safety: loaded=None on parse failure; inspection returns 0 sampled rows with the
-    truncation warning, so caller cannot confuse "no rows" with "successfully parsed
-    empty array".
+  reason: Tier-3 trust boundary — full JSON document parsing of operator-supplied blob content. JSONDecodeError is expected
+    when the 8 KiB peek truncates mid-object on a large file. Surfaced via warning.
+  safety: loaded=None on parse failure; inspection returns 0 sampled rows with the truncation warning, so caller cannot confuse
+    "no rows" with "successfully parsed empty array".
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=f017758d8e2160b1
   owner: web-composer
-  reason: Tier-3 trust boundary — discriminating between JSON array, wrapped object,
-    and single object shapes. Each branch routes to the correct extraction; without
-    isinstance, the boundary cannot be enforced.
-  safety: Each branch handles its shape explicitly; unexpected shapes (e.g., scalar
-    at top level) fall through to the "single object" branch which still produces
-    a faithful one-row inspection.
+  reason: Tier-3 trust boundary — discriminating between JSON array, wrapped object, and single object shapes. Each branch
+    routes to the correct extraction; without isinstance, the boundary cannot be enforced.
+  safety: Each branch handles its shape explicitly; unexpected shapes (e.g., scalar at top level) fall through to the "single
+    object" branch which still produces a faithful one-row inspection.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=dd094eb33f16cc79
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that an array element is a dict before
-    treating it as a row. JSON arrays can contain mixed types per RFC 8259; non-dict
-    elements are skipped, not coerced.
-  safety: Non-dict array elements silently skipped from row sample; matches Tier-3
-    quarantine semantics.
+  reason: Tier-3 trust boundary — checking that an array element is a dict before treating it as a row. JSON arrays can contain
+    mixed types per RFC 8259; non-dict elements are skipped, not coerced.
+  safety: Non-dict array elements silently skipped from row sample; matches Tier-3 quarantine semantics.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=0cc810474bf90776
   owner: web-composer
-  reason: 'Tier-3 trust boundary — checking that a wrapped object''s value is a list
-    (data_key shape detection). The wrapped-object pattern is `{"results": [...]}`
-    and the value-must-be-a-list check is the heuristic for it.'
-  safety: If the wrapped value is not a list, the heuristic falls through to the next
-    value or to the "single object" branch; no row is fabricated.
+  reason: 'Tier-3 trust boundary — checking that a wrapped object''s value is a list (data_key shape detection). The wrapped-object
+    pattern is `{"results": [...]}` and the value-must-be-a-list check is the heuristic for it.'
+  safety: If the wrapped value is not a list, the heuristic falls through to the next value or to the "single object" branch;
+    no row is fabricated.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=b950006dea2a8e4c
   owner: web-composer
-  reason: Tier-3 trust boundary — same wrapped-object value-is-list check (sibling
-    check on data_key path).
-  safety: Same as the prior entry; the heuristic only fires when both the value is
-    a list AND its first element is a dict.
+  reason: Tier-3 trust boundary — same wrapped-object value-is-list check (sibling check on data_key path).
+  safety: Same as the prior entry; the heuristic only fires when both the value is a list AND its first element is a dict.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=cd1ca795d54bfce7
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a wrapped-list element is a dict before
-    treating it as a row.
-  safety: Non-dict elements within the wrapped list are skipped; matches Tier-3 quarantine
-    semantics.
+  reason: Tier-3 trust boundary — checking that a wrapped-list element is a dict before treating it as a row.
+  safety: Non-dict elements within the wrapped list are skipped; matches Tier-3 quarantine semantics.
   expires: null
 - key: web/composer/source_inspection.py:R5:_inspect_json:fp=69d61f954d1b400a
   owner: web-composer
-  reason: Tier-3 trust boundary — final isinstance check confirms the picked element
-    is dict-shaped before adding it to the sampled-objects list.
+  reason: Tier-3 trust boundary — final isinstance check confirms the picked element is dict-shaped before adding it to the
+    sampled-objects list.
   safety: Non-dict elements skipped; no fabrication.
   expires: null
 - key: web/composer/source_inspection.py:R8:_facts_from_objects:fp=bae7c85c095a2ddc
   owner: web-composer
-  reason: 'Tier-3 trust boundary — `objects: list[dict[str, Any]]` is the natural
-    shape of parsed JSON sample rows and serves as the input contract to the type-inference
-    helper. A TypedDict cannot describe arbitrary external JSON without enumerating
+  reason: 'Tier-3 trust boundary — `objects: list[dict[str, Any]]` is the natural shape of parsed JSON sample rows and serves
+    as the input contract to the type-inference helper. A TypedDict cannot describe arbitrary external JSON without enumerating
     every possible operator-supplied schema.'
-  safety: All access is via isinstance dispatch (allowlisted as R5 Tier-3) so there
-    is no key-error path; keys absent from a particular row record as "null" rather
-    than crashing or coercing.
+  safety: All access is via isinstance dispatch (allowlisted as R5 Tier-3) so there is no key-error path; keys absent from
+    a particular row record as "null" rather than crashing or coercing.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=49c1fdeaa9a232d0
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a sampled row entry is a dict before
-    iterating its keys.
-  safety: Non-dict entries silently skipped from row sample; matches Tier-3 quarantine
-    semantics.
+  reason: Tier-3 trust boundary — checking that a sampled row entry is a dict before iterating its keys.
+  safety: Non-dict entries silently skipped from row sample; matches Tier-3 quarantine semantics.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=6bca32144439a076
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that an observed value is a bool before
-    promoting bool. Required because bool is a subclass of int in Python; without
-    the bool isinstance check first, every bool would be misclassified as int (a fabrication).
-  safety: bool check is ordered before int check; mismatched values fall through to
-    the str branch which is the type-conservative answer per the merge ladder.
+  reason: Tier-3 trust boundary — checking that an observed value is a bool before promoting bool. Required because bool is
+    a subclass of int in Python; without the bool isinstance check first, every bool would be misclassified as int (a fabrication).
+  safety: bool check is ordered before int check; mismatched values fall through to the str branch which is the type-conservative
+    answer per the merge ladder.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=0dea7337cc179dbd
   owner: web-composer
-  reason: Tier-3 trust boundary — int isinstance check during type inference of operator-supplied
-    JSON values.
+  reason: Tier-3 trust boundary — int isinstance check during type inference of operator-supplied JSON values.
   safety: Mis-typed values fall through to the str branch.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=df6e4a3440e67e6f
   owner: web-composer
-  reason: Tier-3 trust boundary — float isinstance check during type inference of
-    operator-supplied JSON values.
+  reason: Tier-3 trust boundary — float isinstance check during type inference of operator-supplied JSON values.
   safety: Mis-typed values fall through to the str branch.
   expires: null
 - key: web/composer/source_inspection.py:R1:_facts_from_objects:fp=085dc55ef33d506f
   owner: web-composer
-  reason: Tier-3 trust boundary — `obj.get(h)` for membership probing on operator-supplied
-    JSON. Returns None for absent fields (not a fabricated default — None is "absence"
-    per the manifesto), then the next isinstance check routes the value or falls through.
-  safety: None values caught explicitly by the isinstance(v, list/dict) gate; no fabrication,
-    no coercion.
+  reason: Tier-3 trust boundary — `obj.get(h)` for membership probing on operator-supplied JSON. Returns None for absent fields
+    (not a fabricated default — None is "absence" per the manifesto), then the next isinstance check routes the value or falls
+    through.
+  safety: None values caught explicitly by the isinstance(v, list/dict) gate; no fabrication, no coercion.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=44a662ccdd0e79e8
   owner: web-composer
-  reason: Tier-3 trust boundary — checking whether a probed JSON value is a list or
-    dict (nested structure). Used to emit the json_explode warning so the operator
-    knows the field will need exploding before downstream consumption.
+  reason: Tier-3 trust boundary — checking whether a probed JSON value is a list or dict (nested structure). Used to emit
+    the json_explode warning so the operator knows the field will need exploding before downstream consumption.
   safety: Only used to surface a warning; no row is dropped or coerced.
   expires: null
 - key: web/composer/source_inspection.py:R5:_facts_from_objects:fp=4d5d902b2a8e9445
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a value is a string before scanning
-    it for URL candidates. Non-string values skipped from URL extraction.
+  reason: Tier-3 trust boundary — checking that a value is a string before scanning it for URL candidates. Non-string values
+    skipped from URL extraction.
   safety: Non-string values silently skipped; URL candidates list is best-effort.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=c4263279c40a5961
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a blob_id slot value is a string before
-    UUID parsing. Operator may supply any JSON type; non-string values are rejected
-    with a repair hint pointing to create_blob.
-  safety: Non-string values raise RecipeValidationError with repair guidance; never
-    silently coerced.
+  reason: Tier-3 trust boundary — checking that a blob_id slot value is a string before UUID parsing. Operator may supply
+    any JSON type; non-string values are rejected with a repair hint pointing to create_blob.
+  safety: Non-string values raise RecipeValidationError with repair guidance; never silently coerced.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=69736596ab831836
   owner: web-composer
-  reason: Tier-3 trust boundary — checking that a str slot value is actually a string
-    before passing through.
+  reason: Tier-3 trust boundary — checking that a str slot value is actually a string before passing through.
   safety: Non-string values raise RecipeValidationError; never silently coerced.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=32ce9b85f3061d4a
   owner: web-composer
-  reason: Tier-3 trust boundary — explicit bool check before numeric coercion. bool
-    is a subclass of int in Python, so without this guard True/False would silently
-    coerce to 1.0/0.0 (a fabrication risk).
-  safety: bool values raise RecipeValidationError telling operator to use 0.0/1.0
-    explicitly.
+  reason: Tier-3 trust boundary — explicit bool check before numeric coercion. bool is a subclass of int in Python, so without
+    this guard True/False would silently coerce to 1.0/0.0 (a fabrication risk).
+  safety: bool values raise RecipeValidationError telling operator to use 0.0/1.0 explicitly.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=37c487dc79354562
   owner: web-composer
-  reason: Tier-3 trust boundary — int/float check for numeric-slot pass-through. Both
-    are valid numeric representations and are coerced to float for downstream gate
-    comparisons.
-  safety: Other types fall through to the str-coercion branch or to the type-mismatch
-    error.
+  reason: Tier-3 trust boundary — int/float check for numeric-slot pass-through. Both are valid numeric representations and
+    are coerced to float for downstream gate comparisons.
+  safety: Other types fall through to the str-coercion branch or to the type-mismatch error.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=4ef2359b87975a9c
   owner: web-composer
-  reason: Tier-3 trust boundary — string check before float coercion. Operator may
-    supply numeric thresholds as strings ("99.95"); we coerce explicitly at the boundary.
-  safety: Unparseable strings raise RecipeValidationError with the original raw value
-    in the message.
+  reason: Tier-3 trust boundary — string check before float coercion. Operator may supply numeric thresholds as strings ("99.95");
+    we coerce explicitly at the boundary.
+  safety: Unparseable strings raise RecipeValidationError with the original raw value in the message.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=3340edc2278b02c2
   owner: web-composer
-  reason: Tier-3 trust boundary — bool check for the int slot type (same fabrication-risk
-    reason as the float branch).
+  reason: Tier-3 trust boundary — bool check for the int slot type (same fabrication-risk reason as the float branch).
   safety: bool values raise RecipeValidationError; never coerced.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=26252daa7c5d88b7
   owner: web-composer
   reason: Tier-3 trust boundary — int check for int-slot pass-through.
-  safety: Non-int values fall through to the str-coercion branch or the type-mismatch
-    error.
+  safety: Non-int values fall through to the str-coercion branch or the type-mismatch error.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=7a2c78322baa89e8
   owner: web-composer
-  reason: Tier-3 trust boundary — string check before int coercion. Same pattern as
-    the float branch.
-  safety: Unparseable strings raise RecipeValidationError with the original raw value
-    in the message.
+  reason: Tier-3 trust boundary — string check before int coercion. Same pattern as the float branch.
+  safety: Unparseable strings raise RecipeValidationError with the original raw value in the message.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=be30a8e022576252
   owner: web-composer
-  reason: Tier-3 trust boundary — list/tuple check for str_list slot type before iteration.
-    Operator-supplied JSON arrays arrive at this boundary with no static type guarantee;
-    rejecting non-iterables with a RecipeValidationError preserves the explicit-failure-mode
-    contract for the apply_pipeline_recipe entrypoint.
-  safety: Non-iterable values raise RecipeValidationError naming the slot and observed
-    type — never silently coerces or fabricates a list.
+  reason: Tier-3 trust boundary — list/tuple check for str_list slot type before iteration. Operator-supplied JSON arrays
+    arrive at this boundary with no static type guarantee; rejecting non-iterables with a RecipeValidationError preserves
+    the explicit-failure-mode contract for the apply_pipeline_recipe entrypoint.
+  safety: Non-iterable values raise RecipeValidationError naming the slot and observed type — never silently coerces or fabricates
+    a list.
   expires: null
 - key: web/composer/recipes.py:R5:_coerce_slot:fp=f611b51374d3f4ea
   owner: web-composer
-  reason: Tier-3 trust boundary — per-element string check inside str_list slot iteration.
-    Same fabrication risk reasoning as the str/blob_id branches; rejecting non-string
-    elements before they pass through to LLM/transform options preserves the recipe's
-    explicit-failure-mode contract.
-  safety: Non-string elements raise RecipeValidationError with the offending index
-    in the message — never silently coerces or fabricates a string element.
+  reason: Tier-3 trust boundary — per-element string check inside str_list slot iteration. Same fabrication risk reasoning
+    as the str/blob_id branches; rejecting non-string elements before they pass through to LLM/transform options preserves
+    the recipe's explicit-failure-mode contract.
+  safety: Non-string elements raise RecipeValidationError with the offending index in the message — never silently coerces
+    or fabricates a string element.
   expires: null
 - key: web/composer/recipes.py:R1:get_recipe:fp=2669127d1300bf00
   owner: web-composer
-  reason: Internal-registry membership probe — `_RECIPES.get(name)` returns None when
-    ``name`` is not a registered recipe. Not a Tier-3 trust boundary; the registry
-    itself is system-owned data and the None-or-spec signal is the function's documented
-    contract (``RecipeSpec | None`` return type). Equivalent to ``dict.get`` used
-    as a probe rather than as a defensive default.
-  safety: None return is the documented "unknown recipe" signal; the caller (apply_recipe)
-    raises RecipeValidationError listing the registered names.
+  reason: Internal-registry membership probe — `_RECIPES.get(name)` returns None when ``name`` is not a registered recipe.
+    Not a Tier-3 trust boundary; the registry itself is system-owned data and the None-or-spec signal is the function's documented
+    contract (``RecipeSpec | None`` return type). Equivalent to ``dict.get`` used as a probe rather than as a defensive default.
+  safety: None return is the documented "unknown recipe" signal; the caller (apply_recipe) raises RecipeValidationError listing
+    the registered names.
   expires: null
 - key: web/composer/recipes.py:R1:apply_recipe:fp=fb7764c2c4816ee2
   owner: web-composer
-  reason: Internal-registry membership probe — `_RECIPES.get(name)` is followed by
-    an immediate `if recipe is None` arm that raises RecipeValidationError listing
-    the registered names. Not a Tier-3 boundary; the registry is system-owned data.
-    Same pattern as get_recipe.
-  safety: None branch raises RecipeValidationError listing available recipe names;
-    never silently fabricates a recipe or coerces a missing entry.
+  reason: Internal-registry membership probe — `_RECIPES.get(name)` is followed by an immediate `if recipe is None` arm that
+    raises RecipeValidationError listing the registered names. Not a Tier-3 boundary; the registry is system-owned data. Same
+    pattern as get_recipe.
+  safety: None branch raises RecipeValidationError listing available recipe names; never silently fabricates a recipe or coerces
+    a missing entry.
   expires: null
 - key: web/execution/validation.py:R5:validate_pipeline:fp=6f4e67822581fe4b
   owner: web-execution
-  reason: isinstance(exc, PluginConfigError) discriminates exception type to extract
-    plugin_name attribute
-  safety: Type dispatch for error formatting, not contract masking; both branches
-    produce validation checks
+  reason: isinstance(exc, PluginConfigError) discriminates exception type to extract plugin_name attribute
+  safety: Type dispatch for error formatting, not contract masking; both branches produce validation checks
   expires: null
 - key: web/execution/validation.py:R5:validate_pipeline:fp=f0ed91863378771b
   owner: web-execution
-  reason: isinstance(exc, PluginConfigError) discriminates exception type to prefer
-    cause detail over generic str(exc)
-  safety: Type dispatch for error formatting, not contract masking; both branches
-    produce validation checks
+  reason: isinstance(exc, PluginConfigError) discriminates exception type to prefer cause detail over generic str(exc)
+  safety: Type dispatch for error formatting, not contract masking; both branches produce validation checks
   expires: null
 - key: web/execution/validation.py:R1:validate_pipeline:fp=c6903597690d892e
   owner: web-execution
-  reason: Validation checks optional source path/file keys supplied by composition
-    state
-  safety: Absent keys are treated honestly as 'no path provided' and the check is
-    recorded as skipped/passed
+  reason: Validation checks optional source path/file keys supplied by composition state
+  safety: Absent keys are treated honestly as 'no path provided' and the check is recorded as skipped/passed
   expires: null
 - key: web/execution/validation.py:R1:validate_pipeline:fp=be655085e074f73a
   owner: web-execution
-  reason: Validation checks optional output path/file keys supplied by composition
-    state
+  reason: Validation checks optional output path/file keys supplied by composition state
   safety: Absent keys treated as 'no path provided'; check recorded as skipped/passed
   expires: null
 - key: web/secrets/server_store.py:R1:ServerSecretStore:has_secret:fp=64afc66c27b37667
   owner: web-secrets
-  reason: Tier 3 boundary — os.environ.get() checks env var presence for has_secret
-    fast path
+  reason: Tier 3 boundary — os.environ.get() checks env var presence for has_secret fast path
   safety: Returns bool only; no secret value exposed; no default fabrication
   expires: null
 - key: web/secrets/server_store.py:R1:ServerSecretStore:get_secret:fp=208ba630bb980dc3
   owner: web-secrets
-  reason: Tier 3 boundary — os.environ.get() reads external env var; unset/empty raises
-    SecretNotFoundError
+  reason: Tier 3 boundary — os.environ.get() reads external env var; unset/empty raises SecretNotFoundError
   safety: Missing env var raises SecretNotFoundError; no default fabrication
   expires: null
 - key: web/secrets/server_store.py:R1:ServerSecretStore:list_secrets:fp=19395c7ca9458241
   owner: web-secrets
-  reason: Tier 3 boundary — os.environ.get() checks env var presence to populate the
-    inventory's structural reason (env_var_not_set vs fingerprint_resolver_not_configured).
-    The env value is never read into the response — only its truthy/falsy state controls
+  reason: Tier 3 boundary — os.environ.get() checks env var presence to populate the inventory's structural reason (env_var_not_set
+    vs fingerprint_resolver_not_configured). The env value is never read into the response — only its truthy/falsy state controls
     the closed-list reason.
-  safety: Returns SecretInventoryItem with closed-list Literal reason field; no secret
-    value or env content can reach the response (the Literal type makes free-form
-    interpolation a structural impossibility).
+  safety: Returns SecretInventoryItem with closed-list Literal reason field; no secret value or env content can reach the
+    response (the Literal type makes free-form interpolation a structural impossibility).
   expires: null
 - key: web/secrets/user_store.py:R1:_fingerprint_key_available:fp=9ec1dd9710d48731
   owner: web-secrets
-  reason: Tier 3 boundary — os.environ.get() checks deployment env var presence for
-    fingerprint key
+  reason: Tier 3 boundary — os.environ.get() checks deployment env var presence for fingerprint key
   safety: Returns bool only; deployment readiness check; no default fabrication
   expires: null
 - key: web/secrets/user_store.py:R6:UserSecretStore:_row_is_resolvable:fp=54cac57e74b91be4
   owner: web-secrets
-  reason: Decryptability probe — Fernet InvalidToken is the expected signal for key
-    rotation or ciphertext corruption when computing browser-safe availability metadata
-  safety: Exception is converted only into available=False; get_secret() still raises
-    SecretNotFoundError with explicit cause on the resolution path
+  reason: Decryptability probe — Fernet InvalidToken is the expected signal for key rotation or ciphertext corruption when
+    computing browser-safe availability metadata
+  safety: Exception is converted only into available=False; get_secret() still raises SecretNotFoundError with explicit cause
+    on the resolution path
   expires: null
 - key: web/secrets/service.py:R6:WebSecretService:resolve:fp=2d6278e2028d9ca9
   owner: web-secrets
@@ -948,8 +802,7 @@ allow_hits:
   expires: null
 - key: web/execution/validation.py:R5:_collect_secret_refs:fp=c9f04d71c92aa668
   owner: web-execution
-  reason: Tree-walk — isinstance(Mapping) dispatches dict/list/scalar branches in
-    recursive config traversal
+  reason: Tree-walk — isinstance(Mapping) dispatches dict/list/scalar branches in recursive config traversal
   safety: No contract masking; structural dispatch on deserialized YAML (Tier 3 data)
   expires: null
 - key: web/execution/validation.py:R5:_collect_secret_refs:fp=016598c8c3151d58
@@ -959,85 +812,73 @@ allow_hits:
   expires: null
 - key: web/execution/validation.py:R5:_collect_secret_refs:fp=d3d34fed237ded0f
   owner: web-execution
-  reason: Tree-walk — isinstance() dispatches list/tuple branch in recursive config
-    traversal
+  reason: Tree-walk — isinstance() dispatches list/tuple branch in recursive config traversal
   safety: No contract masking; structural dispatch on deserialized YAML (Tier 3 data)
   expires: null
 - key: web/execution/validation.py:R5:validate_pipeline:fp=b7d91134b5bfc706
   owner: web-execution
-  reason: isinstance(config_dict, dict) validates YAML parse output before resolve_secret_refs
-    — yaml.safe_load can return non-dict for malformed input
+  reason: isinstance(config_dict, dict) validates YAML parse output before resolve_secret_refs — yaml.safe_load can return
+    non-dict for malformed input
   safety: Raises TypeError with diagnostic message; no error suppression
   expires: null
 - key: web/execution/validation.py:R5:validate_pipeline:fp=10045d5841840f5d
   owner: web-execution
-  reason: EdgeContractError is the schema-validation subtype carrying component attribution
-    and LLM repair suggestion data.
-  safety: Type dispatch only selects richer error formatting; all GraphValidationError
-    cases still append a failed validation check and surface to the caller.
+  reason: EdgeContractError is the schema-validation subtype carrying component attribution and LLM repair suggestion data.
+  safety: Type dispatch only selects richer error formatting; all GraphValidationError cases still append a failed validation
+    check and surface to the caller.
   expires: null
 - key: web/execution/validation.py:R1:_find_identity_node_advisories:fp=307627249b718317
   owner: web-execution
-  reason: Tier-3 inspection — node.options is operator/LLM-supplied (Mapping[str, Any]);
-    options['schema'] is optional and absent for transforms with no declared schema.
-    .get() returns None honestly when the key is missing; treated as "no schema declared".
-  safety: Absence is a meaningful state (no Concept-5 anchor); no error is suppressed,
-    no value is fabricated.
+  reason: Tier-3 inspection — node.options is operator/LLM-supplied (Mapping[str, Any]); options['schema'] is optional and
+    absent for transforms with no declared schema. .get() returns None honestly when the key is missing; treated as "no schema
+    declared".
+  safety: Absence is a meaningful state (no Concept-5 anchor); no error is suppressed, no value is fabricated.
   expires: null
 - key: web/execution/validation.py:R5:_find_identity_node_advisories:fp=cc2f6dfb9e7c9e5a
   owner: web-execution
-  reason: Tier-3 dispatch — schema_block came from a node.options['schema'] value (Any
-    type); isinstance(Mapping) discriminates well-formed schema dict from malformed
-    or absent input. Same pattern as _collect_secret_refs.
-  safety: Non-Mapping value falls through to "no schema fields found"; structural
-    validators elsewhere catch malformed schema declarations.
+  reason: Tier-3 dispatch — schema_block came from a node.options['schema'] value (Any type); isinstance(Mapping) discriminates
+    well-formed schema dict from malformed or absent input. Same pattern as _collect_secret_refs.
+  safety: Non-Mapping value falls through to "no schema fields found"; structural validators elsewhere catch malformed schema
+    declarations.
   expires: null
 - key: web/execution/validation.py:R1:_find_identity_node_advisories:fp=1074192e98f892c5
   owner: web-execution
-  reason: 'Tier-3 inspection — schema_block[''fields''] is optional inside the schema
-    block; absent for schema declarations that only specify mode (e.g., {mode: observed}).
-    .get() returns None honestly; treated as "no fields declared".'
-  safety: Absence is a meaningful state; the surrounding rule treats no-fields as
-    "not Concept-5 anchoring" and proceeds to flag the node.
+  reason: 'Tier-3 inspection — schema_block[''fields''] is optional inside the schema block; absent for schema declarations
+    that only specify mode (e.g., {mode: observed}). .get() returns None honestly; treated as "no fields declared".'
+  safety: Absence is a meaningful state; the surrounding rule treats no-fields as "not Concept-5 anchoring" and proceeds to
+    flag the node.
   expires: null
 - key: web/execution/validation.py:R5:_find_identity_node_advisories:fp=2b37c14cbc4c50b7
   owner: web-execution
-  reason: Tier-3 dispatch — fields value came from schema_block['fields'] (Any type);
-    isinstance((list, tuple)) discriminates a real fields sequence from a malformed
-    scalar/dict value.
-  safety: Non-sequence value falls through to "not Concept-5 anchoring"; the advisory
-    fires (operator gets visibility into a misshapen schema).
+  reason: Tier-3 dispatch — fields value came from schema_block['fields'] (Any type); isinstance((list, tuple)) discriminates
+    a real fields sequence from a malformed scalar/dict value.
+  safety: Non-sequence value falls through to "not Concept-5 anchoring"; the advisory fires (operator gets visibility into
+    a misshapen schema).
   expires: null
 - key: web/execution/validation.py:R1:_find_identity_node_advisories:fp=ed973530b03f9d8b
   owner: web-execution
-  reason: Tier-3 inspection — sink.options is operator-supplied (Mapping[str, Any]);
-    options['schema'] is optional and absent for sinks that don't declare a schema.
-    .get() returns None honestly.
-  safety: Absence yields sink_schema_mode=None; advisory detail string omits the mode
-    suffix.
+  reason: Tier-3 inspection — sink.options is operator-supplied (Mapping[str, Any]); options['schema'] is optional and absent
+    for sinks that don't declare a schema. .get() returns None honestly.
+  safety: Absence yields sink_schema_mode=None; advisory detail string omits the mode suffix.
   expires: null
 - key: web/execution/validation.py:R5:_find_identity_node_advisories:fp=529465d7847d0b95
   owner: web-execution
-  reason: Tier-3 dispatch — sink_schema_block came from sink.options['schema'] (Any
-    type); isinstance(Mapping) discriminates a well-formed schema dict from a malformed
-    or absent value.
-  safety: Non-Mapping value yields sink_schema_mode=None; advisory still emits with
-    no mode suffix, and the operator can investigate the malformed schema separately.
+  reason: Tier-3 dispatch — sink_schema_block came from sink.options['schema'] (Any type); isinstance(Mapping) discriminates
+    a well-formed schema dict from a malformed or absent value.
+  safety: Non-Mapping value yields sink_schema_mode=None; advisory still emits with no mode suffix, and the operator can investigate
+    the malformed schema separately.
   expires: null
 - key: web/execution/validation.py:R1:_find_identity_node_advisories:fp=4d6d9875290c5253
   owner: web-execution
-  reason: Tier-3 inspection — sink_schema_block['mode'] is optional inside the schema
-    block; .get() returns None honestly when the key is missing.
-  safety: Absence yields sink_schema_mode=None and an advisory detail string with no
-    mode suffix; no value is fabricated.
+  reason: Tier-3 inspection — sink_schema_block['mode'] is optional inside the schema block; .get() returns None honestly
+    when the key is missing.
+  safety: Absence yields sink_schema_mode=None and an advisory detail string with no mode suffix; no value is fabricated.
   expires: null
 - key: web/execution/validation.py:R5:_find_identity_node_advisories:fp=b4fb2c8e991b71f9
   owner: web-execution
-  reason: Tier-3 dispatch — mode value came from sink_schema_block['mode'] (Any type);
-    isinstance(str) discriminates a real mode string from a malformed value (e.g., dict,
-    int).
-  safety: Non-str value yields sink_schema_mode=None; advisory still emits with no
-    mode suffix.
+  reason: Tier-3 dispatch — mode value came from sink_schema_block['mode'] (Any type); isinstance(str) discriminates a real
+    mode string from a malformed value (e.g., dict, int).
+  safety: Non-str value yields sink_schema_mode=None; advisory still emits with no mode suffix.
   expires: null
 - key: web/app.py:R1:create_app:fp=afce9c1b36c2a3b4
   owner: web-app
@@ -1046,11 +887,10 @@ allow_hits:
   expires: null
 - key: web/blobs/service.py:R6:BlobServiceImpl:copy_blobs_for_fork:fp=a6f3d6c5c313a06c
   owner: web-blobs
-  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback delete_blob — DB/IO
-    faults expected during cleanup; programmer bugs still propagate
-  safety: Cleanup failure attached as RecoveryFailed[<type>] note on primary_exc with
-    orphan blob_id and target session_id; storage file unlinked best-effort; primary
-    copy exception remains the headline
+  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback delete_blob — DB/IO faults expected during cleanup; programmer
+    bugs still propagate
+  safety: Cleanup failure attached as RecoveryFailed[<type>] note on primary_exc with orphan blob_id and target session_id;
+    storage file unlinked best-effort; primary copy exception remains the headline
   expires: null
 - key: web/sessions/service.py:R5:SessionServiceImpl:_unwrap_envelope:fp=4ab3f7e9e6db955b
   owner: web-sessions
@@ -1069,56 +909,45 @@ allow_hits:
   expires: null
 - key: web/sessions/service.py:R6:SessionServiceImpl:archive_session:_sync:fp=9e6d620e8c66e0c9
   owner: web-sessions
-  reason: Narrow OSError during staged blob-directory restore after archive rollback
-    — compensation disk faults must not bury the primary archive failure
-  safety: Restore failure is attached via add_note() to primary_exc and the original
-    archive exception is re-raised unchanged
+  reason: Narrow OSError during staged blob-directory restore after archive rollback — compensation disk faults must not bury
+    the primary archive failure
+  safety: Restore failure is attached via add_note() to primary_exc and the original archive exception is re-raised unchanged
   expires: null
 - key: web/sessions/service.py:R6:SessionServiceImpl:archive_session:_sync:fp=a993a0b8253a45c8
   owner: web-sessions
-  reason: Narrow OSError around post-commit quarantine purge — once session rows are
-    deleted, staged blob cleanup is best-effort only
-  safety: Returns after leaving the staged directory in quarantine for manual cleanup;
-    it does not fabricate a rollback or mask the already-completed archive
+  reason: Narrow OSError around post-commit quarantine purge — once session rows are deleted, staged blob cleanup is best-effort
+    only
+  safety: Returns after leaving the staged directory in quarantine for manual cleanup; it does not fabricate a rollback or
+    mask the already-completed archive
   expires: null
 - key: web/sessions/service.py:R7:SessionServiceImpl:archive_session:_sync:fp=22760e1163ff05ab
   owner: web-sessions
-  reason: Best-effort quarantine-root cleanup after staged blob purge — the parent
-    directory may still contain other files or be recreated concurrently
-  safety: Failing to remove the parent leaves only a manual-cleanup directory behind;
-    session archival has already succeeded
-  expires: null
-- key: web/app.py:R1:create_app:fp=8d07b8380b030844
-  owner: web-app
-  reason: Tier 3 — os.environ.get() for optional ELSPETH_ENV
-  safety: Returns None when absent; only used for test guard
+  reason: Best-effort quarantine-root cleanup after staged blob purge — the parent directory may still contain other files
+    or be recreated concurrently
+  safety: Failing to remove the parent leaves only a manual-cleanup directory behind; session archival has already succeeded
   expires: null
 - key: web/blobs/service.py:R6:BlobServiceImpl:finalize_run_output_blobs:_sync:fp=167813bc5b04773a
   owner: web-blobs
-  reason: Quota exceeded during finalization marks blob as error instead of crashing
-    run
+  reason: Quota exceeded during finalization marks blob as error instead of crashing run
   safety: Over-quota file deleted; blob marked error; run still finalized
   expires: null
 - key: web/blobs/service.py:R6:BlobServiceImpl:finalize_run_output_blobs:_sync:fp=0989f39b81a966ed
   owner: web-blobs
-  reason: Per-blob operational errors caught to prevent one failure from aborting
-    remaining blobs
+  reason: Per-blob operational errors caught to prevent one failure from aborting remaining blobs
   safety: Failed blobs moved to "error" status best-effort; errors returned in BlobFinalizationResult
   expires: null
 - key: web/blobs/service.py:R6:BlobServiceImpl:finalize_run_output_blobs:_sync:fp=3af5b664750c7418
   owner: web-blobs
-  reason: Narrow (SQLAlchemyError, OSError) around pending->error recovery UPDATE
-    — DB/IO faults expected; programmer bugs still propagate
-  safety: Recovery failure appended to errors list as RecoveryFailed[<type>]; not
-    a silent swallow
+  reason: Narrow (SQLAlchemyError, OSError) around pending->error recovery UPDATE — DB/IO faults expected; programmer bugs
+    still propagate
+  safety: Recovery failure appended to errors list as RecoveryFailed[<type>]; not a silent swallow
   expires: null
 - key: web/execution/routes.py:R5:_run_integrity_http:fp=869196b901b5f49d
   owner: web-execution
-  reason: Internal response-shaping helper dispatches the closed union of Pydantic
-    ValidationError versus _RunStatusIntegrityError to decide which diagnostic fields
-    are safe for the 500 response body.
-  safety: Both branches return explicit HTTP 500 run_integrity_error detail; no exception
-    is discarded and no successful RunEvent/RunStatusResponse is fabricated.
+  reason: Internal response-shaping helper dispatches the closed union of Pydantic ValidationError versus _RunStatusIntegrityError
+    to decide which diagnostic fields are safe for the 500 response body.
+  safety: Both branches return explicit HTTP 500 run_integrity_error detail; no exception is discarded and no successful RunEvent/RunStatusResponse
+    is fabricated.
   expires: null
 - key: web/execution/routes.py:R1:create_execution_router:websocket_run_progress:fp=2e7290677ad9bc65
   owner: web-execution
@@ -1133,8 +962,7 @@ allow_hits:
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=ba9a814d244bb41d
   owner: web-execution
   reason: Idle-timeout status recheck — run may be deleted between heartbeat polls
-  safety: Only not-found errors close with 4004; infrastructure errors propagate to
-    the outer handler
+  safety: Only not-found errors close with 4004; infrastructure errors propagate to the outer handler
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=1ab958aee8c80fc8
   owner: web-execution
@@ -1143,8 +971,7 @@ allow_hits:
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=68ea2a01611f6b51
   owner: web-execution
-  reason: Narrowed outer handler to (ConnectionError, OSError) — programming errors
-    now propagate
+  reason: Narrowed outer handler to (ConnectionError, OSError) — programming errors now propagate
   safety: Logged with slog.error; clean 1011 close sent to client
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=04237c8ec7089177
@@ -1154,16 +981,13 @@ allow_hits:
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=acb41e45438d1242
   owner: web-execution
-  reason: WebSocket auth — narrowed from except (AuthenticationError, Exception) to
-    except AuthenticationError only
-  safety: Only auth failures close with 4001; infrastructure errors propagate to outer
-    handler
+  reason: WebSocket auth — narrowed from except (AuthenticationError, Exception) to except AuthenticationError only
+  safety: Only auth failures close with 4001; infrastructure errors propagate to outer handler
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=5b35a1655d0c5767
   owner: web-execution
   reason: Run-ownership IDOR gate — narrowed from except Exception to except ValueError
-  safety: Only not-found errors return 4004; infrastructure errors propagate to outer
-    handler
+  safety: Only not-found errors return 4004; infrastructure errors propagate to outer handler
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=87e1b0d9f0a50493
   owner: web-execution
@@ -1172,19 +996,17 @@ allow_hits:
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=480bc70ce871e4cb
   owner: web-execution
-  reason: Initial terminal-status seed may fail accounting response validation after
-    auth/ownership succeeds; the WebSocket must report an explicit internal-error
-    close instead of sending a malformed terminal event.
-  safety: Closes with 1011 and returns immediately; programming and infrastructure
-    errors outside the validation/integrity union still propagate to the outer handler.
+  reason: Initial terminal-status seed may fail accounting response validation after auth/ownership succeeds; the WebSocket
+    must report an explicit internal-error close instead of sending a malformed terminal event.
+  safety: Closes with 1011 and returns immediately; programming and infrastructure errors outside the validation/integrity
+    union still propagate to the outer handler.
   expires: null
 - key: web/execution/routes.py:R6:create_execution_router:websocket_run_progress:fp=cf957b520b5d6d22
   owner: web-execution
-  reason: Idle-timeout terminal-status recheck may fail accounting response validation;
-    the WebSocket must close with an explicit internal-error signal rather than fabricating
-    heartbeat or terminal payloads.
-  safety: Closes with 1011 and exits the loop; programming and infrastructure errors
-    outside the validation/integrity union still propagate to the outer handler.
+  reason: Idle-timeout terminal-status recheck may fail accounting response validation; the WebSocket must close with an explicit
+    internal-error signal rather than fabricating heartbeat or terminal payloads.
+  safety: Closes with 1011 and exits the loop; programming and infrastructure errors outside the validation/integrity union
+    still propagate to the outer handler.
   expires: null
 - key: web/app.py:R1:lifespan:fp=b1ff2d1a73a16036
   owner: web-app
@@ -1193,426 +1015,252 @@ allow_hits:
   expires: null
 - key: web/app.py:R7:lifespan:fp=23086cf145cf02ce
   owner: web-execution
-  reason: contextlib.suppress(CancelledError) is the expected shutdown path for the
-    periodic orphan cleanup task
+  reason: contextlib.suppress(CancelledError) is the expected shutdown path for the periodic orphan cleanup task
   safety: Clean cancellation during app shutdown; no error suppression
-  expires: null
-- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=617365ac6c45895a
-  owner: composer-audit
-  reason: Audit-system-failure exemption (logging-telemetry-policy permits slog when
-    audit DB itself fails). Per-tool-call audit row persistence is best-effort — a
-    SQLAlchemy failure here MUST NOT mask the calling handler's primary outcome (the
-    assistant message has already been written, the partial-state row has already
-    been written). Symmetric with the SQLAlchemyError fallbacks in _handle_convergence_error
-    / _handle_plugin_crash / _handle_runtime_preflight_failure.
-  safety: Logged via slog.error with class name only and session_id correlation; audit
-    gap is observable on read-back by comparing tool-row count against the parent
-    assistant message's reported tool_invocations count.
-  expires: null
-- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=61d4cc6981e69907
-  owner: composer-audit
-  reason: Audit-system-failure exemption (logging-telemetry-policy permits slog when
-    audit DB itself fails). Per-LLM-call audit row persistence is best-effort — a
-    SQLAlchemy failure here MUST NOT mask the calling handler's primary outcome or
-    replace a provider/convergence error with an audit-storage error.
-  safety: Logged via slog.error with class name only and session_id/model/status correlation;
-    exc_info is omitted so SQLAlchemy cause chains cannot leak connection strings
-    or raw SQL into structured logs.
   expires: null
 - key: web/composer/audit.py:R5:begin_dispatch:fp=6b7675b334ff7856
   owner: composer-audit
-  reason: Typed-union narrowing inside the audit envelope helper — begin_dispatch
-    accepts Mapping[str, Any] | str (parsed dict from successful json.loads, or raw
-    string from the JSON-decode-failure branch). isinstance(arguments, str) selects
-    the truncated-canonical path for raw input. Same pattern as _cached_runtime_preflight's
-    union narrowing. Helper hoisted from web/composer/service.py to web/composer/audit.py
-    during the dispatch_with_audit extraction (panel-review B1/B2 fix).
-  safety: Both branches build a canonical_json + stable_hash payload; no defensive
-    access of attributes; no silent fallback. The dispatch site documents which call
-    pattern is allowed.
+  reason: Typed-union narrowing inside the audit envelope helper — begin_dispatch accepts Mapping[str, Any] | str (parsed
+    dict from successful json.loads, or raw string from the JSON-decode-failure branch). isinstance(arguments, str) selects
+    the truncated-canonical path for raw input. Same pattern as _cached_runtime_preflight's union narrowing. Helper hoisted
+    from web/composer/service.py to web/composer/audit.py during the dispatch_with_audit extraction (panel-review B1/B2 fix).
+  safety: Both branches build a canonical_json + stable_hash payload; no defensive access of attributes; no silent fallback.
+    The dispatch site documents which call pattern is allowed.
   expires: null
 - key: web/composer/audit.py:R5:_normalize_audit_payload:fp=40b234ca7e3778ba
   owner: composer-audit
-  reason: Pydantic-aware audit-payload normalization (elspeth-281f259235 fix). The
-    web composer audit canonicalizes payloads via canonical_json -> rfc8785.dumps
-    which rejects Pydantic BaseModel; without this normalization, discovery tool results
-    (PluginSummary, PluginSchemaInfo) trigger the sentinel-canonical fallback and
-    obliterate the actual catalog data the LLM saw. The isinstance(value, BaseModel)
-    check selects the Pydantic-conversion branch (model_dump) inside a recursive walker
-    — structurally identical to deep_freeze/deep_thaw in contracts/freeze.py. Mirrors
-    the working pattern in composer_mcp/server.py:_ensure_serializable. Type-dispatch,
-    not contract-violation hiding.
-  safety: BaseModel branch returns a fully-converted dict via model_dump (Pydantic's
-    canonical serializer). No silent fallback; types that are neither BaseModel nor
-    Mapping nor list|tuple pass through and rfc8785 will reject them (sentinel fallback
+  reason: Pydantic-aware audit-payload normalization (elspeth-281f259235 fix). The web composer audit canonicalizes payloads
+    via canonical_json -> rfc8785.dumps which rejects Pydantic BaseModel; without this normalization, discovery tool results
+    (PluginSummary, PluginSchemaInfo) trigger the sentinel-canonical fallback and obliterate the actual catalog data the LLM
+    saw. The isinstance(value, BaseModel) check selects the Pydantic-conversion branch (model_dump) inside a recursive walker
+    — structurally identical to deep_freeze/deep_thaw in contracts/freeze.py. Mirrors the working pattern in composer_mcp/server.py:_ensure_serializable.
+    Type-dispatch, not contract-violation hiding.
+  safety: BaseModel branch returns a fully-converted dict via model_dump (Pydantic's canonical serializer). No silent fallback;
+    types that are neither BaseModel nor Mapping nor list|tuple pass through and rfc8785 will reject them (sentinel fallback
     fires) — same fail-closed discipline as before this normalization step.
   expires: null
 - key: web/composer/audit.py:R5:_normalize_audit_payload:fp=70c834a8c9944af6
   owner: composer-audit
-  reason: Recursive container walking inside _normalize_audit_payload. isinstance(value,
-    Mapping) is the standard JSON-tree dispatch pattern (Mapping covers dict, MappingProxyType,
-    OrderedDict, and any future Mapping subclass). Same shape as deep_freeze in contracts/freeze.py
-    and _ensure_serializable in composer_mcp/server.py. Not defensive access — type
-    dispatch on a heterogeneous Any-typed input from ToolResult.to_dict() / cache-hit
-    hand-built dicts.
-  safety: Mapping branch recurses into key/value pairs; non-Mapping containers fall
-    through to the list|tuple branch; scalars and opaque types pass through. rfc8785
-    rejection downstream still fires the sentinel fallback.
+  reason: Recursive container walking inside _normalize_audit_payload. isinstance(value, Mapping) is the standard JSON-tree
+    dispatch pattern (Mapping covers dict, MappingProxyType, OrderedDict, and any future Mapping subclass). Same shape as
+    deep_freeze in contracts/freeze.py and _ensure_serializable in composer_mcp/server.py. Not defensive access — type dispatch
+    on a heterogeneous Any-typed input from ToolResult.to_dict() / cache-hit hand-built dicts.
+  safety: Mapping branch recurses into key/value pairs; non-Mapping containers fall through to the list|tuple branch; scalars
+    and opaque types pass through. rfc8785 rejection downstream still fires the sentinel fallback.
   expires: null
 - key: web/composer/audit.py:R5:_normalize_audit_payload:fp=2cd1d47c9a297586
   owner: composer-audit
-  reason: List/tuple branch of the recursive normalizer. isinstance(value, list |
-    tuple) ensures lists of Pydantic models (e.g. list[PluginSummary] from catalog.list_sources())
-    get walked element-wise. Type dispatch, not defensive access.
-  safety: Returns a freshly-constructed list of normalized items; the original frozen
-    tuples from ToolResult.data are not mutated. Downstream rfc8785 rejection still
-    fires sentinel fallback for unsupported element types.
+  reason: List/tuple branch of the recursive normalizer. isinstance(value, list | tuple) ensures lists of Pydantic models
+    (e.g. list[PluginSummary] from catalog.list_sources()) get walked element-wise. Type dispatch, not defensive access.
+  safety: Returns a freshly-constructed list of normalized items; the original frozen tuples from ToolResult.data are not
+    mutated. Downstream rfc8785 rejection still fires sentinel fallback for unsupported element types.
   expires: null
 - key: web/composer/audit.py:R5:build_canonicalization_sentinel:fp=313242b6c0f63d5a
   owner: composer-audit
-  reason: Allowlist policy gate for the sentinel-detail capture (elspeth-281f259235
-    diagnostic upgrade). isinstance(exc, rfc8785.CanonicalizationError) selects exception
-    classes whose messages are bounded and value-free by spec (rfc8785 reports type
-    names and JCS rule violations, never echoes payload bytes). Other ValueError/TypeError
-    paths (e.g. core/canonical.py raising non-finite-float ValueError with the offending
-    Decimal/float interpolated) are excluded from detail capture to prevent Tier-3
-    leak into the Tier-1 audit row. This is leak-prevention policy, not contract-violation
-    hiding.
-  safety: rfc8785 detail captured at 512-char cap (belt-and-braces against future
-    rfc8785 versions inlining longer fragments); other exception paths get type-name-only
-    treatment. Exact policy pinned by test_canonicalization_sentinel_omits_detail_for_non_rfc8785_errors
+  reason: Allowlist policy gate for the sentinel-detail capture (elspeth-281f259235 diagnostic upgrade). isinstance(exc, rfc8785.CanonicalizationError)
+    selects exception classes whose messages are bounded and value-free by spec (rfc8785 reports type names and JCS rule violations,
+    never echoes payload bytes). Other ValueError/TypeError paths (e.g. core/canonical.py raising non-finite-float ValueError
+    with the offending Decimal/float interpolated) are excluded from detail capture to prevent Tier-3 leak into the Tier-1
+    audit row. This is leak-prevention policy, not contract-violation hiding.
+  safety: rfc8785 detail captured at 512-char cap (belt-and-braces against future rfc8785 versions inlining longer fragments);
+    other exception paths get type-name-only treatment. Exact policy pinned by test_canonicalization_sentinel_omits_detail_for_non_rfc8785_errors
     and companions in tests/unit/web/composer/test_compose_loop_audit_wiring.py.
   expires: null
 - key: web/composer/audit.py:R5:build_canonicalization_sentinel:fp=c9698b60d5007f6e
   owner: composer-audit
-  reason: Audit-payload-shape diagnostic — isinstance(payload, Mapping) selects the
-    branch that records sorted top-level keys into _payload_keys. Lets auditors fingerprint
-    the failure shape (discovery-tool result vs compose-state mutation vs unparseable
-    arguments) without correlating with operational logs. Non-Mapping payloads (the
-    str branch from begin_dispatch's raw-string path, or future list-shaped shapes)
-    skip the diagnostic to avoid emitting a noisy index- key list. Type dispatch,
-    not defensive access — the helper is purposely called with Any so policy lives
-    in one place.
-  safety: Captures only key NAMES (sorted, str-coerced), not values. No nested traversal.
-    Bounded by definition (a composition state has O(10) top-level keys; an LLM tool-call
-    argument set is similar). Pinned by test_canonicalization_sentinel_omits_payload_keys_for_non_mapping.
+  reason: Audit-payload-shape diagnostic — isinstance(payload, Mapping) selects the branch that records sorted top-level keys
+    into _payload_keys. Lets auditors fingerprint the failure shape (discovery-tool result vs compose-state mutation vs unparseable
+    arguments) without correlating with operational logs. Non-Mapping payloads (the str branch from begin_dispatch's raw-string
+    path, or future list-shaped shapes) skip the diagnostic to avoid emitting a noisy index- key list. Type dispatch, not
+    defensive access — the helper is purposely called with Any so policy lives in one place.
+  safety: Captures only key NAMES (sorted, str-coerced), not values. No nested traversal. Bounded by definition (a composition
+    state has O(10) top-level keys; an LLM tool-call argument set is similar). Pinned by test_canonicalization_sentinel_omits_payload_keys_for_non_mapping.
   expires: null
 - key: web/composer/audit.py:R5:begin_dispatch_or_arg_error:fp=76a8dda47a83ecc6
   owner: composer-audit
-  reason: Pass-through gate for the sentinel-diagnostic helper. begin_dispatch accepts
-    Mapping[str, Any] | str and the arg-canonicalization-failure path needs to forward
-    the right shape to build_canonicalization_sentinel. The isinstance(arguments,
-    Mapping) check selects the Mapping branch (so _payload_keys gets meaningful key
-    names) and discards the str branch (so a raw-string truncation site doesn't emit
-    a single-char index key list). Type dispatch on the same union narrowing as begin_dispatch's
-    primary isinstance check.
-  safety: Both branches feed build_canonicalization_sentinel a typed-correct value.
-    No silent fallback; the sentinel still records the exception class name regardless
-    of payload shape.
+  reason: Pass-through gate for the sentinel-diagnostic helper. begin_dispatch accepts Mapping[str, Any] | str and the arg-canonicalization-failure
+    path needs to forward the right shape to build_canonicalization_sentinel. The isinstance(arguments, Mapping) check selects
+    the Mapping branch (so _payload_keys gets meaningful key names) and discards the str branch (so a raw-string truncation
+    site doesn't emit a single-char index key list). Type dispatch on the same union narrowing as begin_dispatch's primary
+    isinstance check.
+  safety: Both branches feed build_canonicalization_sentinel a typed-correct value. No silent fallback; the sentinel still
+    records the exception class name regardless of payload shape.
   expires: null
 - key: web/composer/audit.py:R6:finish_success:fp=2fabcd796b747c1b
   owner: composer-audit
-  reason: Sentinel-canonical fallback for canonical_json failures on the SUCCESS path.
-    Closes panel-review blocker B1 — a non-finite float in the tool result would otherwise
-    raise from inside finish_success and bypass the recorder.record(...) call entirely
-    (the audit hole the helper extraction was designed to close). Mirrors the standalone-MCP
-    fallback at composer_mcp/server.py:715-721 byte-for-byte. Caught classes (ValueError,
-    TypeError) are exactly what rfc8785.dumps raises on non-finite floats / non-serializable
-    types — narrow by RFC 8785 spec. Updated 2026-05-06 (elspeth-281f259235) to delegate
-    sentinel construction to build_canonicalization_sentinel for diagnostic-shape
-    symmetry across audit surfaces.
-  safety: The audit row still lands carrying a sentinel object whose _canonicalization_error
-    key holds the exception class name and whose _payload_keys key holds sorted top-level
-    keys of the failed payload, set as the result_canonical column. The diagnostic
-    upgrade adds bounded, leak-safe metadata (top-level keys + rfc8785-allowlisted
-    detail) so auditors can fingerprint the failure shape without correlating with
-    operational telemetry. Tier-1 invariant version_after-is-None-on-dispatch-did-not-complete
-    is unaffected — this path runs on the SUCCESS branch where the handler returned
-    a result and the state was already advanced. The _canonicalization_error key is
-    an internal sentinel name reserved by the audit subsystem (composer_mcp/server.py
-    and web/composer/audit.py — single source of truth).
+  reason: Sentinel-canonical fallback for canonical_json failures on the SUCCESS path. Closes panel-review blocker B1 — a
+    non-finite float in the tool result would otherwise raise from inside finish_success and bypass the recorder.record(...)
+    call entirely (the audit hole the helper extraction was designed to close). Mirrors the standalone-MCP fallback at composer_mcp/server.py:715-721
+    byte-for-byte. Caught classes (ValueError, TypeError) are exactly what rfc8785.dumps raises on non-finite floats / non-serializable
+    types — narrow by RFC 8785 spec. Updated 2026-05-06 (elspeth-281f259235) to delegate sentinel construction to build_canonicalization_sentinel
+    for diagnostic-shape symmetry across audit surfaces.
+  safety: The audit row still lands carrying a sentinel object whose _canonicalization_error key holds the exception class
+    name and whose _payload_keys key holds sorted top-level keys of the failed payload, set as the result_canonical column.
+    The diagnostic upgrade adds bounded, leak-safe metadata (top-level keys + rfc8785-allowlisted detail) so auditors can
+    fingerprint the failure shape without correlating with operational telemetry. Tier-1 invariant version_after-is-None-on-dispatch-did-not-complete
+    is unaffected — this path runs on the SUCCESS branch where the handler returned a result and the state was already advanced.
+    The _canonicalization_error key is an internal sentinel name reserved by the audit subsystem (composer_mcp/server.py and
+    web/composer/audit.py — single source of truth).
   expires: null
 - key: web/composer/audit.py:R5:_result_to_audit_payload:fp=71c8a7d9cb04f04c
   owner: composer-audit
-  reason: Coerce a tool-handler result into a canonicalizable Mapping. The compose
-    loop's handler returns a ToolResult dataclass with a to_dict() method; the helper
-    is callback-driven and does not import the concrete type. Tests pass a dict directly,
-    production passes a ToolResult — the isinstance(Mapping) branch admits both shapes
-    without coupling to the concrete handler type. Not defensive access, structural
-    pre-dispatch on a small typed shape.
-  safety: Anything that is neither a Mapping nor exposes to_dict() crashes loud via
-    the AttributeError below. The isinstance(Mapping) check fast-paths the test/dict
-    case; the ``result.to_dict`` path serves the production case.
+  reason: Coerce a tool-handler result into a canonicalizable Mapping. The compose loop's handler returns a ToolResult dataclass
+    with a to_dict() method; the helper is callback-driven and does not import the concrete type. Tests pass a dict directly,
+    production passes a ToolResult — the isinstance(Mapping) branch admits both shapes without coupling to the concrete handler
+    type. Not defensive access, structural pre-dispatch on a small typed shape.
+  safety: Anything that is neither a Mapping nor exposes to_dict() crashes loud via the AttributeError below. The isinstance(Mapping)
+    check fast-paths the test/dict case; the ``result.to_dict`` path serves the production case.
   expires: null
 - key: web/composer/audit.py:R5:_result_to_audit_payload:fp=46507706eb3c6494
   owner: composer-audit
-  reason: Offensive guard — verify ``result.to_dict()`` actually returned a Mapping
-    before passing it to canonical_json. A handler whose to_dict() drifted to return
-    a list/tuple/scalar would silently corrupt the audit row; the explicit raise crashes
-    loud per CLAUDE.md "Plugin Ownership" — a handler bug must surface, not be papered
-    over with a fallback.
-  safety: TypeError raised with the actual returned class name and the expected shape.
-    The exception leaves the helper via the general PLUGIN_CRASH path, so the audit
-    row still lands recording "the dispatch produced an unrecordable result" — rather
-    than the alternative of silently writing zero into the audit trail.
+  reason: Offensive guard — verify ``result.to_dict()`` actually returned a Mapping before passing it to canonical_json. A
+    handler whose to_dict() drifted to return a list/tuple/scalar would silently corrupt the audit row; the explicit raise
+    crashes loud per CLAUDE.md "Plugin Ownership" — a handler bug must surface, not be papered over with a fallback.
+  safety: TypeError raised with the actual returned class name and the expected shape. The exception leaves the helper via
+    the general PLUGIN_CRASH path, so the audit row still lands recording "the dispatch produced an unrecordable result" —
+    rather than the alternative of silently writing zero into the audit trail.
   expires: null
 - key: web/app.py:R6:_periodic_orphan_cleanup:fp=25fec73ee847c85b
   owner: web-execution
-  reason: Audit/IO-cleanup narrow catch — except (SQLAlchemyError, OSError) absorbs
-    recoverable failures of cancel_all_orphaned_runs (transient DB loss, lock contention,
-    SQLite file I/O) so the periodic loop retries on the next interval. Catch is intentionally
-    narrow; programmer-bug exceptions (AttributeError from a drifted attribute on
-    ExecutionServiceImpl, TypeError from a signature change, AssertionError from an
-    invariant guard) are NOT caught and terminate the background task so they surface
-    at lifespan shutdown (the outer contextlib.suppress absorbs only CancelledError).
-    Same pattern as the CRIT-2 audit-cleanup narrow catch at web/composer/service.py
-    ComposerServiceImpl.compose and the rollback-cleanup sites at web/sessions/routes.py
+  reason: Audit/IO-cleanup narrow catch — except (SQLAlchemyError, OSError) absorbs recoverable failures of cancel_all_orphaned_runs
+    (transient DB loss, lock contention, SQLite file I/O) so the periodic loop retries on the next interval. Catch is intentionally
+    narrow; programmer-bug exceptions (AttributeError from a drifted attribute on ExecutionServiceImpl, TypeError from a signature
+    change, AssertionError from an invariant guard) are NOT caught and terminate the background task so they surface at lifespan
+    shutdown (the outer contextlib.suppress absorbs only CancelledError). Same pattern as the CRIT-2 audit-cleanup narrow
+    catch at web/composer/service.py ComposerServiceImpl.compose and the rollback-cleanup sites at web/sessions/routes.py
     fork_from_message (lines 968 and 987).
-  safety: Recoverable failures are logged via slog.error periodic_orphan_cleanup_failed
-    with exc_class only — exc_info is deliberately omitted so SQLAlchemy __cause__
-    chains (DB URLs, schema names, sqlite file path) cannot reach structured server
-    logs. Same exc_info-redaction pattern commit 59bdf514 established across the HTTP-path
-    slog.error sites. Programmer-bug propagation invariant is guarded by tests/unit/web/test_app.py
-    test_programmer_bug_terminates_task_and_does_not_log (AttributeError terminates
-    the task) and the recoverable-failure path by test_continues_after_exception (OperationalError
-    logged, loop continues, no traceback text leaked).
+  safety: Recoverable failures are logged via slog.error periodic_orphan_cleanup_failed with exc_class only — exc_info is
+    deliberately omitted so SQLAlchemy __cause__ chains (DB URLs, schema names, sqlite file path) cannot reach structured
+    server logs. Same exc_info-redaction pattern commit 59bdf514 established across the HTTP-path slog.error sites. Programmer-bug
+    propagation invariant is guarded by tests/unit/web/test_app.py test_programmer_bug_terminates_task_and_does_not_log (AttributeError
+    terminates the task) and the recoverable-failure path by test_continues_after_exception (OperationalError logged, loop
+    continues, no traceback text leaked).
   expires: null
 - key: web/secrets/user_store.py:R1:_compute_fingerprint:fp=d88552191c8b792f
   owner: web-secrets
-  reason: Tier 3 — fingerprint key from deployment environment; os.environ.get followed
-    by check-and-crash
+  reason: Tier 3 — fingerprint key from deployment environment; os.environ.get followed by check-and-crash
   safety: Missing key raises RuntimeError immediately; no silent default
-  expires: null
-- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=12379b77e06e61bf
-  owner: web-sessions
-  reason: Convergence partial-state save may fail — catch covers the full SQLAlchemyError
-    family (IntegrityError, OperationalError for lock timeout or pool disconnect,
-    ProgrammingError for schema drift, and siblings). A narrow IntegrityError catch
-    would let siblings escape and upgrade the structured 422 into an unstructured
-    500. Narrowed per CLAUDE.md Tier-1 semantics — _state_data_from_composer_state
-    internally handles validate() data-shape errors; TypeError/KeyError from to_dict()
-    or CompositionStateData() is a broken internal invariant and must propagate rather
-    than be laundered into partial_state_save_failed=True. exc_info omitted so SQLAlchemy
-    __cause__ chains do not leak connection strings into structured server logs.
-  safety: Returns 422 with structured error, sets partial_state_save_failed=True;
-    does not swallow. Both the slog (exc_class=...) and the HTTP response body (partial_state_save_error=ClassName)
-    carry the exception class name only — no SQL statement, no bound parameters, no
-    __cause__ text.
-  expires: null
-- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=37cf20ba4b750216
-  owner: web-sessions
-  reason: Plugin-crash partial-state save may fail — catch covers the full SQLAlchemyError
-    family. A narrow IntegrityError catch would let OperationalError, ProgrammingError,
-    and siblings escape and mask the redacted 500 plugin-crash response. Narrowed
-    per CLAUDE.md Tier-1 semantics — _state_data_from_composer_state internally handles
-    validate() data-shape errors; TypeError/KeyError from to_dict() or CompositionStateData()
-    is a broken internal invariant and must propagate rather than be laundered into
-    partial_state_save_failed=True. On save failure, sets partial_state_save_failed=True
-    on the 500 response body for frontend recovery UX symmetry with _handle_convergence_error.
-  safety: Returns 500 with structured error; logs exc_class (no traceback, same redaction
-    policy as the convergence path). Original plugin crash still propagates via the
-    outer `raise HTTPException(...) from crash.original_exc`.
-  expires: null
-- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=ed956ce449f63a48
-  owner: web-sessions
-  reason: Runtime-preflight partial-state save may fail — catch covers the full SQLAlchemyError
-    family, structurally identical to the sibling _handle_plugin_crash and _handle_convergence_error
-    helpers. A narrow IntegrityError catch would let OperationalError (lock timeout
-    / pool disconnect), ProgrammingError (schema drift), and siblings escape and mask
-    the redacted 500 response that recovers from a ComposerRuntimePreflightError.
-    Narrowed per CLAUDE.md Tier-1 semantics — _state_data_from_composer_state internally
-    handles validate() data-shape errors; TypeError/KeyError from to_dict() or CompositionStateData()
-    is a broken internal invariant and must propagate rather than be laundered into
-    partial_state_save_failed=True. On save failure, sets partial_state_save_failed=True
-    on the 500 response body for frontend recovery UX symmetry with the sibling helpers.
-  safety: Returns 500 with structured error; logs exc_class on the audit-system-failure
-    fallback path only (no traceback, same redaction policy as the sibling helpers).
-    Original runtime-preflight cause still propagates via the outer `raise HTTPException(...)
-    from rpf_exc.original_exc` at the call site.
-  expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=1a1b2d1f29569684
-  owner: web-sessions
-  reason: isinstance check on deserialized composition state source — Tier 3 boundary.
-  safety: Validates structure from persisted state
-  expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=24aa5d23430343e0
-  owner: web-sessions
-  reason: source_dict.get() on Tier 3 composition state — optional source options.
-  safety: Returns None on miss, and the blob rewrite path is skipped
-  expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=db78fbcacf1075f0
-  owner: web-sessions
-  reason: isinstance(options, dict) validates persisted source.options before mutating
-    nested fields during fork blob rewrite
-  safety: Non-dict raises AuditIntegrityError immediately; no silent skip or coercion
-  expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=76ebef5c0af14703
-  owner: web-sessions
-  reason: options.get() on Tier 3 state source — blob_ref is optional.
-  safety: Returns None on miss, handled by conditional below
-  expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=390c0356ee6e5e8c
-  owner: web-sessions
-  reason: isinstance check on blob_ref — may be str or UUID from persisted state.
-  safety: Tier 3 boundary — persisted blob_ref type is not guaranteed
-  expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2f77d7a0421ee569
-  owner: web-sessions
-  reason: blob_map.get() on copied blob UUID — not every source reference is guaranteed
-    to have a copied blob target, so fork rewrite falls back to path/file matching
-  safety: None result only triggers the secondary path/file rewrite probe; no fabricated
-    blob mapping is introduced
-  expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=71ff014a59a9ca5c
-  owner: web-sessions
-  reason: options.get(path_key) on persisted source options — path/file keys are optional
-    and used only for fallback blob rewrite
-  safety: None result skips that fallback key and continues scanning remaining candidates
-  expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=a468266561e25f69
-  owner: web-sessions
-  reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string
-    persisted path/file values
-  safety: Only string values participate in the fallback rewrite; non-string values
-    remain unchanged and can still fail later validation instead of being silently
-    coerced
-  expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=c7e3e5350cf2de96
-  owner: web-sessions
-  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in
-    the BlobQuotaExceededError path — DB/IO faults expected during cleanup; programmer
-    bugs still propagate
-  safety: Cleanup failure attached as RecoveryFailed[<type>] note on the HTTPException(413)
-    that propagates; orphan sessions.id flagged for manual cleanup; user-facing 413
-    response remains intact even when cleanup fails
-  expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=4164e16b5f52e001
-  owner: web-sessions
-  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in
-    the generic except Exception path — DB/IO faults expected during cleanup; programmer
-    bugs still propagate
-  safety: Cleanup failure attached as RecoveryFailed[<type>] note on primary_exc with
-    orphan sessions.id; bare `raise` preserves primary_exc and its original traceback
-    as the headline (regression-tested by test_fork_cleanup_failure_preserves_primary_exception_with_note)
   expires: null
 - key: web/sessions/service.py:R1:SessionServiceImpl:prune_state_versions:_sync:fp=2d5441fcfe90acf5
   owner: web-sessions
-  reason: derived_from_map.get() on seed_id — seed may not exist in derived_from_map
-    (states without derived_from parents)
+  reason: derived_from_map.get() on seed_id — seed may not exist in derived_from_map (states without derived_from parents)
   safety: Returns None, while-loop terminates naturally
   expires: null
 - key: web/sessions/service.py:R1:SessionServiceImpl:prune_state_versions:_sync:fp=3cca7fd69ef2859f
   owner: web-sessions
-  reason: derived_from_map.get() traversing parent chain — parent may reference state
-    outside session or not in map
+  reason: derived_from_map.get() traversing parent chain — parent may reference state outside session or not in map
   safety: Returns None, terminates transitive closure walk
   expires: null
 - key: web/composer/skills/__init__.py:R6:load_deployment_skill:fp=a7cf6bcf22cab117
   owner: web-composer
-  reason: Deployment skill is optional — FileNotFoundError is expected when deployment
-    skill is absent. PermissionError/IsADirectoryError now propagate (operator misconfiguration).
-  safety: Returns empty string for absent file only (not a fabricated default). Core
-    skill always loads (crash on missing). Only the deployment overlay is optional.
-    Size guard rejects oversized files.
+  reason: Deployment skill is optional — FileNotFoundError is expected when deployment skill is absent. PermissionError/IsADirectoryError
+    now propagate (operator misconfiguration).
+  safety: Returns empty string for absent file only (not a fabricated default). Core skill always loads (crash on missing).
+    Only the deployment overlay is optional. Size guard rejects oversized files.
   expires: null
 - key: web/composer/redaction.py:R1:redact_source_storage_path:fp=f9cae2269932b86b
   owner: web-composer
-  reason: Function receives multiple dict shapes — to_dict() output always has "source",
-    but component dicts from _execute_get_pipeline_state do not. .get() handles the
-    absent-key case (no-op early return).
+  reason: Function receives multiple dict shapes — to_dict() output always has "source", but component dicts from _execute_get_pipeline_state
+    do not. .get() handles the absent-key case (no-op early return).
   safety: Returns input unchanged when "source" key absent — no data loss or fabrication
   expires: null
 - key: web/composer/redaction.py:R1:redact_source_storage_path:fp=87ca61fbdfb63fd5
   owner: web-composer
-  reason: Source dict from DB records (CompositionStateRecord.source) may lack "options"
-    — _state_response wraps deep_thaw(state.source) which is raw JSON from the DB.
-    Not all source shapes include "options".
+  reason: Source dict from DB records (CompositionStateRecord.source) may lack "options" — _state_response wraps deep_thaw(state.source)
+    which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=2678dd33866365b8
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=625deb17ed7151a9
   owner: web-sessions
-  reason: App-scoped compose lock registry is initialized lazily on first session-router
-    use rather than being required at startup
-  safety: Missing attribute allocates and stores a new _SessionComposeLockRegistry
-    on request.app.state; subsequent calls reuse the same object
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=9c2cf533334f7c5d
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=212a41c4dd1330f5
   owner: web-sessions
-  reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed
-    on every provider error object, and this helper only surfaces it in explicit staging/debug
-    mode.
-  safety: Missing status_code omits provider_status_code from the response; no fabricated
-    status is emitted, and the stable redacted detail still uses type(exc).__name__.
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_state_response:fp=0340a4ef021a8c9c
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e6471c792d6b7650
   owner: web-sessions
-  reason: Unwrapping redact_source_storage_path() output — helper returns dict with
-    "source" key; .get() with fallback to original is defensive against helper contract
-    change
-  safety: Falls back to unredacted source_data (less privacy, not less safety)
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=f3e7f1107ced0b46
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=ea2fdfb5ce4ae744
   owner: web-sessions
-  reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome
-    union type — sentinel, ValidationResult, and None are the three legal values;
-    isinstance is the only way to distinguish sentinel from result without adding
-    a separate boolean parameter.
-  safety: Exhaustive dispatch with ValueError for invalid combinations; no silent
-    default
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=048a7103542e87c1
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=5fb0545704a4c843
   owner: web-sessions
-  reason: state.validate() may fail on structurally damaged partial-state from LLM
-    convergence/crash — catch (ValueError, TypeError, KeyError) mirrors the pre-existing
-    guard in _handle_convergence_error and _handle_plugin_crash to produce a conservative
-    is_valid=False result instead of losing the partial state.
-  safety: Falls back to ValidationSummary(is_valid=False) with a generic error entry;
-    does not swallow the damage, just allows persistence to proceed
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=198b85f2e78b5b2e
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=c298f7b070018c34
   owner: web-sessions
-  reason: isinstance(runtime, ValidationResult) dispatches the _RuntimePreflightOutcome
-    union type to emit telemetry — sentinel and ValidationResult must be distinguished
-    to record pass/fail vs exception metrics correctly.
-  safety: Read-only dispatch for telemetry emission; no state mutation
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  expires: null
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=c96e8f4bfc007521
+  owner: web-sessions
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  expires: null
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=42a6a255408e9d43
+  owner: web-sessions
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
+    all optional user inputs that may be omitted.
+  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  expires: null
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e0a68f3bba01a2e8
+  owner: web-sessions
+  reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
+    fills in when accepting a recipe.
+  safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
+  expires: null
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=baad85de0bd7f8e0
+  owner: web-sessions
+  reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
+    fills in when accepting a recipe.
+  safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
   owner: web-validation
-  reason: Union type dispatch — function receives PluginNotFoundError | PluginConfigError,
-    isinstance needed to read component_type attribute only present on PluginConfigError
+  reason: Union type dispatch — function receives PluginNotFoundError | PluginConfigError, isinstance needed to read component_type
+    attribute only present on PluginConfigError
   safety: Returns None for non-matching type; no error suppression
   expires: null
 - key: web/middleware/rate_limit.py:R9:ComposerRateLimiter:_sweep_stale_entries:fp=50c8c5807a0f8fe3
   owner: web-middleware
-  reason: Sweep eviction — user may have a bucket entry but no corresponding lock
-    if lock was never created (edge case). pop() with default is idempotent cleanup,
-    not error suppression.
+  reason: Sweep eviction — user may have a bucket entry but no corresponding lock if lock was never created (edge case). pop()
+    with default is idempotent cleanup, not error suppression.
   safety: Stale lock removal is best-effort; missing key means no cleanup needed
   expires: null
 - key: web/blobs/service.py:R5:_source_references_blob:fp=4d36218f080a8c27
   owner: web-blobs
-  reason: Tier 1 read guard — composition_states.source JSON must be dict when non-None;
-    raises AuditIntegrityError on DB corruption
-  safety: Explicit raise fires immediately on type mismatch; not a silent recovery;
-    survives ``python -O``
+  reason: Tier 1 read guard — composition_states.source JSON must be dict when non-None; raises AuditIntegrityError on DB
+    corruption
+  safety: Explicit raise fires immediately on type mismatch; not a silent recovery; survives ``python -O``
   expires: null
 - key: web/blobs/service.py:R1:_source_references_blob:fp=f0f84925d830641c
   owner: web-blobs
-  reason: JSON column navigation — source.options is optional (file-path sources omit
-    it)
+  reason: JSON column navigation — source.options is optional (file-path sources omit it)
   safety: Returns False (no match) when absent; Tier 1 raise on wrong type if present
   expires: null
 - key: web/blobs/service.py:R5:_source_references_blob:fp=1c6db8c2e1b02409
   owner: web-blobs
-  reason: Tier 1 read guard — source.options must be dict when non-None; raises AuditIntegrityError
-    on DB corruption
-  safety: Explicit raise fires immediately on type mismatch; not a silent recovery;
-    survives ``python -O``
+  reason: Tier 1 read guard — source.options must be dict when non-None; raises AuditIntegrityError on DB corruption
+  safety: Explicit raise fires immediately on type mismatch; not a silent recovery; survives ``python -O``
   expires: null
 - key: web/blobs/service.py:R1:_source_references_blob:fp=c13b50d74ef3162f
   owner: web-blobs
-  reason: JSON column navigation — blob_ref is optional (only present for blob-backed
-    sources)
+  reason: JSON column navigation — blob_ref is optional (only present for blob-backed sources)
   safety: Returns False (no match) when absent; correct for file-path sources
   expires: null
 - key: web/blobs/service.py:R1:_source_references_blob:fp=92334695308af494
@@ -1623,19 +1271,16 @@ allow_hits:
 - key: web/blobs/sniff.py:R6:_detect_from_text:fp=a966bc58c3ffd3b7
   owner: web-blobs
   reason: Tier 3 boundary — csv.Error during MIME sniffing on untrusted upload content
-  safety: Continues to next delimiter; returns None for uncertain content; no data
-    loss
+  safety: Continues to next delimiter; returns None for uncertain content; no data loss
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=0f19a6c6477e904b
   owner: web-execution
-  reason: Offensive programming — isinstance assertion on YAML generator output (source
-    must be dict)
+  reason: Offensive programming — isinstance assertion on YAML generator output (source must be dict)
   safety: Raises TypeError with diagnostic message on generator bug
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=a04e52dbfb1f9b7f
   owner: web-execution
-  reason: Offensive programming — isinstance assertion on YAML generator output (source.options
-    must be dict)
+  reason: Offensive programming — isinstance assertion on YAML generator output (source.options must be dict)
   safety: Raises TypeError with diagnostic message on generator bug
   expires: null
 - key: web/execution/preflight.py:R1:resolve_runtime_yaml_paths:fp=42996be95a89dd56
@@ -1645,8 +1290,7 @@ allow_hits:
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=7f72acae2e41bb1d
   owner: web-execution
-  reason: Offensive programming — isinstance assertion on YAML generator output (sinks
-    must be dict)
+  reason: Offensive programming — isinstance assertion on YAML generator output (sinks must be dict)
   safety: Raises TypeError with diagnostic message on generator bug
   expires: null
 - key: web/execution/preflight.py:R1:resolve_runtime_yaml_paths:fp=d0e7e2507b117f2d
@@ -1656,8 +1300,7 @@ allow_hits:
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=5e0c3dc17498063e
   owner: web-execution
-  reason: Offensive programming — isinstance assertion on YAML generator output (sink
-    config must be dict)
+  reason: Offensive programming — isinstance assertion on YAML generator output (sink config must be dict)
   safety: Raises TypeError with diagnostic message naming the sink
   expires: null
 - key: web/execution/preflight.py:R1:resolve_runtime_yaml_paths:fp=5f1f81fee41e3e1a
@@ -1667,8 +1310,7 @@ allow_hits:
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=27b0eea4a848386d
   owner: web-execution
-  reason: Offensive programming — isinstance assertion on YAML generator output (sink
-    options must be dict)
+  reason: Offensive programming — isinstance assertion on YAML generator output (sink options must be dict)
   safety: Raises TypeError with diagnostic message naming the sink
   expires: null
 - key: web/execution/preflight.py:R5:resolve_runtime_yaml_paths:fp=126f6792a20126fc
@@ -1685,35 +1327,6 @@ allow_hits:
   owner: web-execution
   reason: Tier 3 — isinstance check on pipeline_yaml argument type
   safety: Raises TypeError with diagnostic; no silent default
-  expires: null
-- key: web/app.py:R2:create_app:_request_id:fp=baeeb84f69bad3cb
-  owner: web-app
-  reason: 'Trust-boundary fallback. The exception handlers registered in
-
-    create_app() use this helper to read request.state.request_id, set
-
-    by RequestIdMiddleware on every request. If a pre-middleware path
-
-    ever fires an exception (e.g., Starlette itself rejecting the
-
-    request before the middleware chain completes), the attribute will
-
-    not exist. getattr(..., "unset") provides a JSON-serialisable
-
-    sentinel so the handler still produces a well-formed response body
-
-    rather than compounding the failure with AttributeError.
-
-    '
-  safety: 'The "unset" sentinel cannot be confused with a real UUID4 or any
-
-    value accepted by RequestIdMiddleware''s validator, so operators
-
-    reading slog events and response bodies can distinguish
-
-    middleware-bypassed failures from normal ones.
-
-    '
   expires: null
 - key: web/secrets/service.py:R6:WebSecretService:check_user_ref_resolvable:fp=2a6dac757cd54d12
   owner: web-secrets
@@ -1804,143 +1417,249 @@ allow_hits:
   expires: null
 - key: web/async_workers.py:R6:run_sync_in_worker:fp=2f6935230e6215d4
   owner: web-runtime
-  reason: Event-loop wake polling in async-over-sync worker helper; TimeoutError from
-    wait_for means the worker has not completed yet, not a failed operation. Fingerprint
-    refreshed by elspeth-e4949acbe1's drain-callback fix; semantics of the except
+  reason: Event-loop wake polling in async-over-sync worker helper; TimeoutError from wait_for means the worker has not completed
+    yet, not a failed operation. Fingerprint refreshed by elspeth-e4949acbe1's drain-callback fix; semantics of the except
     clause are unchanged (the loop continues until shielded future completes).
-  safety: The future is shielded so the worker keeps running; completed result or
-    exception is returned on the next poll, and cancellation now also drains the shielded
-    future's eventual exception via add_done_callback so asyncio's GC handler cannot
-    fire a misleading 'Future exception was never retrieved' traceback.
+  safety: The future is shielded so the worker keeps running; completed result or exception is returned on the next poll,
+    and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
+    cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=a37dcabbfe22fc90
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=fd7e80c36471095f
   owner: web-sessions
-  reason: contextlib.suppress(asyncio.CancelledError) wraps the shielded cancelled-LLM-call
-    audit persistence in the send_message cancellation handler. asyncio.shield re-raises
-    CancelledError to the cancelling task while the inner persistence coroutine continues;
-    suppressing that duplicate re-raise lets the handler still publish the cancelled
-    progress snapshot and then re-raise the original cancellation.
-  safety: The shielded audit persistence is best-effort and records only sanitized
-    llm_call_audit metadata; SQLAlchemy failures are handled inside _persist_llm_calls
-    with class-name-only slog. The explicit raise after the progress publish preserves
-    the cancellation chain.
+  reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
+    audit persistence; FP changed after ruff-format reformatted routes.py when post_guided_respond was added.
+  safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=13a5f800c2fa367c
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=11ea851be16cf4e3
   owner: web-sessions
-  reason: contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
-    publish in the send_message cancellation handler — asyncio.shield re-raises CancelledError
-    to the cancelling task while the inner publish runs to completion in the background;
-    we deliberately swallow the re-raise because the task is already being cancelled
-    and the next ``raise`` two lines below restores the cancel chain. Added with elspeth-29e8bd8a1f
-    (in-flight composer observability).
-  safety: The shielded publish always runs to completion regardless of the suppressed
-    re-raise, so the cancelled snapshot reaches the registry. The cancellation chain
-    is preserved by the explicit ``raise`` that follows, so no real cancellation is
-    silently dropped — only the duplicate re-raise from the shield is suppressed.
+  reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
+    publish in the cancellation handler; FP changed after ruff-format reformatted routes.py when post_guided_respond was added.
+  safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=553aa51d778c8e12
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=b0164f850f3e04a3
   owner: web-sessions
-  reason: Mirror of the send_message cancelled-LLM-call audit persistence suppress
-    above — recompose has the same cancellation and audit-sidecar contract.
-  safety: Same as the send_message audit entry above — shielded audit persistence
-    is best-effort, sanitized, and followed by an explicit re-raise that preserves
-    cancellation semantics.
+  reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
+    changed after ruff-format reformatted routes.py when post_guided_respond was added.
+  safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=c9dd3de7ce2dcd5f
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=8d2ea0eab664902a
   owner: web-sessions
-  reason: Mirror of the send_message cancellation handler above — same shielded-publish
-    pattern in the recompose route so cancellation behaviour cannot drift between
-    the two composer entry points.
-  safety: Same as the send_message entry above — shielded publish completes; explicit
-    ``raise`` restores the cancel chain.
+  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP changed after ruff-format
+    reformatted routes.py when post_guided_respond was added.
+  safety: Same as the prior entry.
+  expires: null
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=af5a556ad58ace4d
+  owner: web-sessions
+  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP changed after ruff-format reformatted
+    routes.py when post_guided_respond was added.
+  safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
+  expires: null
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=5d6e55eff93c5873
+  owner: web-sessions
+  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP changed after ruff-format reformatted
+    routes.py when post_guided_respond was added.
+  safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=9514364097170589
+  owner: web-sessions
+  reason: isinstance(options, dict) validates persisted source.options before mutating nested fields during fork blob rewrite;
+    FP changed after ruff-format.
+  safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
+  expires: null
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=8df87b4871417ecd
+  owner: web-sessions
+  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP changed after ruff-format reformatted
+    routes.py when post_guided_respond was added.
+  safety: Returns None on miss, handled by conditional below; same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=247ba68517b436df
+  owner: web-sessions
+  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP changed after ruff-format.
+  safety: Tier 3 boundary — persisted blob_ref type is not guaranteed.
+  expires: null
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=732516c835899a17
+  owner: web-sessions
+  reason: blob_map.get(old_uuid) — not every source reference is guaranteed to have a copied blob target; FP changed after
+    ruff-format.
+  safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2676e4a4c9c503bc
+  owner: web-sessions
+  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP changed after ruff-format.
+  safety: None result skips that key; same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=f926de07b8a8779c
+  owner: web-sessions
+  reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted path/file values; FP
+    changed after ruff-format.
+  safety: Only string values participate in fallback rewrite; same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e90401537935e657
+  owner: web-sessions
+  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path; FP changed
+    after ruff-format.
+  safety: Same as prior fork_from_message R6 entry.
+  expires: null
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=ad4735d4c08a7e45
+  owner: web-sessions
+  reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
+    changed after ruff-format.
+  safety: Same as prior fork_from_message R6 entry.
+  expires: null
+- key: web/sessions/routes.py:R1:create_session_router:post_guided_respond:fp=a8fe360358c3e6f0
+  owner: web-sessions
+  reason: args.get("validation_result") on emit_turn_answered args dict — validation_result is an optional audit field not
+    required for every turn answer.
+  safety: Returns None on miss; emit_turn_answered handles None validation_result gracefully.
+  expires: null
+- key: web/sessions/routes.py:R2:create_session_router:post_guided_respond:fp=246249499fc36720
+  owner: web-sessions
+  reason: getattr(request.app.state, "session_engine", None) — session_engine is not a required startup attribute (it is set
+    in app.py and test fixtures, but may be absent in minimal test harnesses that don't exercise recipe apply).
+  safety: None is passed to handle_step_2_5_recipe_apply which returns a failure result if session_engine is None; no crash.
+  expires: null
+- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=0bd91249bb52f851
+  owner: web-sessions
+  reason: App-scoped compose lock registry is initialized lazily on first session-router use rather than being required at
+    startup; FP changed after ruff-format.
+  safety: Same as prior _get_session_compose_lock_registry entry.
+  expires: null
+- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=187f2093f92be18f
+  owner: web-sessions
+  reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed on every provider error object; FP
+    changed after ruff-format.
+  safety: Same as prior _litellm_error_detail entry.
+  expires: null
+- key: web/sessions/routes.py:R1:_state_response:fp=506c7bcad2e4f5bb
+  owner: web-sessions
+  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP changed after ruff-format.
+  safety: Falls back to unredacted source_data (less privacy, not less safety); same as prior entry.
+  expires: null
+- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=5983abe8c38d77c1
+  owner: web-sessions
+  reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome union type; FP changed
+    after ruff-format.
+  safety: Same as prior _composer_persisted_validation entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=c157b69c8e36f39d
+  owner: composer-audit
+  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP changed after ruff-format.
+  safety: Same as prior _persist_tool_invocations entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=36e8fd2a0da6478e
+  owner: composer-audit
+  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP changed after ruff-format.
+  safety: Same as prior _persist_llm_calls entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=cbdf0e1ae3fd8975
+  owner: web-sessions
+  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP changed after ruff-format.
+  safety: Same as prior _state_data_from_composer_state R6 entry.
+  expires: null
+- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=0e7fea70a9a346af
+  owner: web-sessions
+  reason: isinstance(runtime, ValidationResult) dispatches _RuntimePreflightOutcome union type for telemetry; FP changed after
+    ruff-format.
+  safety: Same as prior _state_data_from_composer_state R5 entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=839f4c25a3f5694c
+  owner: web-sessions
+  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  safety: Same as prior _handle_convergence_error entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=a68206ef6a1effba
+  owner: web-sessions
+  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  safety: Same as prior _handle_plugin_crash entry.
+  expires: null
+- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1b5f3002e41c0b36
+  owner: web-sessions
+  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  safety: Same as prior _handle_runtime_preflight_failure entry.
+  expires: null
+- key: web/app.py:R1:create_app:fp=298d81d738bfa3b0
+  owner: web-app
+  reason: Tier 3 — os.environ.get() for optional WEB_CONCURRENCY env var; FP changed after ruff-format.
+  safety: Defaults to "1" when absent.
+  expires: null
+- key: web/app.py:R2:create_app:_request_id:fp=8412d4ebeb9ea6e9
+  owner: web-app
+  reason: Trust-boundary fallback getattr(request.state, "request_id", "unset") — pre-middleware exception paths; FP changed
+    after ruff-format.
+  safety: '"unset" sentinel provides well-formed response body; same as prior entry.'
   expires: null
 - key: web/execution/runtime_preflight.py:R1:RuntimePreflightCoordinator:run:fp=2a8571a12863dbd7
   owner: web-execution
-  reason: _inflight.get(key) checks whether a task for this key is already in-flight;
-    key is RuntimePreflightKey (an internal typed value), not external data. Returns
-    None on miss, which triggers task creation below.
+  reason: _inflight.get(key) checks whether a task for this key is already in-flight; key is RuntimePreflightKey (an internal
+    typed value), not external data. Returns None on miss, which triggers task creation below.
   safety: None check is explicit; no silent bypass
   expires: null
 - key: web/execution/runtime_preflight.py:R1:RuntimePreflightCoordinator:run:_evict:fp=3fdb1527637df68a
   owner: web-execution
-  reason: _inflight.get(key) inside the done callback checks whether the entry still
-    references the just-finished task before evicting it; key is an internal typed
-    value. The identity guard protects against popping a replacement task created
-    by a later run() call after the original was evicted by cancellation.
-  safety: Identity check (is finished); incorrect match is impossible; no external
-    data
+  reason: _inflight.get(key) inside the done callback checks whether the entry still references the just-finished task before
+    evicting it; key is an internal typed value. The identity guard protects against popping a replacement task created by
+    a later run() call after the original was evicted by cancellation.
+  safety: Identity check (is finished); incorrect match is impossible; no external data
   expires: null
 - key: web/execution/runtime_preflight.py:R9:RuntimePreflightCoordinator:run:_evict:fp=a4269762ca0780b3
   owner: web-execution
-  reason: _inflight.pop(key, None) inside the done callback evicts the just-finished
-    task from the in-flight dict. None default tolerates the case where the entry
-    was already popped by a concurrent eviction or by an awaiter's earlier cleanup.
-  safety: Only fires from add_done_callback after task completion; pop is idempotent;
-    identity guard above ensures we don't pop a replacement task
+  reason: _inflight.pop(key, None) inside the done callback evicts the just-finished task from the in-flight dict. None default
+    tolerates the case where the entry was already popped by a concurrent eviction or by an awaiter's earlier cleanup.
+  safety: Only fires from add_done_callback after task completion; pop is idempotent; identity guard above ensures we don't
+    pop a replacement task
   expires: null
 - key: web/execution/runtime_preflight.py:R4:RuntimePreflightCoordinator:_capture:fp=cbdc5bec7bc401ee
   owner: web-execution
-  reason: except Exception captures any worker failure (plugin construction errors,
-    TimeoutError, etc.) and wraps it in RuntimePreflightFailure so the coordinator
-    always returns RuntimePreflightEntry — both success and failure paths — without
-    propagating to all waiters
-  safety: Exception is stored on RuntimePreflightFailure.original_exc and re-raised
-    at the caller site with full chain preservation; no silent swallowing
+  reason: except Exception captures any worker failure (plugin construction errors, TimeoutError, etc.) and wraps it in RuntimePreflightFailure
+    so the coordinator always returns RuntimePreflightEntry — both success and failure paths — without propagating to all
+    waiters
+  safety: Exception is stored on RuntimePreflightFailure.original_exc and re-raised at the caller site with full chain preservation;
+    no silent swallowing
   expires: null
 - key: web/execution/schemas.py:R5:RunEvent:_reject_epoch_timestamp:fp=3c9b05232e0eee8f
   owner: web-execution
-  reason: Tier 1 field_validator — isinstance whitelists datetime|str for timestamp,
-    rejects int (Unix epoch)
-  safety: Raises ValueError on non-datetime/non-str; tightens Field(strict=False)
-    coercion scope
+  reason: Tier 1 field_validator — isinstance whitelists datetime|str for timestamp, rejects int (Unix epoch)
+  safety: Raises ValueError on non-datetime/non-str; tightens Field(strict=False) coercion scope
   expires: null
 - key: web/execution/schemas.py:R5:RunEvent:_resolve_data_from_event_type:fp=dcc657a0ad575656
   owner: web-execution
-  reason: Pydantic before-validator — isinstance(values, dict) gates JSON round-trip
-    path; non-dict values handled by Pydantic
+  reason: Pydantic before-validator — isinstance(values, dict) gates JSON round-trip path; non-dict values handled by Pydantic
   safety: Structural dispatch for deserialization, not error suppression
   expires: null
 - key: web/execution/schemas.py:R1:RunEvent:_resolve_data_from_event_type:fp=722acae92f14936c
   owner: web-execution
-  reason: Pydantic before-validator — .get() on pre-validated Tier 3 input from JSON
-    round-trip
+  reason: Pydantic before-validator — .get() on pre-validated Tier 3 input from JSON round-trip
   safety: Missing keys fall through to Pydantic field validation downstream
   expires: null
 - key: web/execution/schemas.py:R1:RunEvent:_resolve_data_from_event_type:fp=0cea4977dfaad477
   owner: web-execution
-  reason: Pydantic before-validator — .get() on pre-validated Tier 3 input from JSON
-    round-trip
+  reason: Pydantic before-validator — .get() on pre-validated Tier 3 input from JSON round-trip
   safety: Missing keys fall through to Pydantic field validation downstream
   expires: null
 - key: web/execution/schemas.py:R5:RunEvent:_resolve_data_from_event_type:fp=fc80b640eaad1fe2
   owner: web-execution
-  reason: Pydantic before-validator — isinstance(values, dict) gates JSON round-trip
-    path; non-dict values handled by Pydantic
+  reason: Pydantic before-validator — isinstance(values, dict) gates JSON round-trip path; non-dict values handled by Pydantic
   safety: Structural dispatch for deserialization, not error suppression
   expires: null
 - key: web/execution/schemas.py:R5:RunEvent:_enforce_data_type:fp=24d8a0d80e61796b
   owner: web-execution
-  reason: Offensive programming — isinstance enforces event_type/data type correspondence
-    at construction time
+  reason: Offensive programming — isinstance enforces event_type/data type correspondence at construction time
   safety: Raises ValueError on mismatch; belt-and-suspenders with before-validator
   expires: null
 - key: web/execution/service.py:R5:_sanitize_error_for_client:fp=10ef92b852ef494a
   owner: web-execution
-  reason: Security boundary — isinstance dispatches SecretResolutionError to safe
-    message (no secret name leakage)
+  reason: Security boundary — isinstance dispatches SecretResolutionError to safe message (no secret name leakage)
   safety: Type dispatch for sanitization, not error suppression
   expires: null
 - key: web/execution/service.py:R5:_sanitize_error_for_client:fp=9c62afebfd0b8f75
   owner: web-execution
-  reason: Security boundary — isinstance dispatches SecretResolutionError to safe
-    message (no secret name leakage)
+  reason: Security boundary — isinstance dispatches SecretResolutionError to safe message (no secret name leakage)
   safety: Type dispatch for sanitization, not error suppression
   expires: null
 - key: web/execution/service.py:R9:ExecutionServiceImpl:cleanup_session_lock:fp=0115d0d1d1a2d2b7
   owner: web-execution
-  reason: Session may never have called execute(), so no lock exists in _session_locks.
-    Cleanup is called on every session delete regardless. Matches ProgressBroadcaster.cleanup_run()
-    pattern.
+  reason: Session may never have called execute(), so no lock exists in _session_locks. Cleanup is called on every session
+    delete regardless. Matches ProgressBroadcaster.cleanup_run() pattern.
   safety: Missing key means session was never executed against; no cleanup needed
   expires: null
 - key: web/execution/service.py:R8:ExecutionServiceImpl:execute:fp=f0ed9aa21cc55535
@@ -1970,11 +1689,9 @@ allow_hits:
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_execute_locked:fp=a52beed30ac36c97
   owner: web-execution
-  reason: Best-effort run status cleanup on setup failure — must not mask original
-    exception. Narrowed from `except Exception` to `(SQLAlchemyError, OSError)` per
-    canonical pattern b8ba2214/127417cb so programmer bugs in update_run_status propagate.
-    Logs exc_class only (no str(exc)) to avoid SQLAlchemy `__cause__` chains exposing
-    DB URLs/credentials.
+  reason: Best-effort run status cleanup on setup failure — must not mask original exception. Narrowed from `except Exception`
+    to `(SQLAlchemyError, OSError)` per canonical pattern b8ba2214/127417cb so programmer bugs in update_run_status propagate.
+    Logs exc_class only (no str(exc)) to avoid SQLAlchemy `__cause__` chains exposing DB URLs/credentials.
   safety: Logged with slog.error; original exception always re-raised
   expires: null
 - key: web/execution/service.py:R1:ExecutionServiceImpl:cancel:fp=aa6305046d263bf4
@@ -1989,58 +1706,47 @@ allow_hits:
   expires: null
 - key: web/execution/service.py:R1:ExecutionServiceImpl:_run_pipeline:fp=4f747d62fb6da925
   owner: web-execution
-  reason: Scope-to-audit-source mapping — .get() on explicit mapping dict with crash-on-unknown
-    guard
+  reason: Scope-to-audit-source mapping — .get() on explicit mapping dict with crash-on-unknown guard
   safety: Unknown scope raises ValueError immediately; no silent default
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_run_pipeline:_safe_broadcast:fp=8beb2c9f5a68f6b1
   owner: web-execution
-  reason: Progress broadcasting via call_soon_threadsafe raises RuntimeError when
-    event loop is closed during shutdown
-  safety: Only RuntimeError caught (narrowed from bare Exception); logged with canonical
-    exc_class; pipeline continues
+  reason: Progress broadcasting via call_soon_threadsafe raises RuntimeError when event loop is closed during shutdown
+  safety: Only RuntimeError caught (narrowed from bare Exception); logged with canonical exc_class; pipeline continues
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_run_pipeline:fp=271aec51d432c0c5
   owner: web-execution
-  reason: GracefulShutdownError is an expected control-flow signal from orchestrator
-    cancellation
+  reason: GracefulShutdownError is an expected control-flow signal from orchestrator cancellation
   safety: Classified as cancelled; separated from BaseException failure path
   expires: null
 - key: web/execution/service.py:R5:ExecutionServiceImpl:_run_pipeline:fp=b25e3bff9dca6bff
   owner: web-execution
-  reason: Signal-exception classification (KeyboardInterrupt/SystemExit) inside the
-    BaseException recovery block — programmer signals must propagate; only normal
-    exceptions are classified to the failed path and routed through the post-completion
+  reason: Signal-exception classification (KeyboardInterrupt/SystemExit) inside the BaseException recovery block — programmer
+    signals must propagate; only normal exceptions are classified to the failed path and routed through the post-completion
     run-state probe.
-  safety: KeyboardInterrupt/SystemExit re-raised by the surrounding handler; non-signal
-    exceptions become operator-visible structured failures
+  safety: KeyboardInterrupt/SystemExit re-raised by the surrounding handler; non-signal exceptions become operator-visible
+    structured failures
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_run_pipeline:fp=4e8f915bcc6109bc
   owner: web-execution
-  reason: 'elspeth-879f6de6bd post-completion run-state probe — catches (SQLAlchemyError,
-    OSError) only, so transient audit-system degradation (DB hiccup, filesystem race)
-    on the get_run() read does not mask the original post-completion exception. ValueError
-    is deliberately NOT caught: per the inline source rationale (web/execution/service.py:1094-1114),
-    the ValueErrors get_run() can raise ("Run not found", malformed UUID, non-UTC
-    datetimes via _ensure_utc) are all Tier-1 audit-data corruption and MUST crash
-    immediately per CLAUDE.md tier model rather than be silently absorbed. Fingerprint
-    shifted from c6a02ba63e915cd4 when the catch tuple was narrowed from (SQLAlchemyError,
-    OSError, ValueError) to (SQLAlchemyError, OSError); previous fingerprint shift
-    was af4245407c3c4a91 → c6a02ba63e915cd4 by the I-4 audit-primacy fix that removed
-    the post-terminal-exception slog block above this handler.'
-  safety: Falls through to best-effort failed-status update on absorbed exceptions;
-    ValueError surfaces Tier-1 audit corruption as required; programmer bugs (TypeError/AttributeError/RuntimeError)
-    propagate
+  reason: 'elspeth-879f6de6bd post-completion run-state probe — catches (SQLAlchemyError, OSError) only, so transient audit-system
+    degradation (DB hiccup, filesystem race) on the get_run() read does not mask the original post-completion exception. ValueError
+    is deliberately NOT caught: per the inline source rationale (web/execution/service.py:1094-1114), the ValueErrors get_run()
+    can raise ("Run not found", malformed UUID, non-UTC datetimes via _ensure_utc) are all Tier-1 audit-data corruption and
+    MUST crash immediately per CLAUDE.md tier model rather than be silently absorbed. Fingerprint shifted from c6a02ba63e915cd4
+    when the catch tuple was narrowed from (SQLAlchemyError, OSError, ValueError) to (SQLAlchemyError, OSError); previous
+    fingerprint shift was af4245407c3c4a91 → c6a02ba63e915cd4 by the I-4 audit-primacy fix that removed the post-terminal-exception
+    slog block above this handler.'
+  safety: Falls through to best-effort failed-status update on absorbed exceptions; ValueError surfaces Tier-1 audit corruption
+    as required; programmer bugs (TypeError/AttributeError/RuntimeError) propagate
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_run_pipeline:fp=af2f0ffc192fe035
   owner: web-execution
-  reason: Canonical narrow-catch pattern (commits b8ba2214 / 127417cb) for the status
-    update inside the BaseException recovery handler. Fingerprint shifted from 7edaa7aa890d4d12
-    by the I-4 audit-primacy fix that removed the post-terminal-exception slog block
-    above this handler.
-  safety: Catches (SQLAlchemyError, OSError) from update_run_status so transient DB
-    or filesystem failures do not mask the original pipeline exception; programmer
-    bugs (TypeError, AttributeError, RuntimeError) propagate
+  reason: Canonical narrow-catch pattern (commits b8ba2214 / 127417cb) for the status update inside the BaseException recovery
+    handler. Fingerprint shifted from 7edaa7aa890d4d12 by the I-4 audit-primacy fix that removed the post-terminal-exception
+    slog block above this handler.
+  safety: Catches (SQLAlchemyError, OSError) from update_run_status so transient DB or filesystem failures do not mask the
+    original pipeline exception; programmer bugs (TypeError, AttributeError, RuntimeError) propagate
   expires: null
 - key: web/execution/service.py:R9:ExecutionServiceImpl:_run_pipeline:fp=9e0b68ce52d4147c
   owner: web-execution
@@ -2049,663 +1755,574 @@ allow_hits:
   expires: null
 - key: web/execution/service.py:R6:ExecutionServiceImpl:_finalize_output_blobs:fp=f1ae7cec624b5aeb
   owner: web-execution
-  reason: Blob finalization before terminal broadcast — failure must not mask run
-    outcome
-  safety: _FINALIZE_SUPPRESSED covers blob-domain exceptions (OSError, SQLAlchemyError,
-    BlobNotFoundError, BlobQuotaExceededError, BlobStateError); RuntimeError deliberately
-    excluded (too broad); programmer bugs propagate; partial failures logged from
+  reason: Blob finalization before terminal broadcast — failure must not mask run outcome
+  safety: _FINALIZE_SUPPRESSED covers blob-domain exceptions (OSError, SQLAlchemyError, BlobNotFoundError, BlobQuotaExceededError,
+    BlobStateError); RuntimeError deliberately excluded (too broad); programmer bugs propagate; partial failures logged from
     structured result
   expires: null
 - key: web/execution/service.py:R5:ExecutionServiceImpl:_on_pipeline_done:fp=b1bc50d69bfcc26b
   owner: web-execution
-  reason: Last-resort safety net — isinstance check excludes KeyboardInterrupt/SystemExit
-    from diagnostic logging
-  safety: Only suppresses signal exceptions; all other exceptions logged as last-resort
-    diagnostic
+  reason: Last-resort safety net — isinstance check excludes KeyboardInterrupt/SystemExit from diagnostic logging
+  safety: Only suppresses signal exceptions; all other exceptions logged as last-resort diagnostic
   expires: null
 - key: web/composer/state.py:R5:_is_static_contract_probe_exception:fp=df312727f02279b0
   owner: web-composer
-  reason: Composer static-contract probes instantiate draft plugins while the user/LLM
-    may still be filling options. Known config/probe exception classes are classified
-    so the validator can return unknown contract facts instead of crashing.
-  safety: Unexpected exceptions are re-raised. Known exception text is never surfaced
-    to the UI; downstream validation treats absent facts as unknown/fail-closed where
-    required.
+  reason: Composer static-contract probes instantiate draft plugins while the user/LLM may still be filling options. Known
+    config/probe exception classes are classified so the validator can return unknown contract facts instead of crashing.
+  safety: Unexpected exceptions are re-raised. Known exception text is never surfaced to the UI; downstream validation treats
+    absent facts as unknown/fail-closed where required.
   expires: null
 - key: web/composer/service.py:R5:_litellm_completion_supports_param:fp=ab6fa2e8fc756fe3
   owner: web-composer
-  reason: Tier 3 LiteLLM supported-parameter metadata boundary; provider metadata
-    must be list-shaped before treating seed as supported.
-  safety: Malformed or absent metadata conservatively omits the seed request parameter
-    instead of fabricating support.
+  reason: Tier 3 LiteLLM supported-parameter metadata boundary; provider metadata must be list-shaped before treating seed
+    as supported.
+  safety: Malformed or absent metadata conservatively omits the seed request parameter instead of fabricating support.
   expires: null
 - key: web/composer/service.py:R5:_provider_details_payload:fp=b5da0985ff7da727
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_provider_details_payload:fp=a630e124ff14d661
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=3d58898df136036f
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R5:_token_usage_from_response:fp=05c49e7370a4623a
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=98dda992e75685e8
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=255fc2e1800dfdae
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=e39115cc686159de
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=d3757b1d7a080da8
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=fce9f4ac1cd494f8
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=eee9978e1d9f29dd
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R5:_token_usage_from_response:fp=761255760cdc95f6
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R5:_token_usage_from_response:fp=095d94312c44b41c
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R5:_token_usage_from_response:fp=75021621184c14eb
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=06e2b357b3407e1e
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=710e6172bd889f64
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R1:_token_usage_from_response:fp=2ecba9ce177551d3
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=72244dff2d50f238
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=6960cb0803124826
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=2764b1803222df25
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=d2fba7566d339255
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=7a04e0ff3abc5a4a
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=f434bde775c0328f
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=e49eab2ecb1cb63d
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=a35ccffaed4c2c4b
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_token_usage_from_response:fp=5125e5bfc84a8fc4
   owner: composer-audit
-  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent,
-    mapping-shaped, object-shaped, or omit optional cache and reasoning fields.
-  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict;
-    no zeroes or costs are fabricated.
+  reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
+    omit optional cache and reasoning fields.
+  safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
 - key: web/composer/service.py:R2:_provider_cost_from_response:fp=a64e80082f7d3cbb
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_provider_cost_from_response:fp=dc0c6f114cc2f436
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_provider_cost_from_response:fp=18c2ff80634b9571
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_safe_response_model:fp=294ad0bd019e41b4
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_safe_response_model:fp=49d0160079b48a50
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_safe_provider_request_id:fp=a646470d89cdb53f
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_safe_provider_request_id:fp=d8c68d317e336ada
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_response_field:fp=f1113fcf21b93aa3
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R1:_response_field:fp=925a8bfc0993c645
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R2:_response_field:fp=c2e22fa021170483
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_first_response_message:fp=b83ee6a1a3c915ee
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=990fbc664ce6d5f6
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=cba69ff6caa46865
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=6bb7b5b7ad960789
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=19393fd9439eabf3
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=f0f24995bda19a32
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=6a207788fff47544
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=ea53d3e6be314007
   owner: composer-audit
-  reason: Tier 3 provider artifact normalization boundary; reasoning details may be
-    nested mappings, sequences, model objects, or opaque provider classes.
-  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value);
-    raw provider objects are not stored.
+  reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
+    or opaque provider classes.
+  safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
 - key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=0f581ca641445cb3
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=8ac027c0e61f8325
   owner: composer-audit
-  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional
-    metadata under provider-specific dict and object shapes.
-  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or
-    malformed fields stay None.
+  reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
+    and object shapes.
+  safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
 - key: web/composer/service.py:R5:_supports_anthropic_prompt_cache_markers:fp=5c0c3c00e8f8d707
   owner: composer-cache-markers
-  reason: Provider-detection predicate for prompt-cache marker support; model identifiers
-    may be absent or malformed before settings are finalized.
-  safety: Non-string input returns False and the LiteLLM call proceeds without cache
-    markers.
+  reason: Provider-detection predicate for prompt-cache marker support; model identifiers may be absent or malformed before
+    settings are finalized.
+  safety: Non-string input returns False and the LiteLLM call proceeds without cache markers.
   expires: null
 - key: web/composer/service.py:R1:_apply_anthropic_cache_markers:fp=439664e132982084
   owner: composer-cache-markers
-  reason: Prompt-cache marker transform scans message dicts whose role field may be
-    absent during composer message construction.
-  safety: Missing role leaves that message unmarked; the transform still preserves
-    the original payload shape.
+  reason: Prompt-cache marker transform scans message dicts whose role field may be absent during composer message construction.
+  safety: Missing role leaves that message unmarked; the transform still preserves the original payload shape.
   expires: null
 - key: web/composer/service.py:R5:_optional_ancestor_present:fp=b7a2c4f11a0fc23f
   owner: composer-walker
-  reason: Tier 3 LLM tool-call argument walker distinguishes absent optional ancestors
-    from present malformed nested values.
-  safety: Malformed shapes become structured argument errors returned to the LLM,
-    not crashes or silent tool execution.
+  reason: Tier 3 LLM tool-call argument walker distinguishes absent optional ancestors from present malformed nested values.
+  safety: Malformed shapes become structured argument errors returned to the LLM, not crashes or silent tool execution.
   expires: null
 - key: web/composer/service.py:R1:ComposerServiceImpl:_cached_runtime_preflight:fp=ee45a7ef20e6e248
   owner: web-composer
-  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks
-    an internal per-compose cache for an existing result.
-  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache
-    misses run the coordinator path.
+  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
+    result.
+  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=4f73f5c829e2f862
   owner: web-composer
-  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks
-    an internal per-compose cache for an existing result.
-  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache
-    misses run the coordinator path.
+  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
+    result.
+  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=9f4489a004a5722e
   owner: web-composer
-  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks
-    an internal per-compose cache for an existing result.
-  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache
-    misses run the coordinator path.
+  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
+    result.
+  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=c5eee98b7f106fb8
   owner: web-composer
-  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks
-    an internal per-compose cache for an existing result.
-  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache
-    misses run the coordinator path.
+  reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
+    result.
+  safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_compose_loop:fp=6051df645b26b9af
   owner: composer-advisor
-  reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider
-    failures are converted into structured composer feedback.
-  safety: Tool execution is skipped on argument errors; advisor/provider failures
-    are audited and returned as bounded tool results.
+  reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider failures are converted into structured
+    composer feedback.
+  safety: Tool execution is skipped on argument errors; advisor/provider failures are audited and returned as bounded tool
+    results.
   expires: null
 - key: web/composer/service.py:R4:ComposerServiceImpl:_compose_loop:fp=b8b21ea56f873034
   owner: composer-advisor
-  reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider
-    failures are converted into structured composer feedback.
-  safety: Tool execution is skipped on argument errors; advisor/provider failures
-    are audited and returned as bounded tool results.
+  reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider failures are converted into structured
+    composer feedback.
+  safety: Tool execution is skipped on argument errors; advisor/provider failures are audited and returned as bounded tool
+    results.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=4f0fa60fae1c3c45
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=73cb467bd2726216
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=ed4c61c1761c3718
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=604d96c7f5ded948
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=5a710005dd5a2f85
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=ffeaf8f3fd1edd46
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=68d3c369d9c85db8
   owner: composer-advisor
-  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked
-    before spending advisor budget or constructing prompts.
-  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
-    made.
+  reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
+    constructing prompts.
+  safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=37783254993bc717
   owner: web-execution
-  reason: Launch guard inspects user-authored LLM plugin options at the execution
-    boundary; queries may be a mapping for named multi-query prompts.
-  safety: Only the query count is used for spend estimation; malformed options still
-    go through plugin/runtime validation before any provider call.
+  reason: Launch guard inspects user-authored LLM plugin options at the execution boundary; queries may be a mapping for named
+    multi-query prompts.
+  safety: Only the query count is used for spend estimation; malformed options still go through plugin/runtime validation
+    before any provider call.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=4f09759c469258d0
   owner: web-execution
-  reason: Launch guard inspects user-authored LLM plugin options at the execution
-    boundary; queries may be a sequence for multi-query prompts.
-  safety: Strings and byte sequences are excluded from the sequence count; malformed
-    options still go through plugin/runtime validation before any provider call.
+  reason: Launch guard inspects user-authored LLM plugin options at the execution boundary; queries may be a sequence for
+    multi-query prompts.
+  safety: Strings and byte sequences are excluded from the sequence count; malformed options still go through plugin/runtime
+    validation before any provider call.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=bbfb386271aa5a70
   owner: web-execution
-  reason: Launch guard distinguishes scalar string-like values from query sequences
-    when estimating LLM provider calls from user-authored plugin options.
-  safety: Scalar string-like values fall back to one provider call per row; plugin/runtime
-    validation remains the authority for option correctness.
+  reason: Launch guard distinguishes scalar string-like values from query sequences when estimating LLM provider calls from
+    user-authored plugin options.
+  safety: Scalar string-like values fall back to one provider call per row; plugin/runtime validation remains the authority
+    for option correctness.
   expires: null
 - key: web/execution/fanout_guard.py:R6:_estimate_source_rows:fp=fdf1ab16ee8462d4
   owner: web-execution
-  reason: Fanout estimation reads user-provided source files before execution; filesystem,
-    encoding, CSV, or JSON parse failures mean cardinality is unknown.
-  safety: The guard never fabricates a row count from unreadable data; execution still
-    validates/opens the source on the normal path before any downstream provider calls.
+  reason: Fanout estimation reads user-provided source files before execution; filesystem, encoding, CSV, or JSON parse failures
+    mean cardinality is unknown.
+  safety: The guard never fabricates a row count from unreadable data; execution still validates/opens the source on the normal
+    path before any downstream provider calls.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_source_path:fp=ddcfcb5be92f7e23
   owner: web-execution
-  reason: Source path/file options are user-authored plugin options and may be absent
-    or non-string before plugin validation runs.
-  safety: Non-string values are treated as unavailable for local row estimation only;
-    normal execution validation remains responsible for rejecting invalid source options.
+  reason: Source path/file options are user-authored plugin options and may be absent or non-string before plugin validation
+    runs.
+  safety: Non-string values are treated as unavailable for local row estimation only; normal execution validation remains
+    responsible for rejecting invalid source options.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_remote_source_limit:fp=f3e8691c99939d74
   owner: web-execution
-  reason: Remote source limit/top/max_rows options are user-authored plugin options
-    and only integer row caps can safely inform spend estimation.
-  safety: Non-integer values do not reduce the guard's estimate; plugin/runtime validation
-    remains responsible for option correctness.
+  reason: Remote source limit/top/max_rows options are user-authored plugin options and only integer row caps can safely inform
+    spend estimation.
+  safety: Non-integer values do not reduce the guard's estimate; plugin/runtime validation remains responsible for option
+    correctness.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_count_csv_source_rows:fp=4de1a38e6489f86a
   owner: web-execution
-  reason: CSV skip_rows is a user-authored option inspected before execution so the
-    launch guard can estimate source cardinality.
-  safety: Only integer skip_rows affects the estimator; invalid values are still rejected
-    by plugin/runtime validation on the normal execution path.
+  reason: CSV skip_rows is a user-authored option inspected before execution so the launch guard can estimate source cardinality.
+  safety: Only integer skip_rows affects the estimator; invalid values are still rejected by plugin/runtime validation on
+    the normal execution path.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=4de14b5c3571bbc7
   owner: web-execution
-  reason: JSON source files are external/user data; data_key counting must first verify
-    the decoded payload is an object before indexing it.
-  safety: Non-object payloads return unknown cardinality for the estimator instead
-    of fabricating a count; execution source validation still handles malformed data.
+  reason: JSON source files are external/user data; data_key counting must first verify the decoded payload is an object before
+    indexing it.
+  safety: Non-object payloads return unknown cardinality for the estimator instead of fabricating a count; execution source
+    validation still handles malformed data.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=b90c5294dec6686f
   owner: web-execution
-  reason: JSON source files are external/user data; only top-level arrays have a directly
-    countable row cardinality for this launch guard.
-  safety: Non-array payloads return unknown cardinality for the estimator instead
-    of fabricating a count; execution source validation still handles malformed data.
+  reason: JSON source files are external/user data; only top-level arrays have a directly countable row cardinality for this
+    launch guard.
+  safety: Non-array payloads return unknown cardinality for the estimator instead of fabricating a count; execution source
+    validation still handles malformed data.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_string_option:fp=551453a6d1751fa2
   owner: web-execution
-  reason: Fanout estimation reads optional user-authored plugin string options such
-    as provider, model, encoding, delimiter, format, and data_key.
-  safety: Only nonblank strings are surfaced into the guard payload; absent or malformed
-    values remain unknown and normal plugin/runtime validation remains authoritative.
+  reason: Fanout estimation reads optional user-authored plugin string options such as provider, model, encoding, delimiter,
+    format, and data_key.
+  safety: Only nonblank strings are surfaced into the guard payload; absent or malformed values remain unknown and normal
+    plugin/runtime validation remains authoritative.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_credential_ref:fp=195a89405c54ca1d
   owner: web-execution
-  reason: LLM credential configuration can be either an inline string or a secret-ref
-    mapping in user-authored plugin options.
-  safety: The guard emits only credential category/ref metadata and never the secret
-    value; actual secret resolution remains on the execution path.
+  reason: LLM credential configuration can be either an inline string or a secret-ref mapping in user-authored plugin options.
+  safety: The guard emits only credential category/ref metadata and never the secret value; actual secret resolution remains
+    on the execution path.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_credential_ref:fp=24c08e5d0ce127d5
   owner: web-execution
-  reason: Secret-ref mappings are user-authored plugin options and the nested secret_ref
-    value must be a visible nonblank string before being identified in the guard payload.
-  safety: The guard emits only the secret_ref name marker and never resolves or logs
-    the secret value; invalid shapes remain unknown for the guard.
+  reason: Secret-ref mappings are user-authored plugin options and the nested secret_ref value must be a visible nonblank
+    string before being identified in the guard payload.
+  safety: The guard emits only the secret_ref name marker and never resolves or logs the secret value; invalid shapes remain
+    unknown for the guard.
   expires: null
 - key: web/execution/fanout_guard.py:R5:_credential_ref:fp=b0754fca2fa41500
   owner: web-execution
-  reason: Inline LLM API keys are user-authored plugin options and must be identified
-    without exposing their contents in the launch guard.
-  safety: Nonblank inline strings are reported only as the category inline_api_key;
-    the actual credential value is never included in the guard payload.
+  reason: Inline LLM API keys are user-authored plugin options and must be identified without exposing their contents in the
+    launch guard.
+  safety: Nonblank inline strings are reported only as the category inline_api_key; the actual credential value is never included
+    in the guard payload.
   expires: null
 - key: web/execution/outputs.py:R6:_is_path_in_sink_allowlist:fp=0cedc3792a8a7287
   owner: web-execution
-  reason: Path.resolve() can raise OSError on symlink loops, missing intermediates,
-    or permission failures while computing the canonical path for the sink-allowlist
-    check. The downloadable flag is a UI hint, not a security boundary — the actual
-    /content endpoint reapplies the allowlist guard with its own resolve(). When
-    resolution fails here we conservatively treat the artifact as not-downloadable.
-  safety: An unresolvable path produces downloadable=false; the UI suppresses the
-    Download button. The audit trail still shows the artifact's recorded path_or_uri,
-    exists_now, and content_hash. No bytes are served on a False result.
+  reason: Path.resolve() can raise OSError on symlink loops, missing intermediates, or permission failures while computing
+    the canonical path for the sink-allowlist check. The downloadable flag is a UI hint, not a security boundary — the actual
+    /content endpoint reapplies the allowlist guard with its own resolve(). When resolution fails here we conservatively treat
+    the artifact as not-downloadable.
+  safety: An unresolvable path produces downloadable=false; the UI suppresses the Download button. The audit trail still shows
+    the artifact's recorded path_or_uri, exists_now, and content_hash. No bytes are served on a False result.
   expires: null
 - key: web/composer/state.py:R5:_validate_web_scrape_abuse_contact_not_reserved:fp=b18e4e501177b46d
   owner: web-composer
-  reason: Tier 3 boundary — LLM/operator-supplied node options may shape `http` as
-    a non-Mapping (e.g., null, list). Validator returns None on shape mismatch and
-    delegates to the plugin schema rule, which surfaces malformed `http` as a structured
+  reason: Tier 3 boundary — LLM/operator-supplied node options may shape `http` as a non-Mapping (e.g., null, list). Validator
+    returns None on shape mismatch and delegates to the plugin schema rule, which surfaces malformed `http` as a structured
     error rather than crashing the validate path.
-  safety: Returns None; downstream plugin schema rule reports the malformed http block
-    as a separate ValidationEntry.
+  safety: Returns None; downstream plugin schema rule reports the malformed http block as a separate ValidationEntry.
   expires: null
 - key: web/composer/state.py:R1:_validate_web_scrape_abuse_contact_not_reserved:fp=54928459e9ddb422
   owner: web-composer
-  reason: Tier 3 boundary — abuse_contact is an optional sub-key of the operator-supplied
-    http options block. Missing key is a documented optional configuration, not an
-    error.
-  safety: Returns None when key is absent; reserved-domain check only fires when the
-    operator explicitly set abuse_contact.
+  reason: Tier 3 boundary — abuse_contact is an optional sub-key of the operator-supplied http options block. Missing key
+    is a documented optional configuration, not an error.
+  safety: Returns None when key is absent; reserved-domain check only fires when the operator explicitly set abuse_contact.
   expires: null
 - key: web/execution/service.py:R4:ExecutionServiceImpl:_run_pipeline:fp=be149cf5244d1481
   owner: web-execution
-  reason: Best-effort failure-sample enrichment — Tier-1 audit DB read via load_top_failure_samples
-    may raise on malformed audit JSON or transient DB error. Degrading to bare error
-    message is preferable to losing the run-status persistence (which is the more
-    important failure-mode invariant). Audit-DB anomalies remain observable via the
-    slog warning per the audit-system-failure exemption in CLAUDE.md logging-telemetry-policy.
-  safety: samples_text falls back to empty string; the failed-requires-error invariant
-    is still satisfied via the structural failure message; slog.warning emits exc_info
-    for forensic visibility.
+  reason: Best-effort failure-sample enrichment — Tier-1 audit DB read via load_top_failure_samples may raise on malformed
+    audit JSON or transient DB error. Degrading to bare error message is preferable to losing the run-status persistence (which
+    is the more important failure-mode invariant). Audit-DB anomalies remain observable via the slog warning per the audit-system-failure
+    exemption in CLAUDE.md logging-telemetry-policy.
+  safety: samples_text falls back to empty string; the failed-requires-error invariant is still satisfied via the structural
+    failure message; slog.warning emits exc_info for forensic visibility.
   expires: null
 - key: web/execution/failure_samples.py:R1:load_top_failure_samples:fp=fdc4a3946c001515
   owner: web-execution
-  reason: Best-effort enrichment field — error_details JSON shape varies by transform
-    (different plugins write different keys). Defaulting to "UnknownError" is the
-    documented fallback for transforms that don't write error_type. Caller wraps with
+  reason: Best-effort enrichment field — error_details JSON shape varies by transform (different plugins write different keys).
+    Defaulting to "UnknownError" is the documented fallback for transforms that don't write error_type. Caller wraps with
     broad-except so any audit-shape anomaly degrades gracefully.
-  safety: Default "UnknownError" preserves rendering; missing error_type does not
-    block run-status persistence.
+  safety: Default "UnknownError" preserves rendering; missing error_type does not block run-status persistence.
   expires: null
 - key: web/execution/failure_samples.py:R1:load_top_failure_samples:fp=b09747c7efb37444
   owner: web-execution
-  reason: Best-effort enrichment field — error_details JSON shape varies by transform.
-    The `error` key is the canonical field; some transforms write `reason` instead.
-    Two-level fallback ("error" → "reason" → "") matches both conventions without
+  reason: Best-effort enrichment field — error_details JSON shape varies by transform. The `error` key is the canonical field;
+    some transforms write `reason` instead. Two-level fallback ("error" → "reason" → "") matches both conventions without
     crashing on either.
-  safety: Empty string when neither key is present; downstream format_failure_samples
-    handles empty messages gracefully.
+  safety: Empty string when neither key is present; downstream format_failure_samples handles empty messages gracefully.
   expires: null
 - key: web/execution/failure_samples.py:R1:load_top_failure_samples:fp=1f176fb7969fbed2
   owner: web-execution
-  reason: Inner fallback for the chained .get("error", details.get("reason", ""))
-    expression — same justification as the outer .get above; both branches converge
-    on empty string when neither key is present.
-  safety: Empty string when neither key is present; downstream format_failure_samples
-    handles empty messages gracefully.
+  reason: Inner fallback for the chained .get("error", details.get("reason", "")) expression — same justification as the outer
+    .get above; both branches converge on empty string when neither key is present.
+  safety: Empty string when neither key is present; downstream format_failure_samples handles empty messages gracefully.
   expires: null
 - key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=de84351ad6bfe956
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied
-    external data (Tier 3). .get("blob_id", "") is the documented coercion at this
-    boundary; an empty-string sentinel means "operator must supply via recipe_offer
+  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied external data (Tier 3). .get("blob_id",
+    "") is the documented coercion at this boundary; an empty-string sentinel means "operator must supply via recipe_offer
     turn". Per module docstring and Errata C8.
-  safety: Empty string sentinel propagates to the recipe_offer turn where the operator
-    is explicitly asked to supply the blob_id. No silent data loss.
+  safety: Empty string sentinel propagates to the recipe_offer turn where the operator is explicitly asked to supply the blob_id.
+    No silent data loss.
   expires: null
 - key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=a6c6f31ab3c80323
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is
-    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
-    coercion at this boundary; default path propagates to the recipe_offer turn for
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
+    .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
     operator confirmation. Per module docstring and Errata C8.
-  safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"];
-    operator confirms or overrides via recipe_offer turn.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"]; operator confirms or
+    overrides via recipe_offer turn.
   expires: null
 - key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=594f7aa0183fa90e
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied
-    external data (Tier 3). .get("blob_id", "") is the documented coercion at this
-    boundary; an empty-string sentinel means "operator must supply via recipe_offer
+  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied external data (Tier 3). .get("blob_id",
+    "") is the documented coercion at this boundary; an empty-string sentinel means "operator must supply via recipe_offer
     turn". Per module docstring and Errata C8.
-  safety: Empty string sentinel propagates to the recipe_offer turn where the operator
-    is explicitly asked to supply the blob_id. No silent data loss.
+  safety: Empty string sentinel propagates to the recipe_offer turn where the operator is explicitly asked to supply the blob_id.
+    No silent data loss.
   expires: null
 - key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=04eea8af1e9b234a
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is
-    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
-    coercion at this boundary; default path propagates to the recipe_offer turn for
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
+    .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
     operator confirmation. Per module docstring and Errata C8.
-  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"];
-    operator confirms or overrides via recipe_offer turn.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"]; operator confirms
+    or overrides via recipe_offer turn.
   expires: null
 - key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=6c8bcb44b83e0e72
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is
-    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
-    coercion at this boundary; default path propagates to the recipe_offer turn for
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is user/LLM-supplied external data (Tier 3).
+    .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
     operator confirmation. Per module docstring and Errata C8.
-  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["below_output_path"];
-    operator confirms or overrides via recipe_offer turn.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["below_output_path"]; operator confirms
+    or overrides via recipe_offer turn.
   expires: null
 per_file_rules:
 - pattern: web/composer/tools.py
@@ -2713,14 +2330,12 @@ per_file_rules:
   - R1
   - R5
   - R9
-  reason: Tier 3 boundary — LLM tool call arguments are external data with optional
-    fields per JSON schema; pop-with-default implements RFC 7386 merge patch null
-    semantics
+  reason: Tier 3 boundary — LLM tool call arguments are external data with optional fields per JSON schema; pop-with-default
+    implements RFC 7386 merge patch null semantics
   expires: null
 - pattern: web/composer/service.py
   rules:
   - R6
-  reason: Tier 3 boundary — LLM tool call arguments may contain malformed JSON (JSONDecodeError)
-    or missing required keys (KeyError/TypeError). Errors returned to LLM for self-correction,
-    not swallowed.
+  reason: Tier 3 boundary — LLM tool call arguments may contain malformed JSON (JSONDecodeError) or missing required keys
+    (KeyError/TypeError). Errors returned to LLM for self-correction, not swallowed.
   expires: null

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1171,7 +1171,7 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=6f7c49b368c3408d
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d48a5a2d814e4af5
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
@@ -1179,7 +1179,7 @@ allow_hits:
     contract drift.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=e31cfd029b5c713a
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=b4b49b523cc3a013
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['options'] must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
@@ -1187,7 +1187,7 @@ allow_hits:
     have collapsed null/list/scalar payloads into an empty dict and fabricated upstream contract conformance.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=17ffe3de710a18d8
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1fe3412bcd84bd85
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['observed_columns'] must be a list per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
@@ -1195,7 +1195,7 @@ allow_hits:
     which would have silently accepted scalars and yielded character-wise tuples (e.g. tuple("abc") → ('a','b','c')).
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=b3d19afa8e6e6c86
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=1d46f8b9f9d4684f
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['sample_rows'] must be a list per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
@@ -1203,7 +1203,7 @@ allow_hits:
     pattern which would have crashed deep in the comprehension on a non-iterable.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c62857823fd15c3b
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=4d81c5e48f62089b
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['columns'] must be a list
     per the narrow wire contract (Pair 5a); isinstance here is offensive validation (raises HTTPException 400 with the actual
@@ -1212,7 +1212,7 @@ allow_hits:
     dispatcher catches non-list here before that coercion runs. Resolves elspeth-obs-57451bbaa6.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=690a1fa6374c17d1
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=7ab395b1d9772442
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
     the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
@@ -1220,7 +1220,7 @@ allow_hits:
     any payload (including None).
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=64df0f81fe364aa7
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d43305a68bd1dcd9
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['options'] must be a Mapping per the
     SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
@@ -1228,7 +1228,7 @@ allow_hits:
     on non-mappings.
   safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=93b211a4e6a30476
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=c866e7dc93d93ee7
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['recipe_name'] must be a non-empty
     string per the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with
@@ -1236,7 +1236,7 @@ allow_hits:
     which masked protocol drift as a downstream "unknown recipe ''" error.
   safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=cc6841deb1d46d38
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2e558c1507b6f496
   owner: web-sessions
   reason: HTTP-boundary trust-boundary validation — recipe_offer ['accept'] edited_values['slots'] must be a Mapping per
     the RecipeOfferTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
@@ -1438,145 +1438,145 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=4f394ff64e8b1291
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d66e00138da0f0c4
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
     audit persistence; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed flip logic
     before the CancelledError handler in send_message.
   safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d62b85dbb726d15a
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=9bda8dca88eb99ca
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
     publish in the cancellation handler; FP rotated by Task 5.2 (progressive-disclosure transition prompt) adding transition_consumed
     flip logic before the CancelledError handler in send_message.
   safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=e01b1684daaa4ae1
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=72252eb1a66e6d8a
   owner: web-sessions
   reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
     rotated by guided_terminal / _post_compose_guided block insertion (Task 5.2 fix).
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=31e290c189425ea5
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=38896944bced28f6
   owner: web-sessions
   reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by guided_terminal
     / _post_compose_guided block insertion (Task 5.2 fix).
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=9b981797d4e29246
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cda3ae2175a3a50f
   owner: web-sessions
   reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=d91f3d75b2a547f3
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=a27644806d428952
   owner: web-sessions
   reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=e989522746daf395
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=303f527b72cfef63
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating nested fields during fork blob rewrite;
     FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=228192e62a173a67
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=f810695c334095c6
   owner: web-sessions
   reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cdb5bc83948436c8
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=0fea32bcbafc94be
   owner: web-sessions
   reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Tier 3 boundary — persisted blob_ref type is not guaranteed.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=b9e0f00815eec2d7
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=91d7ce27c2701fc9
   owner: web-sessions
   reason: blob_map.get(old_uuid) — not every source reference is guaranteed to have a copied blob target; FP changed after
     ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=1bbeda95f80b81dd
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=c5ad0fd939b93a58
   owner: web-sessions
   reason: options.get(path_key) on persisted source options — path/file keys are optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: None result skips that key; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=db3dce50fa69c3a4
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=bd60cb85fb591735
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted path/file values; FP
     changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e2ef8cd067be6c4f
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=5632eb606c04d1bc
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path; FP changed
     after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=b1ab3796f836f98e
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=d1306e4027bed96c
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
     changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=1700385ad06141fd
+- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=edd58c4a70f20c34
   owner: web-sessions
   reason: App-scoped compose lock registry is initialized lazily on first session-router use rather than being required at
     startup; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _get_session_compose_lock_registry entry.
   expires: null
-- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=b6167fb60da6eef7
+- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=d3def3abf63c61e0
   owner: web-sessions
   reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed on every provider error object; FP
     changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _litellm_error_detail entry.
   expires: null
-- key: web/sessions/routes.py:R1:_state_response:fp=fe9244679a1a1e7d
+- key: web/sessions/routes.py:R1:_state_response:fp=94a786ee0bdcaf12
   owner: web-sessions
   reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Falls back to unredacted source_data (less privacy, not less safety); same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=48ecb12793971ee9
+- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=297ade1feddcc00d
   owner: web-sessions
   reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome union type; FP changed
     after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _composer_persisted_validation entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=01f3fd864beccc72
+- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=77fa2aecae3080b8
   owner: composer-audit
   reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _persist_tool_invocations entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=51507e1d8c695356
+- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=68c8189140f7ae51
   owner: composer-audit
   reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _persist_llm_calls entry.
   expires: null
-- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=505dc4062758398f
+- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=65720fbc32da5171
   owner: web-sessions
   reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _state_data_from_composer_state R6 entry.
   expires: null
-- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=60ff974a2b265091
+- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=fc58e94effd4a771
   owner: web-sessions
   reason: isinstance(runtime, ValidationResult) dispatches _RuntimePreflightOutcome union type for telemetry; FP changed after
     ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _state_data_from_composer_state R5 entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=a6eba11e3bd8d777
+- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=e97c35544a90e1ee
   owner: web-sessions
   reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_convergence_error entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=bcc44e9de96bb181
+- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=11e82bf267f1def2
   owner: web-sessions
   reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_plugin_crash entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1b8cd07b1091976e
+- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1eb57f4115a3b2d3
   owner: web-sessions
   reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_runtime_preflight_failure entry.
@@ -2288,7 +2288,7 @@ allow_hits:
     .get above; both branches converge on empty string when neither key is present.
   safety: Empty string when neither key is present; downstream format_failure_samples handles empty messages gracefully.
   expires: null
-- key: web/composer/guided/steps.py:R1:handle_step_1_source:fp=b40a0ef1edd0fd19
+- key: web/composer/guided/steps.py:R1:handle_step_1_source:fp=d12bd40a848a8b71
   owner: composer-guided
   reason: Tier-3 boundary detection in blob-enrichment path — resolved.options is user/LLM-supplied SchemaForm data (Tier 3).
     .get("path") with None default detects presence of a path key without fabricating a value; None means no path was submitted
@@ -2297,7 +2297,7 @@ allow_hits:
     step_1_result is stored unchanged. The enrichment is opportunistic — absence of path leaves recipe match in the correct
     no-blob_ref state.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=c9e0d4caec92d135
+- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=2a5edca2f4ee838a
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
@@ -2305,7 +2305,7 @@ allow_hits:
   safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"]; operator confirms or
     overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=c9fd2f14c6c34847
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=6e09c6850f7ca4d5
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
@@ -2313,7 +2313,7 @@ allow_hits:
   safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"]; operator confirms
     or overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=c2b794bf9adad12d
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=fb34ad1dde480eb4
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1170,53 +1170,40 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=625deb17ed7151a9
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=81efe147ebf9043e
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — options is an optional user input that may be omitted;
+    plugin is now validated with an explicit 422 check before this point.
+  safety: Missing keys fall back to defaults (empty dict); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=212a41c4dd1330f5
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=db8091fb82705ce0
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — observed_columns is an optional user input that may be
+    omitted.
+  safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e6471c792d6b7650
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=56171ebdf6748afd
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted.
+  safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=ea2fdfb5ce4ae744
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=f67da515c3fdaeb6
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — options is an optional user input that may be
+    omitted; plugin is now validated with an explicit 422 check before this point.
+  safety: Missing key falls back to empty dict; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=5fb0545704a4c843
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=3ef7b32f42b6cfc3
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — observed_columns is an optional user input that
+    may be omitted.
+  safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=c298f7b070018c34
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=36c1a9b7fc65f39d
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
-  expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=c96e8f4bfc007521
-  owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
-  expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=42a6a255408e9d43
-  owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — plugin, options, observed_columns, and sample_rows are
-    all optional user inputs that may be omitted.
-  safety: Missing keys fall back to defaults (empty dict/tuple/list); no fabricated values
+  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — sample_rows is an optional user input that may
+    be omitted.
+  safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
 - key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e0a68f3bba01a2e8
   owner: web-sessions
@@ -1505,18 +1492,6 @@ allow_hits:
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
     changed after ruff-format.
   safety: Same as prior fork_from_message R6 entry.
-  expires: null
-- key: web/sessions/routes.py:R1:create_session_router:post_guided_respond:fp=a8fe360358c3e6f0
-  owner: web-sessions
-  reason: args.get("validation_result") on emit_turn_answered args dict — validation_result is an optional audit field not
-    required for every turn answer.
-  safety: Returns None on miss; emit_turn_answered handles None validation_result gracefully.
-  expires: null
-- key: web/sessions/routes.py:R2:create_session_router:post_guided_respond:fp=246249499fc36720
-  owner: web-sessions
-  reason: getattr(request.app.state, "session_engine", None) — session_engine is not a required startup attribute (it is set
-    in app.py and test fixtures, but may be absent in minimal test harnesses that don't exercise recipe apply).
-  safety: None is passed to handle_step_2_5_recipe_apply which returns a failure result if session_engine is None; no crash.
   expires: null
 - key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=0bd91249bb52f851
   owner: web-sessions

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1170,51 +1170,51 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=81efe147ebf9043e
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=a21ab0d22842792d
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — options is an optional user input that may be omitted;
-    plugin is now validated with an explicit 422 check before this point.
+    plugin is now validated with an explicit 422 check before this point; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing keys fall back to defaults (empty dict); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=db8091fb82705ce0
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=d83151090a5bef09
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — observed_columns is an optional user input that may be
-    omitted.
+    omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=56171ebdf6748afd
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=18bc8091cecd1a93
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted.
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=f67da515c3fdaeb6
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=fadf554d2cc0aefa
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — options is an optional user input that may be
-    omitted; plugin is now validated with an explicit 422 check before this point.
+    omitted; plugin is now validated with an explicit 422 check before this point; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing key falls back to empty dict; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=3ef7b32f42b6cfc3
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=ecf7d1a7765f8692
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — observed_columns is an optional user input that
-    may be omitted.
+    may be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=36c1a9b7fc65f39d
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=697b796e82f4084b
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — sample_rows is an optional user input that may
-    be omitted.
+    be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e0a68f3bba01a2e8
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=9b0906221f37adaf
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe.
+    fills in when accepting a recipe; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=baad85de0bd7f8e0
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=343c53dceacf0de3
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe.
+    fills in when accepting a recipe; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
@@ -1411,145 +1411,145 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=fd7e80c36471095f
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d67c463089811195
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
-    audit persistence; FP changed after ruff-format reformatted routes.py when post_guided_respond was added.
+    audit persistence; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=11ea851be16cf4e3
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=b4cab8a430103035
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
-    publish in the cancellation handler; FP changed after ruff-format reformatted routes.py when post_guided_respond was added.
+    publish in the cancellation handler; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=b0164f850f3e04a3
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=ceaae83145693a82
   owner: web-sessions
   reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
-    changed after ruff-format reformatted routes.py when post_guided_respond was added.
+    changed after ruff-format reformatted routes.py when post_guided_respond was added; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=8d2ea0eab664902a
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=54e1a93dec1dca49
   owner: web-sessions
-  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP changed after ruff-format
+  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by Step 3 wiring (Phase 4 Task 4.5)
     reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=af5a556ad58ace4d
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=a2074b6b9a204d6c
   owner: web-sessions
-  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP changed after ruff-format reformatted
+  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
     routes.py when post_guided_respond was added.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=5d6e55eff93c5873
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=6243220782dadf07
   owner: web-sessions
-  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP changed after ruff-format reformatted
+  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=9514364097170589
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=003cbeddfd82ae0f
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating nested fields during fork blob rewrite;
-    FP changed after ruff-format.
+    FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=8df87b4871417ecd
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=aade5352874dbe15
   owner: web-sessions
-  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP changed after ruff-format reformatted
+  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=247ba68517b436df
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=d337312f75404830
   owner: web-sessions
-  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP changed after ruff-format.
+  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Tier 3 boundary — persisted blob_ref type is not guaranteed.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=732516c835899a17
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2dea03f78103b6da
   owner: web-sessions
   reason: blob_map.get(old_uuid) — not every source reference is guaranteed to have a copied blob target; FP changed after
-    ruff-format.
+    ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2676e4a4c9c503bc
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=896daaea542adbfb
   owner: web-sessions
-  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP changed after ruff-format.
+  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: None result skips that key; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=f926de07b8a8779c
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=c5e620eb808fa5fc
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted path/file values; FP
-    changed after ruff-format.
+    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e90401537935e657
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=50fb6c7ce12df024
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path; FP changed
-    after ruff-format.
+    after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=ad4735d4c08a7e45
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=0c0126c4062b9a55
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
-    changed after ruff-format.
+    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=0bd91249bb52f851
+- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=781ddb89d39d8a3a
   owner: web-sessions
   reason: App-scoped compose lock registry is initialized lazily on first session-router use rather than being required at
-    startup; FP changed after ruff-format.
+    startup; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _get_session_compose_lock_registry entry.
   expires: null
-- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=187f2093f92be18f
+- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=8e14e2088e4e222e
   owner: web-sessions
   reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed on every provider error object; FP
-    changed after ruff-format.
+    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _litellm_error_detail entry.
   expires: null
-- key: web/sessions/routes.py:R1:_state_response:fp=506c7bcad2e4f5bb
+- key: web/sessions/routes.py:R1:_state_response:fp=668cdf7bb1201c38
   owner: web-sessions
-  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP changed after ruff-format.
+  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Falls back to unredacted source_data (less privacy, not less safety); same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=5983abe8c38d77c1
+- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=94f4f5454a0cdb2d
   owner: web-sessions
   reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome union type; FP changed
-    after ruff-format.
+    after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _composer_persisted_validation entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=c157b69c8e36f39d
+- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=915df4b95472b886
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP changed after ruff-format.
+  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _persist_tool_invocations entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=36e8fd2a0da6478e
+- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=90f88cebae57c5ac
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP changed after ruff-format.
+  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _persist_llm_calls entry.
   expires: null
-- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=cbdf0e1ae3fd8975
+- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=fc626c25ee2f56c9
   owner: web-sessions
-  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP changed after ruff-format.
+  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _state_data_from_composer_state R6 entry.
   expires: null
-- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=0e7fea70a9a346af
+- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=da99f9dcc94f9c91
   owner: web-sessions
   reason: isinstance(runtime, ValidationResult) dispatches _RuntimePreflightOutcome union type for telemetry; FP changed after
-    ruff-format.
+    ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _state_data_from_composer_state R5 entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=839f4c25a3f5694c
+- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=5395d6da427d5ec6
   owner: web-sessions
-  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _handle_convergence_error entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=a68206ef6a1effba
+- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=13caa996a929f960
   owner: web-sessions
-  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _handle_plugin_crash entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1b5f3002e41c0b36
+- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=92365f4bcab7bab8
   owner: web-sessions
-  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP changed after ruff-format.
+  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
   safety: Same as prior _handle_runtime_preflight_failure entry.
   expires: null
 - key: web/app.py:R1:create_app:fp=298d81d738bfa3b0

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1171,40 +1171,84 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=b2ee7a80ee10460c
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=6f7c49b368c3408d
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — options is an optional user input that may be omitted;
-    plugin is now validated with an explicit 422 check before this point; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing keys fall back to defaults (empty dict); no fabricated values
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
+    the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
+    value in the detail), not error suppression. Replaces the previous silent str(edited['plugin']) coercion that masked
+    contract drift.
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e721908298db3cf6
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=e31cfd029b5c713a
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — observed_columns is an optional user input that may be
-    omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing key falls back to empty tuple; no fabricated values
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['options'] must be a Mapping per the
+    SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
+    in the detail), not error suppression. Replaces the previous silent dict(edited.get("options", {})) default which would
+    have collapsed null/list/scalar payloads into an empty dict and fabricated upstream contract conformance.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=b1da5afefea0764b
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=17ffe3de710a18d8
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing key falls back to empty tuple; no fabricated values
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['observed_columns'] must be a list per
+    the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual
+    type in the detail), not error suppression. Replaces the previous silent tuple(edited.get("observed_columns", [])) default
+    which would have silently accepted scalars and yielded character-wise tuples (e.g. tuple("abc") → ('a','b','c')).
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=d09cedd0417b4678
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=b3d19afa8e6e6c86
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — options is an optional user input that may be
-    omitted; plugin is now validated with an explicit 422 check before this point; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing key falls back to empty dict; no fabricated values
+  reason: HTTP-boundary trust-boundary validation — Step-1 SCHEMA_FORM edited_values['sample_rows'] must be a list per the
+    SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
+    in the detail), not error suppression. Replaces the previous silent tuple(dict(r) for r in edited.get("sample_rows", []))
+    pattern which would have crashed deep in the comprehension on a non-iterable.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=4ec1fb5db6288315
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=eafccf78781770d8
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — observed_columns is an optional user input that
-    may be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing key falls back to empty tuple; no fabricated values
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['plugin'] must be a non-empty
+    string per the server-side state_machine contract (see test_state_machine.test_initial_session_advances_after_source_confirmed);
+    isinstance here is offensive validation (raises HTTPException 400 with the offending value in the detail), not error
+    suppression. Replaces the previous silent str(edited['plugin']) coercion.
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=44eaa62f930e5a6c
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=d4d75e0f7d0db601
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — sample_rows is an optional user input that may
-    be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
-  safety: Missing key falls back to empty tuple; no fabricated values
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['options'] must be a Mapping
+    per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400 with the
+    actual type in the detail), not error suppression. Replaces the previous silent dict(edited.get("options", {})) default.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=4be385491212b4dd
+  owner: web-sessions
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['observed_columns'] must
+    be a list per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400
+    with the actual type in the detail), not error suppression. Replaces the previous silent tuple(edited.get("observed_columns", []))
+    default.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=2230df199fe835a4
+  owner: web-sessions
+  reason: HTTP-boundary trust-boundary validation — post-advance INSPECT_AND_CONFIRM edited_values['sample_rows'] must be a
+    list per the server-side state_machine contract; isinstance here is offensive validation (raises HTTPException 400 with
+    the actual type in the detail), not error suppression. Replaces the previous silent tuple(dict(r) for r in edited.get("sample_rows", []))
+    pattern.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
+  expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=690a1fa6374c17d1
+  owner: web-sessions
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['plugin'] must be a non-empty string per
+    the SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the offending
+    value in the detail), not error suppression. Replaces the previous str(edited['plugin']) coercion that would have stringified
+    any payload (including None).
+  safety: Contract violation raises HTTPException 400 with the offending value in the detail; no fall-through, no fabrication.
+  expires: null
+- key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=64df0f81fe364aa7
+  owner: web-sessions
+  reason: HTTP-boundary trust-boundary validation — Step-2 SCHEMA_FORM edited_values['options'] must be a Mapping per the
+    SchemaFormTurn widget contract; isinstance here is offensive validation (raises HTTPException 400 with the actual type
+    in the detail), not error suppression. Replaces the previous dict(edited['options']) call which would have crashed deep
+    on non-mappings.
+  safety: Contract violation raises HTTPException 400 with the offending type name in the detail; no fall-through, no fabrication.
   expires: null
 - key: web/sessions/routes.py:R5:_dispatch_guided_respond:fp=93b211a4e6a30476
   owner: web-sessions

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -453,26 +453,27 @@ allow_hits:
     rejects malformed trigger.condition values before runtime settings load
   safety: The pipeline remains invalid; no trigger config is fabricated and unexpected exception types propagate
   expires: null
-- key: web/composer/tools.py:R6:_execute_update_blob:fp=8d77465a6c3530e3
+- key: web/composer/tools.py:R6:_execute_update_blob:fp=7c3e82fb37e046c6
   owner: web-composer
   reason: Narrow OSError around storage_path.write_bytes(old_content) rollback — disk faults during post-replace divergence
-    rollback expected; programmer bugs still propagate. FP rotated from fd103b0d6c58a62c by _DATA_ERROR_KEY constant insertion.
+    rollback expected; programmer bugs still propagate. FP rotated from 8d77465a6c3530e3 by _sync_get_blob_by_storage_path
+    insertion above _sync_list_blobs.
   safety: Rollback failure attached as add_note() on primary_exc with blob_id and "manual reconciliation required"; primary
     commit exception remains the headline.  Pre-replace failures bypass the rollback branch entirely (verified by test_primary_db_exception_before_replace_propagates_without_rollback
     and test_quota_breach_returns_failure_without_touching_storage).
   expires: null
-- key: web/composer/tools.py:R6:_execute_delete_blob:fp=2d90cb68d4922fd8
+- key: web/composer/tools.py:R6:_execute_delete_blob:fp=5888ba3f1c2fbf1b
   owner: web-composer
   reason: Narrow OSError around tombstone restore after a failed blob delete — compensation disk faults must not bury the
-    primary DB exception. FP rotated from 8ca49fc9b52455e7 by _DATA_ERROR_KEY constant insertion.
+    primary DB exception. FP rotated from 2d90cb68d4922fd8 by _sync_get_blob_by_storage_path insertion.
   safety: Rollback failure is attached as add_note() on primary_exc and the original delete failure is re-raised unchanged
   expires: null
-- key: web/composer/tools.py:R6:_execute_inspect_source:fp=ac151e3b318a5bcd
+- key: web/composer/tools.py:R6:_execute_inspect_source:fp=ae604775045ea882
   owner: web-composer
   reason: Tier-3 trust boundary — UUID(blob_id) coercion of caller-supplied string. ValueError is the documented failure mode
     for malformed UUIDs and falls back to blob_uuid=None (an optional identity field on inspect_blob_content). Failure is
     NOT silent — a blob_id_not_uuid warning fact is prepended to facts.warnings so the audit trail records why redacted_identity
-    omits blob_id. FP rotated from 79e74330fe91e1de by _DATA_ERROR_KEY constant insertion.
+    omits blob_id. FP rotated from ac151e3b318a5bcd by _sync_get_blob_by_storage_path insertion.
   safety: blob_uuid=None on parse failure; inspection still runs against the resolved blob row (already validated by the _sync_get_blob
     lookup). The blob_id_not_uuid warning surfaces the offending id (truncated to 64 chars) into the audit-bound facts.warnings
     tuple; integrity guards (status=ready, hash match) remain authoritative.
@@ -2261,43 +2262,36 @@ allow_hits:
     .get above; both branches converge on empty string when neither key is present.
   safety: Empty string when neither key is present; downstream format_failure_samples handles empty messages gracefully.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=de84351ad6bfe956
+- key: web/composer/guided/steps.py:R1:handle_step_1_source:fp=b40a0ef1edd0fd19
   owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied external data (Tier 3). .get("blob_id",
-    "") is the documented coercion at this boundary; an empty-string sentinel means "operator must supply via recipe_offer
-    turn". Per module docstring and Errata C8.
-  safety: Empty string sentinel propagates to the recipe_offer turn where the operator is explicitly asked to supply the blob_id.
-    No silent data loss.
+  reason: Tier-3 boundary detection in blob-enrichment path — resolved.options is user/LLM-supplied SchemaForm data (Tier 3).
+    .get("path") with None default detects presence of a path key without fabricating a value; None means no path was submitted
+    and the enrichment lookup is skipped entirely.
+  safety: None causes the blob lookup branch to be skipped (all three guards must be non-None); no blob_ref is injected and
+    step_1_result is stored unchanged. The enrichment is opportunistic — absence of path leaves recipe match in the correct
+    no-blob_ref state.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=a6c6f31ab3c80323
+- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=3b92b7e07cfd1037
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. Per module docstring and Errata C8.
+    operator confirmation. FP rotated from a6c6f31ab3c80323 by blob_id→blob_ref conversion (classify resolver rewrite).
   safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"]; operator confirms or
     overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=594f7aa0183fa90e
-  owner: composer-guided
-  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied external data (Tier 3). .get("blob_id",
-    "") is the documented coercion at this boundary; an empty-string sentinel means "operator must supply via recipe_offer
-    turn". Per module docstring and Errata C8.
-  safety: Empty string sentinel propagates to the recipe_offer turn where the operator is explicitly asked to supply the blob_id.
-    No silent data loss.
-  expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=04eea8af1e9b234a
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=aceba16af59b73b5
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. Per module docstring and Errata C8.
+    operator confirmation. FP rotated from 04eea8af1e9b234a by blob_id→blob_ref conversion (threshold resolver rewrite).
   safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"]; operator confirms
     or overrides via recipe_offer turn.
   expires: null
-- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=6c8bcb44b83e0e72
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=3e175261cb3f249d
   owner: composer-guided
   reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is user/LLM-supplied external data (Tier 3).
     .get("path", default) is the documented coercion at this boundary; default path propagates to the recipe_offer turn for
-    operator confirmation. Per module docstring and Errata C8.
+    operator confirmation. FP rotated from 6c8bcb44b83e0e72 by blob_id→blob_ref conversion (threshold resolver rewrite).
   safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["below_output_path"]; operator confirms
     or overrides via recipe_offer turn.
   expires: null

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1425,16 +1425,16 @@ allow_hits:
     flip logic before the CancelledError handler in send_message.
   safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=cd95569a81303ada
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=e01b1684daaa4ae1
   owner: web-sessions
   reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
-    changed after ruff-format reformatted routes.py when post_guided_respond was added; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
+    rotated by guided_terminal / _post_compose_guided block insertion (Task 5.2 fix).
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=94db8ee65912e8eb
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=31e290c189425ea5
   owner: web-sessions
-  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish)
-    reformatted routes.py when post_guided_respond was added.
+  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by guided_terminal
+    / _post_compose_guided block insertion (Task 5.2 fix).
   safety: Same as the prior entry.
   expires: null
 - key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=9b981797d4e29246
@@ -1749,373 +1749,373 @@ allow_hits:
   safety: Unexpected exceptions are re-raised. Known exception text is never surfaced to the UI; downstream validation treats
     absent facts as unknown/fail-closed where required.
   expires: null
-- key: web/composer/service.py:R5:_litellm_completion_supports_param:fp=ab6fa2e8fc756fe3
+- key: web/composer/service.py:R5:_litellm_completion_supports_param:fp=a55154db3b0e88b5
   owner: web-composer
   reason: Tier 3 LiteLLM supported-parameter metadata boundary; provider metadata must be list-shaped before treating seed
     as supported.
   safety: Malformed or absent metadata conservatively omits the seed request parameter instead of fabricating support.
   expires: null
-- key: web/composer/service.py:R5:_provider_details_payload:fp=b5da0985ff7da727
+- key: web/composer/service.py:R5:_provider_details_payload:fp=1c53bf671eeedc28
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_provider_details_payload:fp=a630e124ff14d661
+- key: web/composer/service.py:R2:_provider_details_payload:fp=e9e044916a7ab8ad
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=3d58898df136036f
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=a64e80082f7d3cbb
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R5:_token_usage_from_response:fp=05c49e7370a4623a
+- key: web/composer/service.py:R5:_token_usage_from_response:fp=dc0c6f114cc2f436
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=98dda992e75685e8
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=d5eea2dd431d64b8
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=255fc2e1800dfdae
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=47a1808c30f3b998
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=e39115cc686159de
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=753534c648b0081d
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=d3757b1d7a080da8
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=68f78768cd0bfe55
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=fce9f4ac1cd494f8
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=ab54c7cdf508bb56
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=eee9978e1d9f29dd
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=f5628acf7a0d07f2
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R5:_token_usage_from_response:fp=761255760cdc95f6
+- key: web/composer/service.py:R5:_token_usage_from_response:fp=6c6a5f8d9921c63b
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R5:_token_usage_from_response:fp=095d94312c44b41c
+- key: web/composer/service.py:R5:_token_usage_from_response:fp=91a8f26901004b82
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R5:_token_usage_from_response:fp=75021621184c14eb
+- key: web/composer/service.py:R5:_token_usage_from_response:fp=f11681ee78fb7bde
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=06e2b357b3407e1e
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=cf1b18e0875cf81f
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=710e6172bd889f64
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=873772560489deab
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R1:_token_usage_from_response:fp=2ecba9ce177551d3
+- key: web/composer/service.py:R1:_token_usage_from_response:fp=97875872a8c3bfe6
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=72244dff2d50f238
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=a1f54d9a331ef03e
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=6960cb0803124826
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=2c4942d7c114249f
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=2764b1803222df25
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=78ea52870a824010
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=d2fba7566d339255
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=df47c908ed06585b
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=7a04e0ff3abc5a4a
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=c74e21326fd9511d
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=f434bde775c0328f
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=4f3d25a7fac075cf
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=e49eab2ecb1cb63d
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=19905c572c9c806c
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=a35ccffaed4c2c4b
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=f075e728e882a04e
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_token_usage_from_response:fp=5125e5bfc84a8fc4
+- key: web/composer/service.py:R2:_token_usage_from_response:fp=b156916e8bce90ae
   owner: composer-audit
   reason: Tier 3 LiteLLM usage metadata boundary; provider usage objects may be absent, mapping-shaped, object-shaped, or
     omit optional cache and reasoning fields.
   safety: Missing or malformed counters are normalized to None by TokenUsage.from_dict; no zeroes or costs are fabricated.
   expires: null
-- key: web/composer/service.py:R2:_provider_cost_from_response:fp=a64e80082f7d3cbb
+- key: web/composer/service.py:R2:_provider_cost_from_response:fp=06efcc52ac50ca7d
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_provider_cost_from_response:fp=dc0c6f114cc2f436
+- key: web/composer/service.py:R5:_provider_cost_from_response:fp=e83809ad68d4a1df
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_provider_cost_from_response:fp=18c2ff80634b9571
+- key: web/composer/service.py:R2:_provider_cost_from_response:fp=cabeba8578f2d974
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_safe_response_model:fp=294ad0bd019e41b4
+- key: web/composer/service.py:R2:_safe_response_model:fp=f29dda3d50759363
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_safe_response_model:fp=49d0160079b48a50
+- key: web/composer/service.py:R5:_safe_response_model:fp=8c2dbc77bb9b60b0
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_safe_provider_request_id:fp=a646470d89cdb53f
+- key: web/composer/service.py:R2:_safe_provider_request_id:fp=7c463ef035c1fecb
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_safe_provider_request_id:fp=d8c68d317e336ada
+- key: web/composer/service.py:R5:_safe_provider_request_id:fp=39c3fedc13c5b50d
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_response_field:fp=f1113fcf21b93aa3
+- key: web/composer/service.py:R5:_response_field:fp=6dc3edbf866ab26d
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R1:_response_field:fp=925a8bfc0993c645
+- key: web/composer/service.py:R1:_response_field:fp=4c8a4d470dd04df8
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R2:_response_field:fp=c2e22fa021170483
+- key: web/composer/service.py:R2:_response_field:fp=72dbc66726eb04d4
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_first_response_message:fp=b83ee6a1a3c915ee
+- key: web/composer/service.py:R5:_first_response_message:fp=2804d030c91b65c7
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=990fbc664ce6d5f6
+- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=7bb508d5357ac5dd
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=cba69ff6caa46865
+- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=6738943e8c54cc7e
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=6bb7b5b7ad960789
+- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=8e528f1652026a6a
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=19393fd9439eabf3
+- key: web/composer/service.py:R5:_json_safe_provider_artifact:fp=9439b23e57296510
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=f0f24995bda19a32
+- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=e95323ab2189f228
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=6a207788fff47544
+- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=427aa6effd8c9b8f
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=ea53d3e6be314007
+- key: web/composer/service.py:R2:_json_safe_provider_artifact:fp=6cbb29276dd46929
   owner: composer-audit
   reason: Tier 3 provider artifact normalization boundary; reasoning details may be nested mappings, sequences, model objects,
     or opaque provider classes.
   safety: Values are recursively reduced to JSON-safe audit artifacts or repr(value); raw provider objects are not stored.
   expires: null
-- key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=0f581ca641445cb3
+- key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=8fc7f9ecf5f72aaf
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=8ac027c0e61f8325
+- key: web/composer/service.py:R5:_reasoning_metadata_from_response:fp=860e608e6b63c8ef
   owner: composer-audit
   reason: Tier 3 LiteLLM response metadata boundary; provider adapters expose optional metadata under provider-specific dict
     and object shapes.
   safety: Only bounded scalar or JSON-safe audit metadata is persisted; absent or malformed fields stay None.
   expires: null
-- key: web/composer/service.py:R5:_supports_anthropic_prompt_cache_markers:fp=5c0c3c00e8f8d707
+- key: web/composer/service.py:R5:_supports_anthropic_prompt_cache_markers:fp=7fc54cb294fb9be0
   owner: composer-cache-markers
   reason: Provider-detection predicate for prompt-cache marker support; model identifiers may be absent or malformed before
     settings are finalized.
   safety: Non-string input returns False and the LiteLLM call proceeds without cache markers.
   expires: null
-- key: web/composer/service.py:R1:_apply_anthropic_cache_markers:fp=439664e132982084
+- key: web/composer/service.py:R1:_apply_anthropic_cache_markers:fp=b0a60c3f1c1ab02a
   owner: composer-cache-markers
   reason: Prompt-cache marker transform scans message dicts whose role field may be absent during composer message construction.
   safety: Missing role leaves that message unmarked; the transform still preserves the original payload shape.
   expires: null
-- key: web/composer/service.py:R5:_optional_ancestor_present:fp=b7a2c4f11a0fc23f
+- key: web/composer/service.py:R5:_optional_ancestor_present:fp=73f9f9a276a3c50d
   owner: composer-walker
   reason: Tier 3 LLM tool-call argument walker distinguishes absent optional ancestors from present malformed nested values.
   safety: Malformed shapes become structured argument errors returned to the LLM, not crashes or silent tool execution.
   expires: null
-- key: web/composer/service.py:R1:ComposerServiceImpl:_cached_runtime_preflight:fp=ee45a7ef20e6e248
+- key: web/composer/service.py:R1:ComposerServiceImpl:_cached_runtime_preflight:fp=1420d05bddf718e9
   owner: web-composer
   reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
     result.
   safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=4f73f5c829e2f862
+- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=59a464229130fe54
   owner: web-composer
   reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
     result.
   safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=9f4489a004a5722e
+- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=2a57bf6e231cc38f
   owner: web-composer
   reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
     result.
   safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=c5eee98b7f106fb8
+- key: web/composer/service.py:R5:ComposerServiceImpl:_cached_runtime_preflight:fp=35e11b85ca9da265
   owner: web-composer
   reason: Runtime preflight cache dispatch narrows RuntimePreflightEntry and checks an internal per-compose cache for an existing
     result.
   safety: ValidationResult and RuntimePreflightFailure are handled explicitly; cache misses run the coordinator path.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_compose_loop:fp=6051df645b26b9af
+- key: web/composer/service.py:R5:ComposerServiceImpl:_compose_loop:fp=56be0a864241f3d2
   owner: composer-advisor
   reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider failures are converted into structured
     composer feedback.
   safety: Tool execution is skipped on argument errors; advisor/provider failures are audited and returned as bounded tool
     results.
   expires: null
-- key: web/composer/service.py:R4:ComposerServiceImpl:_compose_loop:fp=b8b21ea56f873034
+- key: web/composer/service.py:R4:ComposerServiceImpl:_compose_loop:fp=c6bab4340b7384cb
   owner: composer-advisor
   reason: Tier 3 LLM tool-call and advisor boundary; malformed tool arguments or provider failures are converted into structured
     composer feedback.
   safety: Tool execution is skipped on argument errors; advisor/provider failures are audited and returned as bounded tool
     results.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=4f0fa60fae1c3c45
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=551b9850bc6a77aa
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=73cb467bd2726216
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=1fd0e99e8aa6f180
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=ed4c61c1761c3718
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=fae167f4e3ced4e6
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=604d96c7f5ded948
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=97e0d295b4c91c80
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=5a710005dd5a2f85
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=a4f14a9fa75accf3
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=ffeaf8f3fd1edd46
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=cde591d85cf64fde
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is made.
   expires: null
-- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=68d3c369d9c85db8
+- key: web/composer/service.py:R5:ComposerServiceImpl:_validate_advisor_arguments:fp=8041dad41ce969b2
   owner: composer-advisor
   reason: Tier 3 advisor tool-call boundary; LLM-provided arguments must be type-checked before spending advisor budget or
     constructing prompts.

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1,5 +1,5 @@
 allow_hits:
-- key: web/composer/guided/protocol.py:R5:validate_payload:fp=b5b1d34b5d81a046
+- key: web/composer/guided/protocol.py:R5:validate_payload:fp=57d0a263a79cd691
   owner: composer-guided
   reason: Protocol boundary validator — isinstance(turn_type, TurnType) at Tier 3 entry point where untrusted payloads arrive
     from client, distinguishes valid TurnType enum member from arbitrary string to reject malformed protocol messages early

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -2506,91 +2506,91 @@ allow_hits:
   safety: Invalid shapes return ARG_ERROR payloads and no outbound advisor call is
     made.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=acb7b346b49d78de
+- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=37783254993bc717
   owner: web-execution
   reason: Launch guard inspects user-authored LLM plugin options at the execution
     boundary; queries may be a mapping for named multi-query prompts.
   safety: Only the query count is used for spend estimation; malformed options still
     go through plugin/runtime validation before any provider call.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=3bc6520349f25f93
+- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=4f09759c469258d0
   owner: web-execution
   reason: Launch guard inspects user-authored LLM plugin options at the execution
     boundary; queries may be a sequence for multi-query prompts.
   safety: Strings and byte sequences are excluded from the sequence count; malformed
     options still go through plugin/runtime validation before any provider call.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=c5cb478f091b67dd
+- key: web/execution/fanout_guard.py:R5:_provider_calls_per_row:fp=bbfb386271aa5a70
   owner: web-execution
   reason: Launch guard distinguishes scalar string-like values from query sequences
     when estimating LLM provider calls from user-authored plugin options.
   safety: Scalar string-like values fall back to one provider call per row; plugin/runtime
     validation remains the authority for option correctness.
   expires: null
-- key: web/execution/fanout_guard.py:R6:_estimate_source_rows:fp=7dd44a74e9adfaca
+- key: web/execution/fanout_guard.py:R6:_estimate_source_rows:fp=fdf1ab16ee8462d4
   owner: web-execution
   reason: Fanout estimation reads user-provided source files before execution; filesystem,
     encoding, CSV, or JSON parse failures mean cardinality is unknown.
   safety: The guard never fabricates a row count from unreadable data; execution still
     validates/opens the source on the normal path before any downstream provider calls.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_source_path:fp=43c70a65df834ad8
+- key: web/execution/fanout_guard.py:R5:_source_path:fp=ddcfcb5be92f7e23
   owner: web-execution
   reason: Source path/file options are user-authored plugin options and may be absent
     or non-string before plugin validation runs.
   safety: Non-string values are treated as unavailable for local row estimation only;
     normal execution validation remains responsible for rejecting invalid source options.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_remote_source_limit:fp=7d9dc7a2eeb65d98
+- key: web/execution/fanout_guard.py:R5:_remote_source_limit:fp=f3e8691c99939d74
   owner: web-execution
   reason: Remote source limit/top/max_rows options are user-authored plugin options
     and only integer row caps can safely inform spend estimation.
   safety: Non-integer values do not reduce the guard's estimate; plugin/runtime validation
     remains responsible for option correctness.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_count_csv_source_rows:fp=68a64944bd3152b8
+- key: web/execution/fanout_guard.py:R5:_count_csv_source_rows:fp=4de1a38e6489f86a
   owner: web-execution
   reason: CSV skip_rows is a user-authored option inspected before execution so the
     launch guard can estimate source cardinality.
   safety: Only integer skip_rows affects the estimator; invalid values are still rejected
     by plugin/runtime validation on the normal execution path.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=f49836a7537b01a5
+- key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=4de14b5c3571bbc7
   owner: web-execution
   reason: JSON source files are external/user data; data_key counting must first verify
     the decoded payload is an object before indexing it.
   safety: Non-object payloads return unknown cardinality for the estimator instead
     of fabricating a count; execution source validation still handles malformed data.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=b7cd8b2011b9fdf9
+- key: web/execution/fanout_guard.py:R5:_count_json_source_rows:fp=b90c5294dec6686f
   owner: web-execution
   reason: JSON source files are external/user data; only top-level arrays have a directly
     countable row cardinality for this launch guard.
   safety: Non-array payloads return unknown cardinality for the estimator instead
     of fabricating a count; execution source validation still handles malformed data.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_string_option:fp=9fa90e44796e9f63
+- key: web/execution/fanout_guard.py:R5:_string_option:fp=551453a6d1751fa2
   owner: web-execution
   reason: Fanout estimation reads optional user-authored plugin string options such
     as provider, model, encoding, delimiter, format, and data_key.
   safety: Only nonblank strings are surfaced into the guard payload; absent or malformed
     values remain unknown and normal plugin/runtime validation remains authoritative.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=5cb9875f0f626a65
+- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=195a89405c54ca1d
   owner: web-execution
   reason: LLM credential configuration can be either an inline string or a secret-ref
     mapping in user-authored plugin options.
   safety: The guard emits only credential category/ref metadata and never the secret
     value; actual secret resolution remains on the execution path.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=0a8d0c29849f2252
+- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=24c08e5d0ce127d5
   owner: web-execution
   reason: Secret-ref mappings are user-authored plugin options and the nested secret_ref
     value must be a visible nonblank string before being identified in the guard payload.
   safety: The guard emits only the secret_ref name marker and never resolves or logs
     the secret value; invalid shapes remain unknown for the guard.
   expires: null
-- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=cedbffb408e67884
+- key: web/execution/fanout_guard.py:R5:_credential_ref:fp=b0754fca2fa41500
   owner: web-execution
   reason: Inline LLM API keys are user-authored plugin options and must be identified
     without exposing their contents in the launch guard.
@@ -2661,6 +2661,51 @@ allow_hits:
     on empty string when neither key is present.
   safety: Empty string when neither key is present; downstream format_failure_samples
     handles empty messages gracefully.
+  expires: null
+- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=de84351ad6bfe956
+  owner: composer-guided
+  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied
+    external data (Tier 3). .get("blob_id", "") is the documented coercion at this
+    boundary; an empty-string sentinel means "operator must supply via recipe_offer
+    turn". Per module docstring and Errata C8.
+  safety: Empty string sentinel propagates to the recipe_offer turn where the operator
+    is explicitly asked to supply the blob_id. No silent data loss.
+  expires: null
+- key: web/composer/guided/recipe_match.py:R1:_classify_slot_resolver:fp=a6c6f31ab3c80323
+  owner: composer-guided
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is
+    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
+    coercion at this boundary; default path propagates to the recipe_offer turn for
+    operator confirmation. Per module docstring and Errata C8.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE1_SLOTS["output_path"];
+    operator confirms or overrides via recipe_offer turn.
+  expires: null
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=594f7aa0183fa90e
+  owner: composer-guided
+  reason: Tier-3 boundary coercion in slot resolver — source.options is user/LLM-supplied
+    external data (Tier 3). .get("blob_id", "") is the documented coercion at this
+    boundary; an empty-string sentinel means "operator must supply via recipe_offer
+    turn". Per module docstring and Errata C8.
+  safety: Empty string sentinel propagates to the recipe_offer turn where the operator
+    is explicitly asked to supply the blob_id. No silent data loss.
+  expires: null
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=04eea8af1e9b234a
+  owner: composer-guided
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[0].options is
+    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
+    coercion at this boundary; default path propagates to the recipe_offer turn for
+    operator confirmation. Per module docstring and Errata C8.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["above_output_path"];
+    operator confirms or overrides via recipe_offer turn.
+  expires: null
+- key: web/composer/guided/recipe_match.py:R1:_split_threshold_slot_resolver:fp=6c8bcb44b83e0e72
+  owner: composer-guided
+  reason: Tier-3 boundary coercion in slot resolver — sink.outputs[1].options is
+    user/LLM-supplied external data (Tier 3). .get("path", default) is the documented
+    coercion at this boundary; default path propagates to the recipe_offer turn for
+    operator confirmation. Per module docstring and Errata C8.
+  safety: Default path value matches the registered SlotSpec default in _RECIPE2_SLOTS["below_output_path"];
+    operator confirms or overrides via recipe_offer turn.
   expires: null
 per_file_rules:
 - pattern: web/composer/tools.py

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -1649,6 +1649,27 @@ allow_hits:
   safety: Exception is stored on RuntimePreflightFailure.original_exc and re-raised at the caller site with full chain preservation;
     no silent swallowing
   expires: null
+- key: web/sessions/routes.py:R4:create_session_router:get_guided:fp=f975e89752c0ea46
+  owner: composer-guided
+  reason: PR-review B3 finally-block drain — the broad except wraps _persist_tool_invocations inside the unconditional
+    finally so an audit-system failure during exception handling cannot mask the in-flight HTTPException. Python's default
+    behaviour is to let a finally-block raise replace the outer exception; allowing that here would surface a generic 500
+    instead of the intended 400/409 and lose the original audit trail. The handler must surface the original outcome to
+    the client unchanged.
+  safety: Caught exception is logged via slog.error under the audit-system-failure exemption (CLAUDE.md telemetry primacy
+    order) with exc_class + frames only (B1 convention — never str(exc) since the exception message may carry Tier-bearing
+    strings). The original HTTPException continues to propagate. No silent suppression; operators observe the audit-persist
+    failure via the structured log event.
+  expires: null
+- key: web/sessions/routes.py:R4:create_session_router:post_guided_respond:fp=3fe8f16aa5674a5e
+  owner: composer-guided
+  reason: PR-review B3 finally-block drain — same rationale as get_guided above. The post_guided_respond handler emits
+    guided_turn_answered before the dispatcher's try-block can raise 400; the finally-drain ensures that audit event lands
+    even on rejection paths, and the broad except prevents a persist failure from masking the original 400/409/500.
+  safety: Caught exception is logged via slog.error under the audit-system-failure exemption with exc_class + frames only
+    (B1 convention). The original HTTPException continues to propagate. No silent suppression; operators observe the
+    audit-persist failure via the structured log event.
+  expires: null
 - key: web/execution/schemas.py:R5:RunEvent:_reject_epoch_timestamp:fp=3c9b05232e0eee8f
   owner: web-execution
   reason: Tier 1 field_validator — isinstance whitelists datetime|str for timestamp, rejects int (Unix epoch)

--- a/config/cicd/enforce_tier_model/web.yaml
+++ b/config/cicd/enforce_tier_model/web.yaml
@@ -453,26 +453,26 @@ allow_hits:
     rejects malformed trigger.condition values before runtime settings load
   safety: The pipeline remains invalid; no trigger config is fabricated and unexpected exception types propagate
   expires: null
-- key: web/composer/tools.py:R6:_execute_update_blob:fp=fd103b0d6c58a62c
+- key: web/composer/tools.py:R6:_execute_update_blob:fp=8d77465a6c3530e3
   owner: web-composer
   reason: Narrow OSError around storage_path.write_bytes(old_content) rollback — disk faults during post-replace divergence
-    rollback expected; programmer bugs still propagate
+    rollback expected; programmer bugs still propagate. FP rotated from fd103b0d6c58a62c by _DATA_ERROR_KEY constant insertion.
   safety: Rollback failure attached as add_note() on primary_exc with blob_id and "manual reconciliation required"; primary
     commit exception remains the headline.  Pre-replace failures bypass the rollback branch entirely (verified by test_primary_db_exception_before_replace_propagates_without_rollback
     and test_quota_breach_returns_failure_without_touching_storage).
   expires: null
-- key: web/composer/tools.py:R6:_execute_delete_blob:fp=8ca49fc9b52455e7
+- key: web/composer/tools.py:R6:_execute_delete_blob:fp=2d90cb68d4922fd8
   owner: web-composer
   reason: Narrow OSError around tombstone restore after a failed blob delete — compensation disk faults must not bury the
-    primary DB exception
+    primary DB exception. FP rotated from 8ca49fc9b52455e7 by _DATA_ERROR_KEY constant insertion.
   safety: Rollback failure is attached as add_note() on primary_exc and the original delete failure is re-raised unchanged
   expires: null
-- key: web/composer/tools.py:R6:_execute_inspect_source:fp=79e74330fe91e1de
+- key: web/composer/tools.py:R6:_execute_inspect_source:fp=ac151e3b318a5bcd
   owner: web-composer
   reason: Tier-3 trust boundary — UUID(blob_id) coercion of caller-supplied string. ValueError is the documented failure mode
     for malformed UUIDs and falls back to blob_uuid=None (an optional identity field on inspect_blob_content). Failure is
     NOT silent — a blob_id_not_uuid warning fact is prepended to facts.warnings so the audit trail records why redacted_identity
-    omits blob_id.
+    omits blob_id. FP rotated from 79e74330fe91e1de by _DATA_ERROR_KEY constant insertion.
   safety: blob_uuid=None on parse failure; inspection still runs against the resolved blob row (already validated by the _sync_get_blob
     lookup). The blob_id_not_uuid warning surfaces the offending id (truncated to 64 chars) into the audit-bound facts.warnings
     tuple; integrity guards (status=ready, hash match) remain authoritative.
@@ -1170,51 +1170,51 @@ allow_hits:
     which is raw JSON from the DB. Not all source shapes include "options".
   safety: Returns input unchanged when "options" absent — no data loss or fabrication
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=a21ab0d22842792d
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=b2ee7a80ee10460c
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — options is an optional user input that may be omitted;
-    plugin is now validated with an explicit 422 check before this point; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    plugin is now validated with an explicit 422 check before this point; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing keys fall back to defaults (empty dict); no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=d83151090a5bef09
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=e721908298db3cf6
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — observed_columns is an optional user input that may be
-    omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=18bc8091cecd1a93
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=b1da5afefea0764b
   owner: web-sessions
-  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: edited.get() on Tier 3 user-submitted SCHEMA_FORM payload — sample_rows is an optional user input that may be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=fadf554d2cc0aefa
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=d09cedd0417b4678
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — options is an optional user input that may be
-    omitted; plugin is now validated with an explicit 422 check before this point; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    omitted; plugin is now validated with an explicit 422 check before this point; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty dict; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=ecf7d1a7765f8692
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=4ec1fb5db6288315
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — observed_columns is an optional user input that
-    may be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    may be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=697b796e82f4084b
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=44eaa62f930e5a6c
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted INSPECT_AND_CONFIRM payload — sample_rows is an optional user input that may
-    be omitted; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    be omitted; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing key falls back to empty tuple; no fabricated values
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=9b0906221f37adaf
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=5c6bd309ba8475d8
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    fills in when accepting a recipe; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
   expires: null
-- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=343c53dceacf0de3
+- key: web/sessions/routes.py:R1:_dispatch_guided_respond:fp=7ced99282cc4454b
   owner: web-sessions
   reason: edited.get() on Tier 3 user-submitted recipe-offer payload — recipe_name and slots are optional fields the user
-    fills in when accepting a recipe; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    fills in when accepting a recipe; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Missing keys fall back to empty string/dict; failure propagates via handle_step_2_5_recipe_apply
   expires: null
 - key: web/execution/validation.py:R5:_infer_component_type_from_plugin_error:fp=0a36998f74801109
@@ -1411,145 +1411,145 @@ allow_hits:
     and cancellation now also drains the shielded future's eventual exception via add_done_callback so asyncio's GC handler
     cannot fire a misleading 'Future exception was never retrieved' traceback.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d67c463089811195
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=7b716b48f0be464b
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps shielded cancelled-LLM-call
-    audit persistence; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted routes.py when post_guided_respond was added.
+    audit persistence; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry — shielded persistence is best-effort; explicit raise preserves cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=b4cab8a430103035
+- key: web/sessions/routes.py:R7:create_session_router:send_message:fp=d751dcfc9fa4c949
   owner: web-sessions
   reason: Same as the prior send_message R7 entry — contextlib.suppress(asyncio.CancelledError) wraps the shielded progress
-    publish in the cancellation handler; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted routes.py when post_guided_respond was added.
+    publish in the cancellation handler; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry — shielded publish completes; explicit raise restores cancellation chain.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=ceaae83145693a82
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=cd95569a81303ada
   owner: web-sessions
   reason: Same as the prior recompose R7 entry — mirror of cancelled-LLM-call audit persistence suppress in recompose; FP
-    changed after ruff-format reformatted routes.py when post_guided_respond was added; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    changed after ruff-format reformatted routes.py when post_guided_respond was added; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=54e1a93dec1dca49
+- key: web/sessions/routes.py:R7:create_session_router:recompose:fp=94db8ee65912e8eb
   owner: web-sessions
-  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by Step 3 wiring (Phase 4 Task 4.5)
+  reason: Same as the prior recompose R7 entry — mirror of shielded-publish suppress in recompose; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish)
     reformatted routes.py when post_guided_respond was added.
   safety: Same as the prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=a2074b6b9a204d6c
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=9b981797d4e29246
   owner: web-sessions
-  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
+  reason: isinstance check on deserialized composition state source — Tier 3 boundary; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Validates structure from persisted state; same as prior fork_from_message R5 entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=6243220782dadf07
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=d91f3d75b2a547f3
   owner: web-sessions
-  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
+  reason: source_dict.get("options") on Tier 3 composition state — optional source options; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, blob rewrite path is skipped; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=003cbeddfd82ae0f
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=e989522746daf395
   owner: web-sessions
   reason: isinstance(options, dict) validates persisted source.options before mutating nested fields during fork blob rewrite;
-    FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Non-dict raises AuditIntegrityError; no silent skip or coercion.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=aade5352874dbe15
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=228192e62a173a67
   owner: web-sessions
-  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP rotated by Step 3 wiring (Phase 4 Task 4.5) reformatted
+  reason: options.get("blob_ref") on Tier 3 state source — blob_ref is optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish) reformatted
     routes.py when post_guided_respond was added.
   safety: Returns None on miss, handled by conditional below; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=d337312f75404830
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=cdb5bc83948436c8
   owner: web-sessions
-  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: isinstance(old_ref, str) — blob_ref may be str or UUID from persisted state; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Tier 3 boundary — persisted blob_ref type is not guaranteed.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=2dea03f78103b6da
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=b9e0f00815eec2d7
   owner: web-sessions
   reason: blob_map.get(old_uuid) — not every source reference is guaranteed to have a copied blob target; FP changed after
-    ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: None result only triggers secondary path/file rewrite probe; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=896daaea542adbfb
+- key: web/sessions/routes.py:R1:create_session_router:fork_from_message:fp=1bbeda95f80b81dd
   owner: web-sessions
-  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: options.get(path_key) on persisted source options — path/file keys are optional; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: None result skips that key; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=c5e620eb808fa5fc
+- key: web/sessions/routes.py:R5:create_session_router:fork_from_message:fp=db3dce50fa69c3a4
   owner: web-sessions
   reason: isinstance(path_value, str) guards source_blob_path_map lookup against non-string persisted path/file values; FP
-    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Only string values participate in fallback rewrite; same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=50fb6c7ce12df024
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=e2ef8cd067be6c4f
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the BlobQuotaExceededError path; FP changed
-    after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=0c0126c4062b9a55
+- key: web/sessions/routes.py:R6:create_session_router:fork_from_message:fp=b1ab3796f836f98e
   owner: web-sessions
   reason: Narrow (SQLAlchemyError, OSError) around fork-rollback archive_session in the generic except Exception path; FP
-    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior fork_from_message R6 entry.
   expires: null
-- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=781ddb89d39d8a3a
+- key: web/sessions/routes.py:R2:_get_session_compose_lock_registry:fp=1700385ad06141fd
   owner: web-sessions
   reason: App-scoped compose lock registry is initialized lazily on first session-router use rather than being required at
-    startup; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    startup; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _get_session_compose_lock_registry entry.
   expires: null
-- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=8e14e2088e4e222e
+- key: web/sessions/routes.py:R2:_litellm_error_detail:fp=b6167fb60da6eef7
   owner: web-sessions
   reason: Optional LiteLLM/provider exception metadata — status_code is not guaranteed on every provider error object; FP
-    changed after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    changed after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _litellm_error_detail entry.
   expires: null
-- key: web/sessions/routes.py:R1:_state_response:fp=668cdf7bb1201c38
+- key: web/sessions/routes.py:R1:_state_response:fp=fe9244679a1a1e7d
   owner: web-sessions
-  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Unwrapping redact_source_storage_path() output — helper returns dict with "source" key; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Falls back to unredacted source_data (less privacy, not less safety); same as prior entry.
   expires: null
-- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=94f4f5454a0cdb2d
+- key: web/sessions/routes.py:R5:_composer_persisted_validation:fp=48ecb12793971ee9
   owner: web-sessions
   reason: isinstance(runtime_preflight, _RuntimePreflightFailed) dispatches the _RuntimePreflightOutcome union type; FP changed
-    after ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    after ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _composer_persisted_validation entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=915df4b95472b886
+- key: web/sessions/routes.py:R6:_persist_tool_invocations:fp=01f3fd864beccc72
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Audit-system-failure exemption — per-tool-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _persist_tool_invocations entry.
   expires: null
-- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=90f88cebae57c5ac
+- key: web/sessions/routes.py:R6:_persist_llm_calls:fp=51507e1d8c695356
   owner: composer-audit
-  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Audit-system-failure exemption — per-LLM-call audit row persistence is best-effort; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _persist_llm_calls entry.
   expires: null
-- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=fc626c25ee2f56c9
+- key: web/sessions/routes.py:R6:_state_data_from_composer_state:fp=505dc4062758398f
   owner: web-sessions
-  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: state.validate() may fail on structurally damaged partial-state from LLM convergence/crash; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _state_data_from_composer_state R6 entry.
   expires: null
-- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=da99f9dcc94f9c91
+- key: web/sessions/routes.py:R5:_state_data_from_composer_state:fp=60ff974a2b265091
   owner: web-sessions
   reason: isinstance(runtime, ValidationResult) dispatches _RuntimePreflightOutcome union type for telemetry; FP changed after
-    ruff-format; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+    ruff-format; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _state_data_from_composer_state R5 entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=5395d6da427d5ec6
+- key: web/sessions/routes.py:R6:_handle_convergence_error:fp=a6eba11e3bd8d777
   owner: web-sessions
-  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Convergence partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_convergence_error entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=13caa996a929f960
+- key: web/sessions/routes.py:R6:_handle_plugin_crash:fp=bcc44e9de96bb181
   owner: web-sessions
-  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Plugin-crash partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_plugin_crash entry.
   expires: null
-- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=92365f4bcab7bab8
+- key: web/sessions/routes.py:R6:_handle_runtime_preflight_failure:fp=1b8cd07b1091976e
   owner: web-sessions
-  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by Step 3 wiring (Phase 4 Task 4.5).
+  reason: Runtime-preflight partial-state save may fail — SQLAlchemyError family; FP rotated by _DATA_ERROR_KEY import in routes.py (Task 5.1 polish).
   safety: Same as prior _handle_runtime_preflight_failure entry.
   expires: null
 - key: web/app.py:R1:create_app:fp=298d81d738bfa3b0

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -21,6 +21,10 @@ This guide covers common errors and their solutions when running ELSPETH pipelin
 - [Configuration Issues](#configuration-issues)
   - [YAML Parsing Errors](#yaml-parsing-errors)
   - [Schema Validation Failures](#schema-validation-failures)
+- [Web Composer — Guided Mode](#web-composer--guided-mode)
+  - [Auto-dropped to freeform — what happened?](#auto-dropped-to-freeform--what-happened)
+  - [Wizard disagreed with my source schema](#wizard-disagreed-with-my-source-schema)
+  - [Recipe didn't appear for my (CSV, JSONL) pipeline](#recipe-didnt-appear-for-my-csv-jsonl-pipeline)
 
 ---
 
@@ -421,6 +425,96 @@ The readiness probe prevents traffic before the app is ready. The liveness probe
    - Missing `sinks` section
    - Plugin options with wrong types
    - Undefined environment variables in `${VAR}` syntax
+
+---
+
+## Web Composer — Guided Mode
+
+### Auto-dropped to freeform — what happened?
+
+**Cause:** Guided mode dropped you to the freeform composer because the
+wizard could not complete the step you were on. Two paths trigger an
+auto-drop:
+
+- **`solver_exhausted`** — at Step 3, the LLM proposed a transform chain
+  that failed `preview_pipeline`. The wizard tried one repair attempt
+  (feeding the validator's rejection reason back to the LLM) and optionally
+  consulted the advisor. Both came back red, so the wizard handed the
+  partial pipeline state to freeform mode rather than loop forever.
+- **`protocol_violation`** — the LLM emitted a turn type that is not
+  legal at the current step. The wizard granted one retry, the LLM
+  emitted another illegal turn, and the wizard auto-dropped.
+
+**Solution:**
+
+1. Scroll up in the chat history. The drop is recorded as a system
+   message with the `drop_reason` field set. For `solver_exhausted`, the
+   validator's rejection reason is also recorded.
+2. Inspect the last `propose_chain` turn (if any) to see the chain the
+   LLM tried and what the validator said about it. The validator usually
+   names the specific edge or required-field constraint that was
+   violated.
+3. Finish the pipeline by hand in freeform mode. The composer carries
+   over the partial pipeline you had at the moment of the drop, so you
+   are not starting from scratch.
+4. If the LLM keeps producing the same broken chain on similar inputs,
+   that is a real bug — open an issue with the chat history attached.
+
+---
+
+### Wizard disagreed with my source schema
+
+**Cause:** Step 1 of guided mode runs `inspect_source` on the blob you
+attached and shows you the columns it observed. If the inspector's
+opinion of your data does not match what you expected (wrong column
+names, missing columns, columns that should not be there), one of the
+following is usually true:
+
+- The blob was uploaded with the wrong `mime_type`, so the inspector
+  picked the wrong parser (for example, JSONL parsed as plain text).
+- The CSV has a non-standard delimiter, encoding, or header row that
+  the inspector's default heuristics missed.
+- The data actually does have the columns the inspector reported, and
+  your expectation was based on a different file.
+
+**Solution:**
+
+1. Read the column list and sample values the `inspect_and_confirm` turn
+   is showing you. The truth is in the bytes of the blob, not in your
+   memory of the file.
+2. If the columns are wrong, edit the column list directly on the
+   `inspect_and_confirm` turn before continuing. Your edits are recorded
+   as the schema-of-record for the rest of the wizard.
+3. If the underlying problem is the parser choice, exit to freeform,
+   re-upload the blob with the correct `mime_type`, and use the
+   freeform composer's `inspect_source` tool to get an authoritative
+   reading before retrying guided mode.
+
+---
+
+### Recipe didn't appear for my (CSV, JSONL) pipeline
+
+**Cause:** The recipe pre-match step (Step 2.5) matches on the pipeline
+**topology** (source plugin, sink plugin, and sink count) **plus a
+discriminator** — usually a required output field that names the recipe's
+purpose. For example, the `classify-rows-llm-jsonl` recipe requires a
+`classifier_keyword`-style field in the output. A bare (CSV, JSONL)
+shape is not enough; the discriminator has to match too.
+
+**Solution:**
+
+1. Switch to freeform mode briefly and call `list_recipes`. The response
+   names every registered recipe, its required slots, and the
+   discriminator field(s) it matches on.
+2. If a recipe exists but its discriminator did not match your output
+   fields, go back to guided Step 2 and add the discriminator field to
+   the required-output list. The recipe will then match on the next
+   pass through Step 2.5.
+3. If no registered recipe matches your (source, sink) shape at all,
+   that is expected: the wizard will skip Step 2.5 and let the LLM
+   propose a chain in Step 3. You can also pre-apply a recipe manually
+   from freeform mode with `list_recipes` + the recipe-application tool,
+   then return to guided mode to finish the rest.
 
 ---
 

--- a/docs/guides/user-manual.md
+++ b/docs/guides/user-manual.md
@@ -13,7 +13,8 @@ This manual covers day-to-day usage of the ELSPETH CLI for running auditable pip
 7. [Managing Storage](#managing-storage)
 8. [Resuming Failed Runs](#resuming-failed-runs)
 9. [Health Checks](#health-checks)
-10. [Examples](#examples)
+10. [Examples](#examples-walkthrough)
+11. [Web Composer: Guided Mode](#web-composer-guided-mode)
 
 ---
 
@@ -456,6 +457,151 @@ For more complex scenarios, see the configuration reference:
 - **Fork/Join Patterns** - Parallel processing with coalesce
 
 See [Configuration Reference](../reference/configuration.md) for the complete settings documentation.
+
+---
+
+## Web Composer: Guided Mode
+
+The Web Composer is a browser-based authoring surface for building ELSPETH
+pipelines without hand-editing YAML. Start it with:
+
+```bash
+elspeth web
+```
+
+Then open the URL printed on the console (typically <http://localhost:8765>).
+
+When you create a new session, the composer starts in **Guided Mode** — a
+structured wizard for first-time pipeline authors. If you would rather author
+freely from the start (or you are an experienced operator who already knows
+what plugins and options you want), every guided turn exposes an
+**"Exit to freeform"** button that hands you over to the freeform composer with
+whatever partial pipeline state you have built so far. Existing sessions resume
+in whichever mode they were last in.
+
+### What guided mode is for
+
+Guided mode walks you through three steps in order:
+
+1. **Source** — choose where the data comes from.
+2. **Sink** — choose where the results go, and declare which fields you need
+   in the output.
+3. **Transforms** — pick the chain of processing steps that bridges the source
+   to the sink.
+
+Between Step 2 and Step 3 there is a deterministic **recipe pre-match** step:
+the server inspects your (source, sink) topology and the required output
+fields, and if any registered recipe fits the shape you have described, it
+offers that recipe instead of asking an LLM to invent a transform chain. This
+keeps simple, well-known pipelines (for example: "CSV in, classify each row
+with an LLM, write JSONL out") deterministic and cheap to build.
+
+### When to use guided mode versus freeform
+
+- **Use guided mode** if you are new to ELSPETH, if you want a recipe-first
+  authoring experience, or if you want the wizard to validate each step as
+  you go.
+- **Use freeform mode** if you already know which plugins you want to wire
+  together, or if your pipeline does not match any of the patterns guided mode
+  supports (multi-source pipelines, custom branching topologies, exotic
+  aggregations, etc.). Press **"Exit to freeform"** at any guided turn to
+  switch.
+
+Both modes target the same runtime, the same validators, and the same audit
+trail. Switching modes never discards pipeline state — only the authoring
+surface changes.
+
+### The closed turn protocol
+
+Both you and the assistant LLM operate inside a closed protocol: you answer
+only by clicking widgets the wizard offers, and the LLM can only emit one of
+six structured turn types. **The LLM is read-only with respect to pipeline
+state** — pipeline mutations happen server-side only, in response to your
+clicks. You can think of the LLM as a navigator, not a driver.
+
+The six turn types are:
+
+| Turn type | When it appears |
+|---|---|
+| `inspect_and_confirm` | Step 1, after you attach a blob: shows the columns and samples the source detected, and lets you correct them before continuing. |
+| `single_select` | Step 1 / Step 2 / Step 3: pick exactly one option from a set of chips (for example: pick the source plugin, pick the sink plugin, or resolve a clarifying question). |
+| `multi_select_with_custom` | Step 2: pick the output fields, with the observed columns from Step 1 pre-populated; you can also add custom field names. |
+| `schema_form` | Step 1 / Step 2: a form auto-generated from the chosen plugin's option schema (for example: file path, encoding, table name). |
+| `propose_chain` | Step 3: the LLM has proposed a sequence of transform steps with per-step rationale; accept it, edit a single step, or reject. |
+| `recipe_offer` | Step 2.5: the server has matched your (source, sink) shape to a registered recipe and is offering it; accept it (filling in any required slots like `classifier_template`, `model`, `api_key_secret`) or choose "Build manually" to proceed to Step 3. |
+
+### How the recipe pre-match works
+
+After Step 2 completes, the server looks at the pipeline shape (which source
+plugin you chose, which sink plugin you chose, how many sinks, and which
+output fields you said were required) and walks the registered recipe table.
+For example: a CSV source plus a JSON sink plus a required `classifier_keyword`
+field matches the `classify-rows-llm-jsonl` recipe.
+
+If a recipe matches, you see a **`recipe_offer`** turn. You then either:
+
+- **Apply the recipe**, filling in any required slots that the recipe needs
+  (commonly `classifier_template`, `model`, `api_key_secret`). The slots are
+  pre-validated against the recipe's contract before the recipe is committed.
+- **Build manually**, which skips the recipe and advances to Step 3, where
+  the LLM proposes a chain from scratch.
+
+If no recipe matches, the wizard skips Step 2.5 and goes straight to Step 3.
+
+### Step 3 — the chain proposer
+
+Once you reach Step 3, the LLM looks at the (source, sink) shape, the
+required output fields, and the recipe table, and emits a `propose_chain`
+turn. Each step in the chain has a one-line rationale explaining why it is
+there. You can:
+
+- **Accept the full chain** — the wizard commits every step and moves to
+  completion.
+- **Edit step N** — the wizard locks every other step and re-asks the LLM
+  for just that step.
+- **Reject** — the LLM either emits a `single_select` clarification ("I'm
+  trying to bridge X to Y; do you want approach A or approach B?") or
+  escalates to the advisor for a stronger reviewer model.
+
+If the LLM cannot produce a valid chain after one repair attempt plus an
+optional advisor consultation, the wizard **auto-drops to freeform mode**
+with the partial pipeline state preserved and a `solver_exhausted` reason
+recorded in the chat history. From there you finish the pipeline by hand.
+
+### Completion and execution
+
+When the wizard runs out of guided steps, you see a **completion summary**
+showing the final pipeline shape. From the summary you can:
+
+- **Save and exit** — keep the pipeline as it is; the session is saved.
+- **Drop to freeform to keep editing** — switch to freeform mode with the
+  completed pipeline pre-loaded, and continue authoring there.
+
+Once the pipeline is saved you can validate it, preview the YAML, and execute
+it directly from the composer. The composer's `/validate` and `/execute`
+endpoints use the same runtime assembly and graph validation contracts as
+`elspeth validate` and `elspeth run` — there is no separate UI-only validator.
+
+### What guided mode does not cover
+
+Guided mode is intentionally narrow. It does not (yet) cover:
+
+- Pipelines with multiple sources.
+- Pipelines with branching topologies (forks, gates with multiple downstream
+  paths, fork+coalesce patterns).
+- Aggregation transforms that span more than a single row.
+- Custom plugin authoring.
+
+For any of these, exit to freeform when guided mode reaches a step it cannot
+represent. The chat history and the partial pipeline state both carry over.
+
+### See also
+
+- The full technical design of guided mode (server architecture, turn-protocol
+  contract, audit and telemetry, testing strategy) is documented at
+  `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md`.
+- For freeform composer authoring, plugin discovery, and tool contracts, see
+  the composer skill at `src/elspeth/web/composer/skills/pipeline_composer.md`.
 
 ---
 

--- a/docs/superpowers/handovers/2026-05-12-phase-10-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-10-complete.md
@@ -1,0 +1,127 @@
+# Phase 10 close — Composer Guided Mode (Gap 6 + docs + umbrella PR)
+
+**Status: complete.** Phase 10 delivered the three things the dispatch brief required: (1) Gap 6 RecipeOfferTurn editable slots with the demo SLA E2E un-fixmed and passing, (2) user-facing documentation, and (3) the umbrella PR is open against `main`. No deferrals required; Tasks 9.2 / 9.3 / ChaosLLM Playwright fixture remain explicitly out of scope per Phase 9's close (carried forward in the PR description for the merge reviewer).
+
+## TL;DR
+
+**Demo SLA: GREEN.** `tests/e2e/composer-guided.spec.ts` passes at **9 clicks / 3.5s** (budget: ≤9 / <30s). The recipe-match happy path (CSV → classify-rows-llm-jsonl → JSON) is now end-to-end verifiable, deterministic (zero LLM calls), and assertable in CI.
+
+**Phase 10 commits (4 substantive + this handover):**
+| SHA | Title | Role |
+|---|---|---|
+| `c7cb7ee9` | feat(web/composer): RecipeOfferTurn editable slots; un-fixme demo SLA E2E | Gap 6 wire-shape change (Convention 14) + un-fixme |
+| `f8ca63f9` | refactor(web/composer): tighten _RecipeSlotInput.slot_type to SlotType Literal | Code-review Important #1 — closes wire-schema/recipes.py drift gap |
+| `d6ea2ca0` | docs(guides+changelog): composer guided mode | User-facing docs + CHANGELOG entry |
+| _(this file)_ | docs(handover): Phase 10 complete | Phase 10 close |
+
+**Gates at Phase 10 close:**
+- pytest guided (`tests/unit/web/composer/guided/` + `tests/integration/web/composer/guided/`): **181 passed**
+- mypy: **clean, 391 source files**
+- enforce_tier_model.py check: **passed** (FPs rotated in `config/cicd/enforce_tier_model/web.yaml`)
+- enforce_freeze_guards.py: **passed**
+- vitest: **427 passed / 39 files**
+- tsc -p tsconfig.app.json --noEmit: **clean**
+- Playwright composer-guided: **4 passed / 9 skipped** (demo SLA test moved from skipped to passing)
+
+## What landed (per task)
+
+### Task 10.0 + 10.0b — Gap 6 + un-fixme demo SLA
+
+Wire-shape change subject to Convention 14 (one commit, all sites). 15 files / +726 / -196 in `c7cb7ee9`, followed by the slot_type Literal tightening in `f8ca63f9`.
+
+**Design:** Option (c) from the pre-dispatch advisor consult — `RecipeMatch` carries `unsatisfied_slots: Mapping[str, SlotSpec]`, populated inside `match_recipe` via `get_recipe(recipe_name).slots` minus the resolver's coverage. Emitter stays pure (no upward import to `recipes.py`).
+
+**Touch list (17 sites, all visited):**
+
+Backend:
+1. `src/elspeth/web/composer/guided/recipe_match.py` — `RecipeMatch.unsatisfied_slots` field + `freeze_fields` extension; `match_recipe` derivation; offensive crash on missing recipe.
+2. `src/elspeth/web/composer/guided/protocol.py` — `_RecipeSlotInput` TypedDict with `slot_type: SlotType` (after `f8ca63f9`); `RecipeOfferPayload.unsatisfied_slots`; `_REQUIRED_KEYS` updated.
+3. `src/elspeth/web/composer/guided/emitters.py` — `build_step_2_5_recipe_offer_turn` projects `(name, SlotSpec)` → `_RecipeSlotInput` literal.
+4. `src/elspeth/web/sessions/routes.py` — apply-time `_RecipeMatch(..., unsatisfied_slots={})` reconstruction (consumer reads only `recipe_name` / `slots`; comment-justified, observation filed — see below).
+
+Frontend:
+5. `src/elspeth/web/frontend/src/types/guided.ts` — `RecipeSlotInput` interface + `unsatisfied_slots` field on `RecipeOfferPayload`.
+6. `src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx` — controlled inputs, inline fieldset (no disclosure), `<label htmlFor>` accessibility, Apply disabled until every required slot is non-empty trimmed, merge on submit, **`type="text"` for `str` slots / `type="number"` for `int`/`float` — NEVER `type="password"`** (audit-trail integrity).
+7. `src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx` — new tests: empty case, labelled inputs, disabled→enabled gate, merged submit, numeric type, **security pin (positive + negative assertion that `api_key_secret` renders `type="text"` not `type="password"`)**, hint rendering.
+
+Tests:
+8. `tests/unit/web/composer/guided/test_protocol.py` — literal updated + happy/missing-key validate_payload tests.
+9. `tests/integration/web/composer/guided/test_step_handlers.py` — `RecipeMatch` literals updated (2 sites).
+10. `tests/integration/web/composer/guided/test_respond.py` — `unsatisfied_slots` shape assertions for classify (3 entries) + split-threshold (2 entries).
+11. `tests/integration/web/composer/guided/test_audit_emission.py` — no change required (its drive-helper already supplied all required slots).
+12. `tests/unit/web/composer/guided/test_skill.py` — no change required (iterates TurnType values).
+13. `src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx` — `RECIPE_OFFER_PAYLOAD` literal updated.
+14. `src/elspeth/web/frontend/src/types/guided.test.ts` — no change required.
+15. `tests/unit/web/composer/guided/test_recipe_match.py` — new `TestUnsatisfiedSlots` class (6 tests: classify 3 entries, split-threshold 2 entries, exclusion of resolver-filled + optional-with-defaults, SlotSpec metadata preserved, freeze contract).
+16. `tests/unit/web/composer/guided/test_emitters.py` — NEW file, 7 tests pinning emitter projection.
+
+E2E:
+17. `src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts` — `test.fixme()` removed; three `.fill()` calls populate `classifier_template`, `model`, `api_key_secret`; header trimmed to "Gap 6 RESOLVED" summary.
+
+**Sites verified NOT in the touch list:**
+- `src/elspeth/web/composer/tools.py:_execute_explain_validation_error` — pattern-matches error text only; independent of `RecipeOfferPayload` shape.
+- Audit schema — only `stable_hash(payload)` recorded; new payload field changes the hash but not the audit-record column shape. No DB migration in this change.
+
+### Task 10.1 + 10.2 — User docs + CHANGELOG
+
+Landed at `d6ea2ca0` (markdown-only commit, `--no-verify` per `feedback_doc_only_commits_no_ci`).
+
+- `docs/guides/user-manual.md` (+148 / -1) — new "Web Composer: Guided Mode" section (~1100 words) covers: what guided mode is, when to use it vs. freeform, the three-step flow, the closed six-turn taxonomy table, recipe pre-match at Step 2.5, Step 3 chain proposer + auto-drop behaviour, completion / Save-and-exit / Drop-to-freeform-to-keep-editing controls, scope limits, and a See-also pointing at the design spec.
+- `docs/guides/troubleshooting.md` (+94) — new "Web Composer — Guided Mode" subsection with three Cause/Solution entries: (a) auto-dropped to freeform → `solver_exhausted` diagnosis; (b) wizard disagreed with source schema → `inspect_and_confirm` edit; (c) recipe didn't appear → predicate-discriminator explanation + `list_recipes` workflow.
+- `CHANGELOG.md` (+13) — new `[Unreleased]` section at the top (Keep-a-Changelog convention) with the verbatim plan-body text under `### Added`. The `[0.5.1]` section is preserved unchanged.
+
+**Source-grounded technical writing discipline applied:** the docs-implementer grepped the actual frontend components (`ExitToFreeformButton.tsx`, `CompletionSummary.tsx`) for UI labels and the design spec for the six-turn taxonomy terms before writing prose. No invented features; no internal Phase numbers or filigree observation IDs leak into user-facing text.
+
+### Task 10.3 — Umbrella PR open
+
+PR opened against `main` from `feat/composer-guided-mode` (see below for PR URL once landed). Phase-by-phase commit map (1–10) carried in the PR description for reviewer navigation; DB migration note (delete sessions DB), open observations, and deferred tasks (9.2 / 9.3 / ChaosLLM fixture) all surfaced.
+
+No reviewers requested in the PR-open per dispatch-brief constraint — operator chooses.
+
+## Observation housekeeping
+
+| ID | Status | Action |
+|---|---|---|
+| `elspeth-obs-f626607b13` | RESOLVED by `c7cb7ee9` (Gap 6 wire shape) | Dismissed in this phase |
+| `elspeth-obs-d3d0d7fa70` | RESOLVED by `9ae407a2` (sessionStore wiring) | Dismissed in this phase |
+| `elspeth-obs-a8a9bc010a` | RESOLVED by `74ea68eb` (slot resolver blob_ref) | Dismissed in this phase |
+| `elspeth-obs-5ea21f94af` | RESOLVED by `2b692cab` (focus on step advance) | Dismissed in this phase |
+| `elspeth-obs-5e905f3c9d` | RESOLVED by `a5df0b6c` (Bug 2 sink intent persistence) | Verified closed in filigree |
+| `elspeth-obs-06854f0842` | NEW (P3) — `RecipeMatch` lifecycle ambiguity at apply-time reconstruction | Filed in this phase; deferred to a future cleanup phase |
+| `elspeth-obs-134474dfcb` | Open (P2) — InspectAndConfirmTurn unreachable on the live emission path | Carried forward; surfaced in PR description |
+| `elspeth-obs-83d97315a7` | Open (P3) — forkFromMessage doesn't restart guided state for new session | Carried forward; surfaced in PR description |
+| `elspeth-obs-a076365f64` | Open (P3) — test-file fixture extraction (Phase 8) | Carried forward; cosmetic |
+| `elspeth-obs-510a4fbdeb` | Open — TurnPayload discriminated-union refactor | Carried forward; no urgency |
+| `elspeth-obs-f9e991f517` | Open — useNonInitialEffect hook extraction | Carried forward; no urgency |
+| `elspeth-611fc01d94` | Open — GuidedHistory rich step summaries (Phase 7) | Carried forward; cosmetic |
+| `elspeth-2c08408170` | Open + Phase 9 deferral note | Carried forward; gates a future Task 9.2 |
+
+## What's deferred (carried from Phase 9, not addressed in Phase 10)
+
+Per Phase 9 close and the Phase 10 dispatch brief, the following are explicitly out of Phase 10 scope. The umbrella PR description surfaces this rationale for the merge reviewer:
+
+- **Task 9.2 — Hand-built path (LLM-driven Step 3) E2E.** Hard-blocked on `elspeth-2c08408170` (Step-3 backend handler completion). Awaiting backend resolution.
+- **Task 9.3 — Auto-drop path E2E.** Failure-path coverage, not demo-anchor. Depends on the LLM-stub Playwright fixture.
+- **ChaosLLM Playwright fixture.** Required by 9.2 + 9.3. Not built — Phase 10 scope was strictly "demo SLA + umbrella PR."
+
+These belong to a polish phase or a Phase 11 plan. Phase 10's outcome — "demo SLA assertion green + umbrella PR opens for review" — does not require them.
+
+## Conventions reaffirmed in Phase 10
+
+The fourteen prior-handover conventions all held. Two were exercised this phase:
+
+- **Convention 13** (Playwright verification before declaring a feature complete): Task 10.0's verification gate explicitly required the un-fixmed `composer-guided.spec.ts` to pass before the implementer reported DONE. It did, at 9 clicks / 3.5s.
+- **Convention 14** (wire-shape changes ship as one commit covering every touched site). Task 10.0 hit 14 of 17 sites in `c7cb7ee9`; sites 11, 12, 14 required no change (test fixtures that didn't construct the affected literal). The follow-up `f8ca63f9` is a separate forward-compat hardening commit, not a Convention-14 violation — it tightens a type annotation that doesn't change wire bytes.
+
+No new conventions emerged in Phase 10. The phase was small and clean, as the Phase 9 close advisor predicted ("Phase 9's value is making Phase 10 small").
+
+## Hand-off
+
+The umbrella PR is open. Operator owns triage from here:
+
+- **Code review** — operator nominates reviewers. Branch state: clean (no uncommitted work); 90 commits total against `main`.
+- **Merge timing** — operator's call. PR is non-draft.
+- **Post-merge cleanup** — sibling branch `feat/composer-progress-persistence-1a` (Phase 1B/1C/Phase-2-redaction work, per memory `project_phase1b_implementation_complete` / `project_phase1c_implementation_complete` / `project_phase2_implementation_complete`) is independent work not delivered by this PR.
+- **Phase 11 / polish phase scope** — Tasks 9.2 / 9.3 / ChaosLLM fixture + the `elspeth-obs-06854f0842` `RecipeMatch` lifecycle refactor + the carried-forward observations. No commitments on timing.
+
+The composer-guided-mode feature ships to `main` with this PR.

--- a/docs/superpowers/handovers/2026-05-12-phase-10-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-10-complete.md
@@ -74,7 +74,7 @@ Landed at `d6ea2ca0` (markdown-only commit, `--no-verify` per `feedback_doc_only
 
 ### Task 10.3 — Umbrella PR open
 
-PR opened against `main` from `feat/composer-guided-mode` (see below for PR URL once landed). Phase-by-phase commit map (1–10) carried in the PR description for reviewer navigation; DB migration note (delete sessions DB), open observations, and deferred tasks (9.2 / 9.3 / ChaosLLM fixture) all surfaced.
+PR #37 (https://github.com/johnm-dta/elspeth/pull/37) opened from `feat/composer-guided-mode`. Initially targeted `main`; retargeted to `RC5.2` at operator's request immediately after PR-open. Branch is 87 commits ahead of `RC5.2` / 0 commits behind, so retarget was clean (no merge resolution required). Phase-by-phase commit map (1–10) carried in the PR description for reviewer navigation; DB migration note (delete sessions DB), open observations, and deferred tasks (9.2 / 9.3 / ChaosLLM fixture) all surfaced.
 
 No reviewers requested in the PR-open per dispatch-brief constraint — operator chooses.
 
@@ -119,7 +119,7 @@ No new conventions emerged in Phase 10. The phase was small and clean, as the Ph
 
 The umbrella PR is open. Operator owns triage from here:
 
-- **Code review** — operator nominates reviewers. Branch state: clean (no uncommitted work); 90 commits total against `main`.
+- **Code review** — operator nominates reviewers. Branch state: clean (no uncommitted work); 87 commits total against `RC5.2`.
 - **Merge timing** — operator's call. PR is non-draft.
 - **Post-merge cleanup** — sibling branch `feat/composer-progress-persistence-1a` (Phase 1B/1C/Phase-2-redaction work, per memory `project_phase1b_implementation_complete` / `project_phase1c_implementation_complete` / `project_phase2_implementation_complete`) is independent work not delivered by this PR.
 - **Phase 11 / polish phase scope** — Tasks 9.2 / 9.3 / ChaosLLM fixture + the `elspeth-obs-06854f0842` `RecipeMatch` lifecycle refactor + the carried-forward observations. No commitments on timing.

--- a/docs/superpowers/handovers/2026-05-12-phase-10-dispatch-brief.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-10-dispatch-brief.md
@@ -1,0 +1,302 @@
+# Dispatch brief — Composer Guided Mode Phase 10 (Gap 6 + docs + umbrella PR)
+
+**Companion doc.** This is forward-looking guidance for the Phase 10 controller. The retrospective handover at `docs/superpowers/handovers/2026-05-12-phase-9-complete.md` captures what landed at Phase 9 close; this doc tells you what Phase 10 needs to deliver and how to sequence it.
+
+Read both. Where they disagree, this brief wins (it's the more recent document).
+
+## TL;DR
+
+Phase 10 lands two things and opens the umbrella PR:
+
+1. **Task 10.0 — Gap 6: RecipeOfferTurn editable slots.** Extends `RecipeOfferPayload` (wire contract) so unsatisfied required slots ship with their schema, and `RecipeOfferTurn` renders editable inputs for them. Multi-component frontend+backend work — the textbook scenario for convention 14 (one-commit wire-contract change). **Gates the demo SLA assertion.**
+2. **Task 10.0b — Un-fixme the demo SLA spec.** Once Gap 6 lands, `tests/e2e/composer-guided.spec.ts` becomes a one-line change (`test.fixme(true, ...)` → `test(...)`). Run end-to-end, confirm ≤9 clicks / <30s SLA holds.
+3. **Task 10.1 — User-facing docs.** Add "Guided Mode" section to `docs/guides/user-manual.md` + entries in `docs/guides/troubleshooting.md`. Original Phase 10 plan body §10.1.
+4. **Task 10.2 — CHANGELOG entry.** Add `### Added` entry under the active release header per plan body §10.2.
+5. **Task 10.3 — Open the umbrella PR.** Per `project_adr010_umbrella_branch` memory: this PR delivers all of Phases 1–10 of composer-guided-mode against `main`. PR description carries a phase-by-phase commit map (per Phase 9 cross-impl reviewer's umbrella-PR-prep guidance) so reviewers can navigate the diff.
+
+**Out of Phase 10 scope (deferred to Phase 11 or polish):** Tasks 9.2 (hand-built path E2E — hard-blocked on `elspeth-2c08408170`), 9.3 (auto-drop path E2E), and the ChaosLLM Playwright fixture they both depend on. Phase 9 explicitly closed without these; Phase 10's outcome ("demo SLA assertion green + umbrella PR opens for review") doesn't need them. Document the deferral in the Phase 10 close handover.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode`
+- **Top commit at start of Phase 10:** `80cab3b6 docs(handover): fix Phase 9 commit count to include the handover itself` — or whatever has accumulated since.
+- **Python:** `.venv/bin/python` in the worktree. Do NOT use main's venv (Python-version mismatch corrupts `enforce_tier_model.py` results — per memory `project_tier_model_python_version`).
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). Vitest is the unit/integration runner. Playwright (1.59.1) is the E2E runner; auto-launches uvicorn (:8451) + Vite (:5173) under `webServer`.
+- **Canonical frontend typecheck:** `npx tsc -p tsconfig.app.json --noEmit` — NOT `npx tsc --noEmit` at the root.
+- **ESLint is broken** on this worktree (v9 flat-config migration debt). Don't fix it as part of Phase 10. Rely on vitest + tsc + Playwright.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` — Phase 10 starts around line 4634. Phase 9 amendment landed at `df5306cf`.
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md`. Relevant for Phase 10: §3.3 (recipe pre-match), §6.4 (recipe matcher backend), §7.1 (component layout — RecipeOfferTurn lives in `components/chat/guided/`).
+
+## State at Phase 10 start (post Phase 9)
+
+- Demo SLA E2E spec exists at `tests/e2e/composer-guided.spec.ts` — drives steps 1–5 successfully, blocked at step 6 (Apply recipe) by Gap 6. `test.fixme()`.
+- Backend wire-shape bugs Bug 1 + Bug 2 fixed (commits `e05e02b2`, `a5df0b6c`).
+- Slot resolver `blob_ref` fix landed (`74ea68eb`) — including blob_ref injection through `handle_step_1_source` (the deeper architectural gap that surfaced during Gap 5 verification).
+- sessionStore guided wiring landed (`9ae407a2`).
+- Plan body for Task 9.1 corrected (`df5306cf`).
+- Vitest baseline at Phase 10 start: **418 / 418 pass.** `tsc -p tsconfig.app.json --noEmit`: clean.
+- pytest guided suite: 165 pass.
+- Playwright: 3 pass + 10 fixme (the demo SLA spec + adjacent fixmes).
+- Five Phase 9 observations open in filigree:
+  - `elspeth-obs-f626607b13` (P1): Gap 6 — RecipeOfferTurn editable slots. **Phase 10 first task.**
+  - `elspeth-obs-134474dfcb` (P2): InspectAndConfirmTurn unreachable on the live emission path.
+  - `elspeth-obs-83d97315a7` (P3): forkFromMessage doesn't restart guided state for the new session.
+  - `elspeth-obs-d3d0d7fa70` (P1): RESOLVED by `9ae407a2` — dismiss as part of Phase 10 housekeeping.
+  - `elspeth-obs-a8a9bc010a` (P0): RESOLVED by `74ea68eb` — dismiss as part of Phase 10 housekeeping.
+- Phase 8 observation `elspeth-obs-5ea21f94af` RESOLVED by `2b692cab` — dismiss.
+
+## Pre-flight verification (do this FIRST)
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline 80cab3b6..HEAD | head -10                            # confirm Phase 9 close + any drift
+cd src/elspeth/web/frontend
+npm test -- --run                                                      # expect 418 / 418 pass
+npx tsc -p tsconfig.app.json --noEmit                                  # expect clean
+npx playwright test composer-guided                                    # expect 3 passed, 10 skipped
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/unit/web/composer/guided/ tests/integration/web/composer/guided/ -q | tail -5   # expect 165 pass
+.venv/bin/python -m mypy src/ 2>&1 | tail -3                           # expect clean
+```
+
+If any baseline gate fails, stop and investigate before starting Phase 10.
+
+## Sequencing decisions
+
+### Task 10.0 — Gap 6 first; no parallelism with docs
+
+Gap 6 is multi-component wire-contract work that touches:
+
+- `src/elspeth/web/composer/guided/types.py` (or wherever `RecipeOfferPayload` is defined — verify the actual path)
+- `src/elspeth/web/composer/guided/emitters.py` (or `recipe_match.py` — wherever the `RecipeOfferTurn` payload is built)
+- `src/elspeth/web/composer/recipes.py` (slot specs already exist; surface them)
+- `src/elspeth/web/frontend/src/types/guided.ts` — the TypeScript wire type
+- `src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx` — render the editable form
+- `src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx` — vitest coverage
+- `tests/unit/web/composer/guided/test_emitters.py` (or wherever payload-building is tested)
+- `tests/integration/web/composer/guided/test_endpoints.py` — full-flow round-trip
+- The validator-error explanation tool (search for `explain_validation_error` — Phase 9 reviewer flagged this specifically)
+- Possibly the audit schema if the new payload field changes audit-record shape
+
+**Convention 14 from Phase 9 close:** all of those touched in ONE commit. The Phase 10 controller should write the Gap 6 dispatch brief with an explicit per-site checklist; the implementer must check each off before reporting DONE.
+
+Do NOT parallelize Task 10.0 with the docs/CHANGELOG work. Docs reference the demo SLA assertion as proof the demo path works; if the SLA hasn't actually been asserted yet, the docs are aspirational and will need rewriting after Gap 6 lands. Sequence: Gap 6 → un-fixme + verify SLA → docs/CHANGELOG → PR open.
+
+### Task 10.0b — Un-fixme is bundled with Gap 6's verification dispatch
+
+The implementer for Task 10.0 should ALSO un-fixme the spec and run the full Playwright suite as part of their dispatch's verification gate. If the SLA fails after Gap 6 lands, they investigate and fix in-session (not "land Gap 6, then a separate dispatch un-fixmes" — that's gratuitous handoff overhead). If a seventh integration bug surfaces, refer to Phase 9's pattern: small bounded fix in-session; large multi-component fix → file observation, surface DONE_WITH_CONCERNS, escalate.
+
+### Tasks 9.2 / 9.3 / LLM-stub — explicitly out of Phase 10 scope
+
+Per Phase 9 close: 9.3 is failure-path coverage, not the demo anchor; 9.2 is hard-blocked on `elspeth-2c08408170` (Step-3 backend handler completion); both depend on the LLM-stub fixture which doesn't exist. Phase 10's deliverable is "demo SLA assertion green + umbrella PR opens" — none of those three tasks are required for that.
+
+The Phase 10 close handover should explicitly say: "Tasks 9.2, 9.3, and the LLM-stub Playwright fixture are deferred to Phase 11 (or a polish phase) — they are not blockers for the umbrella PR, and including them would inflate Phase 10 scope without changing the demo readiness story."
+
+### Task 10.3 — Umbrella PR open is THE close action
+
+Per memory `project_adr010_umbrella_branch`: this branch delivers Phases 1–10 end-to-end. The PR is opened against `main`. The PR description must:
+
+1. Carry a phase-by-phase commit map for navigation. Without it, reviewers see ~100+ commits across 10 phases and have no chapter markers.
+2. Include the DB migration note flagged by the Phase 9 cross-impl reviewer: "delete your sessions DB before running — Phase 9 added a `step_2_sink_intent` field to `GuidedSession` with strict `from_dict`; pre-Phase-9 sessions are not forward-compatible. This matches the project's stated migration policy (`project_db_migration_policy` memory)."
+3. Reference the four open observations Phase 10 leaves unresolved (Gap 6 will be closed by Task 10.0; the three remaining: `elspeth-obs-134474dfcb`, `elspeth-obs-83d97315a7`, plus polish-phase items) so the merge reviewer doesn't think they were missed.
+4. Note the Tasks 9.2/9.3/LLM-stub deferral with the rationale above.
+
+The PR open does NOT request review from `johnm-dta` or any other operator-side reviewer — operator decides who reviews. The PR open just makes the work visible.
+
+## Per-task dispatch hints
+
+### For Task 10.0 (Gap 6) dispatch
+
+**Files to read first:**
+- `docs/superpowers/handovers/2026-05-12-phase-9-complete.md` — particularly the Gap 6 row in the bug table.
+- `mcp__filigree__get_finding elspeth-obs-f626607b13` — the observation's full text.
+- `tests/e2e/composer-guided.spec.ts` — the spec header documents the Gap 6 failure pattern with backend file:line references the prior implementer found.
+- `src/elspeth/web/composer/recipes.py:181-300` — `_RECIPE1_SLOTS` and the `classify-rows-llm-jsonl` recipe definition; particularly the `classifier_template`, `model`, `api_key_secret` slots that have no derivable defaults.
+- `src/elspeth/web/composer/guided/recipe_match.py` — `_classify_slot_resolver` (the resolver that derives the satisfiable slots; the unresolved ones must be surfaced to the frontend).
+- `src/elspeth/web/composer/guided/emitters.py` (or wherever RecipeOfferTurn payload is built) — the current build site.
+- `src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx` — current widget; buttons exist (Apply / Build manually); add a slot form between recipe summary and action buttons.
+- `src/elspeth/web/frontend/src/types/guided.ts` lines around 240 (per Phase 9 Gap 6 finding) — `RecipeOfferPayload` definition.
+
+**Wire-contract design (suggested but not authoritative):**
+
+```python
+# Backend: extend RecipeOfferPayload with unsatisfied_slots
+@dataclass(frozen=True, slots=True)
+class RecipeSlotInput:
+    name: str          # slot name (e.g. "classifier_template")
+    slot_type: str     # one of SlotType — needed for input rendering
+    description: str   # operator-readable hint
+    required: bool     # always True for this surface (satisfied slots are pre-filled)
+
+# RecipeOfferPayload gets a new field:
+unsatisfied_slots: tuple[RecipeSlotInput, ...] = ()
+```
+
+```ts
+// Frontend wire type:
+interface RecipeSlotInput {
+  name: string;
+  slot_type: "blob_id" | "str" | "float" | "int" | "str_list";
+  description: string;
+  required: boolean;
+}
+
+interface RecipeOfferPayload {
+  // ...existing fields...
+  unsatisfied_slots: RecipeSlotInput[];
+}
+```
+
+The widget renders a `<fieldset>` with one `<input>` per unsatisfied slot. On Apply, the widget submits `chosen: ["accept"], custom_inputs: <slot values>` (verify the custom_inputs key is the right shape — check the RecipeOfferTurn submit handler).
+
+**Critical: respect convention 14.** The dispatch brief MUST list every file the change touches and require the implementer to check each off:
+
+- [ ] `RecipeOfferPayload` dataclass (Python L2 contract)
+- [ ] Recipe match `emitters.py` payload builder — populate `unsatisfied_slots` from slot specs
+- [ ] `recipes.py` slot specs — verify `description` field exists or add it
+- [ ] Frontend `guided.ts` TypeScript type
+- [ ] Frontend `RecipeOfferTurn.tsx` form rendering
+- [ ] Frontend `RecipeOfferTurn.test.tsx` vitest coverage (form renders; submit shape correct)
+- [ ] Backend unit tests for `emitters.py` payload-building
+- [ ] Backend integration tests for full recipe-match flow with required slots
+- [ ] `explain_validation_error` tool (in `composer/tools.py` — verify; the Phase 9 reviewer flagged this as part of the wire-contract surface but didn't confirm it actually needs updating)
+- [ ] Audit schema (only if `RecipeOfferPayload` shape is part of the audit record — check)
+- [ ] Tier-model allowlist (FP rotation likely needed when files grow)
+
+**Verification gate (must all pass before reporting DONE):**
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/unit/web/composer/guided/ tests/integration/web/composer/guided/ -q | tail -5
+.venv/bin/python -m mypy src/ 2>&1 | tail -3
+.venv/bin/python scripts/cicd/enforce_tier_model.py check --root src/elspeth --allowlist config/cicd/enforce_tier_model 2>&1 | tail -3
+.venv/bin/python scripts/cicd/enforce_freeze_guards.py 2>&1 | tail -3
+cd src/elspeth/web/frontend
+npm test -- --run 2>&1 | tail -3
+npx tsc -p tsconfig.app.json --noEmit 2>&1 | tail -3
+npx playwright test composer-guided 2>&1 | tail -10            # un-fixme + must pass; SLA met
+```
+
+After landing, dismiss `elspeth-obs-f626607b13`.
+
+### For Task 10.1 (user-facing docs) dispatch
+
+The original plan body for §10.1 (line 4634+) is fine as-is. Read it; honor it. Two notes:
+
+- The "screenshots from Playwright" suggestion in the plan body is optional. If you skip screenshots, the prose stands on its own. If you include screenshots, capture them via `npx playwright test composer-guided --trace on` and embed; otherwise this becomes its own sub-task.
+- The "user manual" target is `docs/guides/user-manual.md` — verify the file exists; if not, this is a new file (the plan body assumes it exists).
+
+### For Task 10.2 (CHANGELOG) dispatch
+
+Trivial; can be combined with Task 10.1's commit. The plan body at line 4670+ has the Markdown verbatim — copy it under the active release header.
+
+### For Task 10.3 (umbrella PR) dispatch
+
+Use the `pr-create` workflow (or the equivalent toolchain in your environment — likely `gh pr create` directly). The PR description body must include:
+
+1. **Phase-by-phase commit map.** One bullet per phase: phase number, brief description, commit range. Read each phase's `*-complete.md` handover for the commit ranges.
+2. **DB migration note.** "Delete your sessions DB before running this branch. Phase 9 added a `step_2_sink_intent` field to `GuidedSession` with strict `from_dict` (per `project_db_migration_policy`)."
+3. **Open observations the PR doesn't close.** List `elspeth-obs-134474dfcb` (InspectAndConfirmTurn unreachable, P2), `elspeth-obs-83d97315a7` (forkFromMessage guided-state, P3), and any other observations open at PR-open time.
+4. **Deferred tasks with rationale.** Tasks 9.2 (hand-built path E2E — hard-blocked on `elspeth-2c08408170`), 9.3 (auto-drop path E2E — failure-path coverage, not demo-anchor), and the ChaosLLM Playwright fixture they depend on. Phase 11 owns these.
+5. **Demo SLA verification.** "Recipe-match demo path verified end-to-end via `tests/e2e/composer-guided.spec.ts`: ≤9 user clicks, <30s wall-clock, zero LLM calls (recipe-match path is deterministic)."
+
+**Do NOT request reviewers in the PR-open. Operator decides who reviews.** The brief landing the work makes it visible; operator triages from there.
+
+## Convention reminders (carry from Phase 9)
+
+All fourteen conventions from prior handovers carry forward. Two added in Phase 9 are particularly load-bearing for Phase 10:
+
+13. **Backend integration bugs at the seams require curl probes against the live backend OR a Playwright run before declaring a feature complete.** Phase 10 Task 10.0 (Gap 6) is the canonical example — the Phase 10 dispatch brief MUST require the implementer to demonstrate the un-fixmed Playwright spec passes before reporting DONE.
+
+14. **Wire-shape changes must touch L0 contract type + backend builder + frontend type + widget + widget tests + schema-compliance tests + validator-error tool, all in the same commit.** Gap 6 IS this scenario. The dispatch brief MUST include the per-site checklist.
+
+## Plan-vs-reality drift expected in Phase 10
+
+Phase 10 should drift LESS than Phase 9 because the seam-cleanup work is done. Likely drift patterns:
+
+- **`unsatisfied_slots` shape may differ from the suggested design.** The slot-input wire shape might need additional fields (e.g. `default_value` for partially-derivable slots, `validation_pattern` for client-side validation) once the implementer reads the actual slot resolver code. Treat the suggested shape as a starting point.
+- **`explain_validation_error` may not need changes.** The Phase 9 reviewer flagged it as "probably part of the wire-contract surface" but didn't confirm. The implementer should investigate; if the tool's response shape is independent of `RecipeOfferPayload`, no change needed and convention 14's list shrinks by one.
+- **Audit schema may not need changes.** Same investigation: does `RecipeOfferPayload` appear in the audit record verbatim, or is only a hash recorded? If only a hash, the schema is unchanged. Verify before assuming.
+- **The Playwright SLA may NOT pass on first un-fixme** even after Gap 6 lands — the click count budget (≤9) was an estimate from the Phase 9 plan correction. If actual UX produces 10 clicks, investigate where the extra click is and either fix the UX (preferred) or bump the budget with operator buy-in. Per project memories `feedback_correctness_beats_performance` and `feedback_no_calendar_shipping_commitments` — fix root cause, don't lower SLA to make tests green.
+- **The `pr-create` workflow / `gh pr create` may need a `--draft` flag** if the operator prefers staged review. Default to non-draft; flag to operator if the PR description suggests they want draft review.
+
+## Active follow-ups at Phase 10 start
+
+| Issue | Status | Phase 10 priority |
+|---|---|---|
+| `elspeth-obs-f626607b13` (Gap 6 — RecipeOfferTurn editable slots) | Open (P1) | **First task. Gates the demo SLA assertion.** |
+| `elspeth-obs-134474dfcb` (InspectAndConfirmTurn unreachable) | Open (P2) | Out of scope — note in PR description; address in polish phase. |
+| `elspeth-obs-83d97315a7` (forkFromMessage doesn't restart guided state) | Open (P3) | Out of scope — note in PR description. |
+| `elspeth-obs-d3d0d7fa70` (startGuided unwired) | RESOLVED by `9ae407a2` | Dismiss as housekeeping. |
+| `elspeth-obs-a8a9bc010a` (slot resolver blob_id) | RESOLVED by `74ea68eb` | Dismiss as housekeeping. |
+| `elspeth-obs-5ea21f94af` (focus on step advance) | RESOLVED by `2b692cab` | Dismiss as housekeeping. |
+| `elspeth-obs-a076365f64` (test-file fixture extraction P3, Phase 8) | Open | Out of scope — polish. |
+| `elspeth-obs-510a4fbdeb` (TurnPayload discriminated-union refactor) | Open | Out of scope — no urgency. |
+| `elspeth-obs-f9e991f517` (useNonInitialEffect hook extraction) | Open | Out of scope — no urgency. |
+| `elspeth-2c08408170` (Step-3 backend handler) | Open + Phase 9 deferral note | Out of scope — gates Phase 11's Task 9.2. |
+| `elspeth-5e905f3c9d` (referenced in `MultiSelectWithCustomTurn.tsx` original NOTE) | RESOLVED by Bug 2 fix `a5df0b6c` | Verify it's marked closed in filigree; close as housekeeping if not. |
+| `elspeth-611fc01d94` (GuidedHistory rich step summaries — Phase 7) | Open | Out of scope — cosmetic, polish. |
+
+## Important constraints (do not relitigate)
+
+Inherited from CLAUDE.md and prior handovers:
+
+- **DB migration = delete the DB.** No Alembic, no schema-version probes, no migration scripts. Phase 9 added a strict `from_dict` field; pre-Phase-9 sessions crash on load — this is intentional.
+- **Default to worktree.** Stay in `/home/john/elspeth/.worktrees/composer-guided-mode`; do not work in main.
+- **No git stash.** Commit work to a branch if preservation is needed.
+- **No calendar shipping commitments.** Phase 10 ships work-until-done.
+- **Correctness beats performance always.** If the demo SLA fails post-Gap-6, fix the underlying UX latency — don't lower the budget.
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **`any` is forbidden in TypeScript.**
+- **No optimistic updates.** Server is authoritative.
+- **snake_case wire field names; camelCase store-internal.**
+- **ESLint broken; rely on vitest + tsc + Playwright.**
+- **Symbol-anchored cross-references in comments**, never `Filename.tsx:LL-LL`.
+- **No PR-open BEFORE Task 10.3.** The umbrella PR is the close action.
+- **Doc-only commits use `git commit --no-verify`** (markdown-only changes don't need CI hooks per `feedback_doc_only_commits_no_ci`).
+
+## First action when you start Phase 10
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline 80cab3b6..HEAD | head -10                            # confirm Phase 9 close + handovers
+cd src/elspeth/web/frontend
+npm test -- --run                                                      # expect 418 / 418 pass
+npx tsc -p tsconfig.app.json --noEmit                                  # expect clean
+npx playwright test composer-guided                                    # expect 3 passed, 10 skipped
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/unit/web/composer/guided/ tests/integration/web/composer/guided/ -q | tail -5
+.venv/bin/python -m mypy src/ 2>&1 | tail -3
+```
+
+If any baseline gate fails, stop and investigate.
+
+Then make three decisions, in order:
+
+1. **Gap 6 wire-shape design:** read `_RECIPE1_SLOTS` and `RecipeOfferPayload`; confirm the suggested `unsatisfied_slots: tuple[RecipeSlotInput, ...]` shape is appropriate, OR adjust based on what slot specs actually carry. The wire shape is the convention-14 anchor — get it right before any other surface adapts.
+
+2. **Convention 14 site list:** before dispatching Task 10.0, finalize the per-site checklist (the suggested list above is a starting point; investigate `explain_validation_error` and the audit schema to confirm whether they're in the touch set or not). The dispatch brief is malformed without the complete list — convention 14 explicitly requires it.
+
+3. **PR-open mechanics:** confirm the PR target is `main` and the branch is `feat/composer-guided-mode`; verify no inadvertent side branches need merging in first; draft vs non-draft (default non-draft).
+
+## How to dispatch Phase 10 implementers
+
+Phase 10 has fewer dispatches than Phase 9 (which had ~6) because the work is bounded:
+
+1. **One dispatch for Task 10.0 + 10.0b** (Gap 6 + un-fixme + verify SLA) — the largest dispatch in Phase 10 by far. This is multi-component and the per-site checklist must be enforced. Use a capable model.
+2. **One dispatch for Tasks 10.1 + 10.2** (docs + CHANGELOG) — small, doc-focused. Cheap model is fine. Can be combined with the close handover writing if scope is small enough.
+3. **One dispatch for Task 10.3** (umbrella PR) — smallest; PR description writing + `gh pr create` invocation. Could be done by the controller directly rather than dispatched.
+
+Per the SDD discipline established in Phase 9, EACH code-touching dispatch (Task 10.0 here) gets:
+- Spec compliance review (focused on convention 14 site coverage)
+- Code quality review (standard)
+- Re-review on any fix-up
+
+Doc-touching dispatches (10.1, 10.2) can use a lighter review — read the diff, confirm the prose is clear and references match reality, ship.
+
+The Phase 10 close handover should be similar in shape to Phase 9's: list all commits, gates verified at close, observations dismissed/promoted, what Phase 11 (if any) inherits, and convention reminders carried forward.
+
+---
+
+The advisor consulted at Phase 9 close said: *"Phase 9's value is making Phase 10 small."* Phase 10 inherits one tight target (Gap 6) plus the original Phase 10 docs/PR work. If you find yourself dispatching more than three or four times, stop and reassess — Phase 10 should be a small, clean phase compared to Phase 9.

--- a/docs/superpowers/handovers/2026-05-12-phase-5-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-5-complete.md
@@ -1,0 +1,199 @@
+# Handover — Composer Guided Mode (Phase 5 complete; Phase 6 onward)
+
+## TL;DR
+
+Phase 5 is **complete and green**. The backend feature set is closed:
+auto-drop on solver-exhausted, progressive-disclosure transition prompt on
+mode shift, full session-level audit emission coverage. Demo path runs
+end-to-end with audit events backing every protocol decision.
+
+Phases 6–10 ship the frontend. Phase 6 is the foundational layer:
+TypeScript types mirroring the backend protocol, `apiClient` methods for
+`/guided/start` and `/guided/respond`, and a `sessionStore` slice for
+guided session state.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (36 commits ahead of RC5.2 as of Phase 5 close; top commit `8c0f7527`)
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results.
+- **Package manager:** `uv` only.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 6 starts line 3866, ends line 4189)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (Phase 6 relevant: §6.2 endpoints, §7.1–§7.3 component layout / state management, §11 out-of-scope)
+
+## What's delivered in Phase 5
+
+Seven commits on top of Phase 4 closure (`89286d0d`):
+
+| Commit | Task | What |
+|--------|------|------|
+| `8c132210` | 5.1 | Auto-drop on solver-exhausted — repair attempt via `solve_chain(repair_context=…)`; on repair-also-fails → `mark_solver_exhausted` + `emit_dropped_to_freeform`; HTTP 200 with terminal |
+| `84705d3c` | 5.1 | Spec-§9.1 fix: `guided_dropped_to_freeform` payload field renamed `step_index` → `prev_step` (audit-naming bug pre-existed; Task 5.1 first call site to surface it); `validation_result` always populated on solver_exhausted |
+| `49be61ae` | 5.1 | Code-quality polish: `assert` → `raise RuntimeError` (production invariants survive `-O`); `_DATA_ERROR_KEY` constant in `tools.py`; docstring trims |
+| `8bfd9f66` | 5.2 | Progressive-disclosure transition prompt: `build_mode_transition_system_prompt`; `_load_freeform_skill` (lru-cached); `transition_consumed` field on `GuidedSession`; gate + flip in `send_message` handler |
+| `407cb089` | 5.2 | `Any | None` → `TerminalState | None` at 4 protocol/service sites (TYPE_CHECKING import); recompose handler symmetric gap closure (gate + flip + `guided_session` in `composer_meta`) |
+| `21d970d7` | 5.2 | Code-quality polish: hoist lazy imports in `build_messages`; docstring trim; test imports normalised |
+| `8c0f7527` | 5.3 | Full-session audit emission tests: 6 tests across recipe-match happy path + auto-drop path; assert spec §9.1 contract |
+
+### Gate state at handover
+
+- **1748 tests pass** across `tests/integration/web/composer/`, `tests/unit/web/composer/`, `tests/unit/web/sessions/`
+- **163 guided tests** specifically (up from 141 at Phase 4 close — 22 new across Tasks 5.1-5.3)
+- mypy clean on `src/elspeth/web/composer/` and `src/elspeth/web/sessions/routes.py`
+- ruff clean
+- `enforce_tier_model.py check`: clean (FPs rotated three times this phase — at Task 5.1 polish, Task 5.2 initial, Task 5.2 type/recompose fix)
+- `enforce_freeze_guards.py check`: clean
+
+### End-to-end demo capability (post Phase 5)
+
+The wizard now drives:
+1. Step 1: Source resolution (CSV / JSON / etc) via `_execute_set_source`
+2. Step 2: Sink resolution (JSONL / JSON / CSV / etc) via `_execute_set_output`
+3. Step 2.5: Recipe pre-match against (source, sink) — if match, apply recipe + auto-advance to COMPLETED
+4. Step 3: LLM chain proposal via `solve_chain` (when no recipe match) → user accept → commit + COMPLETED
+5. Step 3 failure modes: chain validation fails → one LLM repair attempt → if repair also fails, auto-drop with `TerminalReason.SOLVER_EXHAUSTED`
+6. Manual exit via `control_signal=exit_to_freeform` at any step
+7. Progressive disclosure: any subsequent freeform chat turn after any non-None terminal (including COMPLETED) uses the layered guided-skill + transition-message + freeform-skill prompt for ONE turn, then reverts to freeform-only
+
+All seven flows emit the spec §9.1 audit events: `guided_turn_emitted`, `guided_turn_answered`, `guided_step_advanced`, `guided_dropped_to_freeform`.
+
+## What's pending — Phase 6 onward
+
+Phase 6 is the frontend foundation. Read the plan body at lines 3866–4189 but expect drift — the same pattern as Phases 4 and 5.
+
+### Task 6.1 — TypeScript types mirroring the backend protocol (plan line 3872)
+
+Create `src/elspeth/web/frontend/src/types/guided.ts` with TypeScript mirrors of:
+- `TurnType` enum (`inspect_and_confirm | single_select | multi_select_with_custom | schema_form | propose_chain | recipe_offer`)
+- `Turn`, `TurnResponse`, `ControlSignal` types
+- `GuidedSession`, `TerminalState`, `TerminalKind`, `TerminalReason`
+- `GuidedRespondResponse`, `GetGuidedResponse`, `GuidedStartResponse` (the HTTP response shapes — read from `routes.py`'s pydantic response models around lines 3863+ to find canonical shapes)
+
+Add a vitest type-assertion test at `src/elspeth/web/frontend/src/types/guided.test.ts`.
+
+**Reality check needed before starting:** the backend's HTTP response shapes are pydantic models (e.g., `GuidedRespondResponse` at routes.py). Open them and verify exact field names + nullability before drafting the TS mirrors. The spec §6.2 example is approximate; the running pydantic models are the canonical contract.
+
+### Task 6.2 — API client methods (plan line 4016)
+
+Add `postGuidedStart(sessionId)` and `postGuidedRespond(sessionId, turnResponse)` methods to the existing frontend `apiClient`. Existing API methods in `apiClient` are the pattern reference. Vitest tests with `msw` (already in use) for mocking the HTTP calls.
+
+### Task 6.3 — `sessionStore` guided slice (plan line 4096)
+
+Add a `GuidedSlice` to the existing zustand store:
+```typescript
+interface GuidedSlice {
+  guidedSession: GuidedSession | null;
+  startGuided: (sessionId: string) => Promise<void>;
+  respondGuided: (turnResponse: TurnResponse) => Promise<void>;
+  exitToFreeform: (reason: ExitReason) => Promise<void>;
+}
+```
+
+**No optimistic updates** — server is authoritative. Every action posts to the corresponding endpoint and replaces the local `guidedSession` with the server response.
+
+### Phase 6 exit criterion (plan line 3870)
+
+> "Vitest store-slice tests pass; types compile cleanly; manual smoke against the running backend (curl the start endpoint, assert the store updates)."
+
+The store-slice tests are unit-level (no real HTTP). Manual smoke is a one-off check against the running `elspeth.foundryside.dev` staging service or a locally-running `elspeth-web` (per project memory `project_staging_deployment.md`).
+
+## Plan-vs-reality gotchas observed in Phase 5 (use these to gut-check Phase 6 plan body)
+
+The same drift patterns from Phase 4 continued into Phase 5. Phase 6 will likely show:
+
+| Plan says | Reality (probable) |
+|-----------|---------------------|
+| `chaosllm_stub` fixture | Does not exist (Phases 4+5 confirmed). Frontend tests will be vitest + msw, not chaosllm. |
+| Endpoint module paths in `service.py` | Endpoints live in `routes.py`; `service.py` carries the LLM-orchestration logic. |
+| Lazy imports with `# avoid cycle` comments | Banned per CLAUDE.md "Shifting the Burden" — check for actual cycles first; almost never present. Verified in Phase 5 (zero new lazy imports needed in the code we wrote). |
+| `audit_recorder.guided_events()` | Does not exist. Audit-event tests use `service.get_messages(...)` + `role=="tool"` + filter by `invocation.tool_name`. Pattern established in `test_auto_drop.py` and `test_audit_emission.py`. |
+| Type annotations using `Any | None` for protocol parameters | Anti-pattern — silently disables mypy checking. Use `TerminalState | None` (or whatever concrete type) with a TYPE_CHECKING import. `from __future__ import annotations` is already in effect across the composer codebase. |
+| Plan body specifies one file but the change actually spans multiple files | Common — Phase 5's Task 5.2 brief said "service.py" but the work spanned `composer/prompts.py`, `composer/guided/prompts.py`, `composer/state_machine.py`, `composer/protocol.py`, `composer/service.py`, `routes.py` plus two test files. Phase 6's frontend work will likely span types, apiClient, sessionStore, and component files. |
+
+## Open follow-ups carried out of Phase 5
+
+These are flagged for future work — NOT blocking Phase 6 start:
+
+1. **`_replace_dc` 4-site lazy-import normalisation** — `routes.py` has 4 instances of `from dataclasses import replace as _replace_dc` inside function bodies. The pre-existing pattern was kept (out of Task 5.2 scope per CLAUDE.md "don't refactor beyond what the task requires"). One-pass cleanup recommended in a future hygiene ticket.
+2. **`ValidationSummary.to_dict()` consolidation** — three call sites construct `{"is_valid": ..., "errors": [e.to_dict() for e in ...]}` independently. Code-quality reviewer recommended adding a method on `ValidationSummary`. Out of Task 5.1 scope (would touch `tools.py` and several call sites); flagged for future cleanup.
+3. **`emit_turn_emitted` / `emit_turn_answered` field-name parity audit** — Task 5.1 fixed `step_index` → `prev_step` on `guided_dropped_to_freeform` only. The other two `step_index`-using event types are spec-correct (per spec §9.1 they describe a turn within a step, not a transition), but worth a pass to confirm.
+4. **Filigree observation `elspeth-obs-2bbdb1ddba`** — filed by the Task 5.2 implementer about the recompose handler gap, but the gap was fixed in commit `407cb089`. The observation is stale; can be dismissed by the next session via `mcp__filigree__dismiss_observation`.
+
+## Conventions discovered in Phase 5 (follow these)
+
+### Backend dispatcher (`routes.py::_dispatch_guided_respond`)
+
+- Returns `(state, session, next_turn)` tuple.
+- For mid-dispatch terminal transitions (e.g., auto-drop), emit the audit event INLINE inside `_dispatch_guided_respond` — the outer handler's directive-fan-out (around routes.py:3960-3989) only handles directives from `step_advance()`, not mid-dispatch terminations.
+- Use `mark_solver_exhausted(...)` to construct the terminal + directives, then iterate the directive list and call the matching `emit_*` helper (the only directive type at the auto-drop site is `guided_dropped_to_freeform`, but mirroring the outer-handler pattern keeps the audit-emission shape consistent).
+
+### Audit-emission tests
+
+- Read events via `service.get_messages(session_id, limit=None)` filtered by `role=="tool"`.
+- For each tool message, walk `msg.tool_calls` and inspect each `tc["invocation"]`.
+- `invocation["tool_name"]` is the discriminator (one of `{guided_turn_emitted, guided_turn_answered, guided_step_advanced, guided_dropped_to_freeform}`).
+- `invocation["arguments_canonical"]` is a JSON-encoded payload dict — `json.loads(...)` it to inspect arguments.
+- Constants for the four guided event discriminators are typed `frozenset[str]` (see `test_audit_emission.py:37-44`).
+
+### Stubbing LiteLLM
+
+- Patch path is `elspeth.web.composer.guided.chain_solver._litellm_acompletion` for the Step 3 chain-solver path.
+- Patch path is `elspeth.web.composer.service._litellm_acompletion` for the freeform composer path.
+- Use `unittest.mock.AsyncMock` (NOT `MagicMock` — async functions need `AsyncMock`).
+- Fake response shape is attribute-access SimpleNamespace (NOT dict): `SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[SimpleNamespace(function=SimpleNamespace(name=..., arguments=json.dumps({...})))]))])`. The `arguments` field is a JSON-encoded STRING, not a dict.
+
+### Type discipline
+
+- Protocol parameters MUST have concrete types, never `Any | None`. Use TYPE_CHECKING imports when a concrete type would cause a runtime circular dependency. `from __future__ import annotations` is already enabled across the composer codebase, so all annotations are strings at runtime — TYPE_CHECKING imports are sufficient.
+- `assert` is for type narrowing only. For runtime invariants that must survive `-O`, use explicit `if … raise RuntimeError(...)`.
+
+### Frozen dataclass schema additions
+
+- Adding a field to a frozen dataclass like `GuidedSession`: add the field with a default (e.g., `transition_consumed: bool = False`), update `to_dict()` to serialize it, update `from_dict()` to read it WITHOUT a backward-compat default (per `project_db_migration_policy.md`: delete the DB on schema change).
+- If the dataclass has `freeze_fields(...)` in `__post_init__`, scalar fields don't need to be added to the freeze list. Only container fields (`dict`, `list`, `Mapping`, `Sequence`) require deep-freeze enforcement.
+
+## CI gates (run before declaring any task done)
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/integration/web/composer/guided/ tests/unit/web/composer/guided/ -v
+.venv/bin/python -m pytest tests/unit/web/sessions/ tests/unit/web/composer/ tests/integration/web/composer/ -q
+.venv/bin/python -m mypy src/elspeth/web/composer/ src/elspeth/web/sessions/routes.py
+.venv/bin/python -m ruff check src/elspeth/web/composer/ src/elspeth/web/sessions/ tests/integration/web/composer/guided/
+.venv/bin/python scripts/cicd/enforce_tier_model.py check --root src/elspeth --allowlist config/cicd/enforce_tier_model
+.venv/bin/python scripts/cicd/enforce_freeze_guards.py check --root src/elspeth --allowlist config/cicd/enforce_freeze_guards
+```
+
+For frontend Phase 6 work, also:
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode/src/elspeth/web/frontend
+npm test -- --run                # vitest
+npx tsc --noEmit                  # TypeScript type-check
+npx eslint src/                   # frontend linting
+```
+
+## First action when you start
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline RC5.2..HEAD | head -10                  # expect 36 commits, top = 8c0f7527
+.venv/bin/python -m pytest tests/integration/web/composer/guided/ tests/unit/web/composer/guided/ tests/unit/web/sessions/ -q   # expect 1742 passed
+```
+
+If the baseline isn't clean (1748 across the broader suite, 163 in `tests/integration/web/composer/guided/`), **stop and investigate** before starting Phase 6 — the handover may be stale or someone else may have touched the branch.
+
+Then: read Phase 6 in the plan (lines 3866–4189), spot-check the plan-vs-reality gotchas table above (especially the canonical pydantic response model shapes in `routes.py`), and dispatch the Task 6.1 implementer with a brief that overrides the plan body where it diverges from reality.
+
+Expect to dispatch 3 implementer subagents (one per Phase 6 task) plus reality-verification grep work between each.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic; no migration scripts; no `from_dict` backward-compat defaults.
+- **Default to worktree.** You're already in one; stay here.
+- **No git stash.** Commit work to a branch if you need to preserve it.
+- **Don't recommend `slog` as a diagnostic channel.** Audit/telemetry first per CLAUDE.md primacy order.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done; ADR SLAs are governance devices, not deadlines.
+- **Correctness beats performance always.** Don't frame correctness work as a perf tradeoff.
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **Type annotations must be concrete.** `Any | None` for protocol parameters is forbidden — silently disables mypy. Use TYPE_CHECKING imports for forward references.

--- a/docs/superpowers/handovers/2026-05-12-phase-5-start.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-5-start.md
@@ -1,0 +1,214 @@
+# Handover — Composer Guided Mode (Phase 5 onward)
+
+## TL;DR
+
+You're inheriting a green branch with Phase 4 just landed. Phases 1–4 are complete (protocol + state machine + HTTP endpoints + LLM chain solver + Step 3 wiring). Phases 5–10 remain. **Phase 5 is the backend closer**: three tasks delivering auto-drop on solver-exhausted, progressive-disclosure system prompt on mode transition, and a full-session audit emission test. After Phase 5 the backend is feature-complete and Phases 6+ ship the frontend.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (29 commits ahead of RC5.2 as of Phase 4 close)
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — it'll fail tier-model checks because Python versions can mismatch (`project_tier_model_python_version.md`).
+- **Package manager:** `uv` (never `pip` directly). Editable install: `uv pip install -e ".[all]" --python /home/john/elspeth/.worktrees/composer-guided-mode/.venv/bin/python`.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 5 starts line 3685, ends 3863)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (relevant: §5.3 manual exit, §5.4 auto-drop, §8.2 progressive disclosure, §9.1 audit events)
+
+## Read these BEFORE writing any code
+
+1. **The plan's Errata block** — lines 15–158 of the plan. Ten corrections (C1–C10) some of which still apply (C3 routes location, C5 module-level frontend functions, C6 sessionStore single atomic guidedTurn — relevant to Phase 6 only).
+2. **CLAUDE.md at the repo root.** Especially Three-Tier Trust Model, Plugin Ownership, Defensive Programming Forbidden / Offensive Programming Encouraged, and No-Legacy-Code policy.
+3. **Recent project memory** — `MEMORY.md` in your auto-memory dir. Especially `project_phase4_implementation_complete.md` (predecessor handover with architectural notes), `project_phase3_implementation_complete.md`, `project_tier_model_python_version.md`, `feedback_default_is_fix_not_ticket.md`, `feedback_no_scope_dumping.md`, `feedback_correctness_beats_performance.md`.
+
+## What's delivered (Phase 4 — don't redo)
+
+5 commits on top of Phase 3 closure (`795477d2`):
+
+| Commit | Task | What |
+|--------|------|------|
+| `e0217edc` | 4.1 | Guided skill prompt (80 lines exactly) + `prompts.py` loader with `@lru_cache(maxsize=1)` |
+| `94c768ac` | 4.2 | `build_step_3_context_block(*, source, sink, recipe_match) -> str` in `prompts.py` |
+| `c0867f58` | 4.3 | `src/elspeth/web/composer/guided/chain_solver.py` — `async def solve_chain(*, source, sink, recipe_match=None) -> ChainProposal` wrapping `_litellm_acompletion` |
+| `c87633be` | 4.4 | `handle_step_3_chain_accept` in `steps.py` — atomic commit via `_execute_set_pipeline` with source.on_success rewired to `"chain_in"` |
+| `89286d0d` | 4.5 | Step 3 dispatcher wiring in `routes.py` at 3 seams + 33-FP rotation in `web.yaml` |
+
+Gate state at handover:
+- **495 tests pass** (136 guided + 359 sessions)
+- mypy clean on `src/elspeth/web/composer/`
+- ruff clean
+- `enforce_tier_model.py check`: clean
+- `enforce_freeze_guards.py check`: clean
+
+**Demo path works end-to-end**: CSV source → JSON sink (no recipe match) → LLM-proposed transform chain → user accept → terminal=COMPLETED with rendered YAML.
+
+## What's still pending — Phase 5 scope
+
+Phase 5 has **three tasks**. Read the plan body at lines 3685–3863 but expect drift (see "Plan-vs-reality gotchas" below).
+
+### Task 5.1 — Auto-drop on solver-exhausted (plan lines 3691–3729)
+
+**Trigger:** User accepts a chain proposal at Step 3 (chosen=["accept"]) but `handle_step_3_chain_accept` returns `tool_result.success=False` — the chain failed `_execute_set_pipeline`'s internal validation.
+
+**Current behavior (Phase 4):** `routes.py` raises `HTTPException(400, "Step 3 chain commit failed: ...")`. This is the seam Task 5.1 replaces.
+
+**Phase 5 behavior:**
+1. On preview failure, capture the validation error from `tool_result`.
+2. Call `solve_chain` again with the error injected into the GUIDED CONTEXT block (a "repair this — previous attempt failed with: …" addendum).
+3. Run `handle_step_3_chain_accept` against the repair proposal.
+4. If the repair also fails: call `mark_solver_exhausted(session, validation_result=...)` (already exists at `state_machine.py:583`) and emit the `guided_dropped_to_freeform` audit event via `emit_dropped_to_freeform` (already exists at `audit.py`). The session's `terminal` becomes `TerminalState(kind=EXITED_TO_FREEFORM, reason=SOLVER_EXHAUSTED, pipeline_yaml=None)`.
+5. Return the terminal in the HTTP response (200, not 4xx — the wizard concluded cleanly via auto-drop).
+
+**Architectural decision the next session must make:** how does the repair attempt inject the validation error into the prompt? Two options:
+- **(a)** Extend `solve_chain` signature with `repair_context: str | None = None` and have `prompts.py` build a separate context block. Cleaner separation; touches the chain_solver public surface.
+- **(b)** Build a wrapper function in `routes.py` that constructs the repair prompt inline and passes it as an extra system message to `_litellm_acompletion`. Keeps `chain_solver.py` simple but duplicates the prompt-building logic.
+
+My recommendation is **(a)** — chain_solver is the right home for "talk to the LLM about a chain", and adding one optional parameter is cheap. But verify against spec §5.4 before committing; it may specify the prompt structure.
+
+### Task 5.2 — Progressive-disclosure transition prompt (plan lines 3730–3814)
+
+**Trigger:** Any freeform chat message sent after `composition_state.guided_session.terminal is not None` — the user is now in freeform mode but this is their first turn after exit.
+
+**What to build:**
+1. `build_mode_transition_system_prompt(*, terminal_reason: str) -> str` in `prompts.py`. Returns the layered prompt: `[guided skill] + [transition message] + [freeform skill]`. Plan body at lines 3776–3792 gives the structure verbatim — the transition message is short, mentions `LIFTED` protocol restrictions, and includes the terminal reason. Spec §8.2 line 515–528 has the canonical text.
+2. `_load_freeform_skill()` helper in `prompts.py` — loads `web/composer/skills/pipeline_composer.md` (the existing 1747-line freeform skill). `@lru_cache(maxsize=1)`.
+3. Wire into the freeform chat endpoint. The endpoint is in `routes.py` (NOT `service.py` — plan body is wrong about location). When `composition_state.guided_session != None` AND `guided_session.terminal != None` AND we haven't yet emitted the transition prompt for this terminal, swap the freeform skill for `build_mode_transition_system_prompt(...)` for **the next chat turn only**.
+4. Track "transition consumed" — the spec says first-turn-after-transition only. Use a flag in the session record OR check message history for the transition marker. The cleanest is to add a `transition_consumed: bool` field to `GuidedSession` (requires schema migration awareness — see `project_db_migration_policy.md`: delete the DB, no Alembic).
+
+**Reality check needed:** find the freeform chat endpoint. Search `routes.py` for `send_message` and `ComposerServiceImpl.compose`. The existing freeform skill is loaded somewhere in that path — that's the swap site.
+
+### Task 5.3 — Phase 5 closure: full audit emission test (plan lines 3816–3860)
+
+**Test only — no implementation.** Two integration tests:
+1. **Recipe match happy path** — drive a full session through recipe acceptance, assert the recorder contains `guided_turn_emitted`, `guided_turn_answered`, `guided_step_advanced`, and NOT `guided_dropped_to_freeform`.
+2. **Auto-drop path** — drive a session through Step 3 with a chain solver that fails twice (Task 5.1 path), assert `guided_dropped_to_freeform` appears with `drop_reason="solver_exhausted"`.
+
+The plan uses `audit_recorder.guided_events()` — that method may not exist. Use the actual `audit_recorder.invocations` API and filter for `tool_name in {"guided_turn_emitted", "guided_turn_answered", "guided_step_advanced", "guided_dropped_to_freeform"}`. The audit shape is `ComposerToolInvocation` per errata C4 (no separate guided audit primitive).
+
+### Phase 5 exit criterion (plan line 3689)
+
+> "A failing chain-solver path drops to freeform with the partial pipeline carried; a freeform chat turn after transition includes the `[freeform skill]` content + transition message and the LLM emits a non-guided tool call."
+
+The freeform-tool-emission half requires a live LLM (or a careful stub). The stubbed version is sufficient for Phase 5 closure — verify the LLM is given the right system prompt; the LLM's actual response shape isn't load-bearing for closure.
+
+## Plan-vs-reality gotchas observed in Phase 4 (use these to gut-check Phase 5 plan body)
+
+The plan body had substantial drift on every Phase 4 task. Phase 5's body has similar patterns — verify before quoting.
+
+| Plan says | Reality |
+|-----------|---------|
+| `chaosllm_stub` fixture | **Does not exist.** Use `patch("elspeth.web.composer.guided.chain_solver._litellm_acompletion", new_callable=AsyncMock, return_value=fake_response)`. Plan still references `chaosllm_stub` in Phase 5. |
+| Routes mount / dispatcher in `service.py` | Dispatcher is `_dispatch_guided_respond` in `src/elspeth/web/sessions/routes.py:~1554` (line may shift; grep for the function name) |
+| `update-fingerprints` subcommand of `enforce_tier_model.py` | **Does not exist.** Tool only has `check` and `dump-edges`. FP rotation is manual in `web.yaml` |
+| Plain LiteLLM response is dict-shaped | **Wrong.** Attribute access via `_FakeLLMResponse` shape. See `chain_solver.py:_extract_tool_call` for the canonical parser |
+| `audit_recorder.guided_events()` | Probably **does not exist.** Use `recorder.invocations` and filter on `tool_name` |
+| `_execute_*(state, args)` positional shape | **Wrong order.** Real: `_execute_*(args, state, catalog, data_dir, *, session_engine?, session_id?) -> ToolResult` |
+| Lazy import with "# avoid cycle" comment | **Banned** by CLAUDE.md ("Shifting the Burden"). Check for actual cycle first; almost never present |
+
+## Phase 5–specific seams already documented in the code
+
+Task 5.1's seam is at **routes.py STEP_3_TRANSFORMS dispatcher branch**. Find the `if not handler_result.tool_result.success:` block in the new Step 3 ACCEPT branch (added in commit `89286d0d`). That's where the repair-then-drop logic plugs in.
+
+Task 5.2's seam is in the **freeform chat path**. The Phase 4 commits did NOT touch this path — find `send_message` in routes.py and trace to where the freeform skill is concatenated into the system prompt for `_litellm_acompletion`. Likely in `ComposerServiceImpl.compose` in `service.py`.
+
+The two **other** 501 raises in routes.py (user-reject, clarifying-question at Step 3) are NOT Phase 5 scope. Leave them alone. They cover legitimate gaps in the wizard and the spec doesn't define their behavior. They can be addressed in a future task or stay as 501s.
+
+## Conventions discovered in Phase 4 (follow these)
+
+### Backend step handlers (steps.py)
+
+- Signature: `def handle_step_N(*, state, session, ..., catalog: CatalogService, data_dir: str | None = None, session_engine: Engine | None = None, session_id: str | None = None) -> StepHandlerResult`. Keyword-only. The session_engine/session_id are needed for executors that touch the session DB (Step 2.5 and Step 3 do via `_execute_set_pipeline`).
+- On failure: return `StepHandlerResult(state=state, session=session, tool_result=tool_result)` — entry state unchanged.
+- On success: return `StepHandlerResult(state=tool_result.updated_state, session=dataclasses.replace(session, ...), tool_result=tool_result)`.
+- Use `dataclasses.replace`, never `_replace` helper.
+
+### Backend dispatcher (routes.py `_dispatch_guided_respond`)
+
+- async function (Phase 4 confirmed this; await works inside).
+- Pattern: handle each (`current_step`, `current_turn_type`, `guided.step`) tuple with explicit branches. The unhandled fall-through raises `AssertionError("_dispatch_guided_respond: unhandled branch ...")` at the bottom — add new branches above it.
+- Audit emission: build `TurnRecord(...)` and `emit_turn_emitted(recorder, ..., emitter="server")` together when emitting a server-side turn. Mirror routes.py:1882–1899 pattern.
+- For step advances: `emit_step_advanced(recorder, prev_step=..., next_step=..., reason=...)` where `reason ∈ {"recipe_applied", "user_advanced", "auto_advanced"}` (closed set, see `audit.py:_VALID_ADVANCE_REASONS`).
+
+### Audit event types (spec §9.1)
+
+Four guided audit events, all emitted as `ComposerToolInvocation` records with `tool_name` discriminator (errata C4):
+- `guided_turn_emitted`
+- `guided_turn_answered`
+- `guided_step_advanced`
+- `guided_dropped_to_freeform`
+
+Helpers in `src/elspeth/web/composer/guided/audit.py`: `emit_turn_emitted`, `emit_turn_answered`, `emit_step_advanced`, `emit_dropped_to_freeform`. They take a `recorder: ComposerToolRecorder` and build the invocation internally.
+
+### Test patterns
+
+- **Integration tests** live in `tests/integration/web/composer/guided/`. Fixtures `composer_test_client` (SyncASGITestClient) and `audit_recorder` (exposes `recorder.invocations`) live in `conftest.py`.
+- **Stubbing LiteLLM**: `patch("elspeth.web.composer.guided.chain_solver._litellm_acompletion", new_callable=AsyncMock, return_value=fake_response)`. The patch path is in `chain_solver`, not `service`, because chain_solver imports the name into its namespace.
+- **Fake LiteLLM response shape**: `SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[SimpleNamespace(function=SimpleNamespace(name=..., arguments=json.dumps(...)))]))])`. The arguments field is a JSON string, not a dict.
+- **Real state for Step 3 tests**: chain `handle_step_1_source` → `handle_step_2_sink` → exercise; don't reconstruct CompositionState by hand.
+
+### TDD via subagents
+
+Use the subagent-driven-development skill or dispatch via Agent. Per-task brief should:
+1. Reality-verify every signature, fixture, and import path before drafting (grep first).
+2. State plan-vs-reality overrides explicitly.
+3. Provide the test specification IN the brief.
+4. List CI gates with explicit exit codes required.
+
+Model selection: Haiku for mechanical tasks; Sonnet for tasks involving schema decisions, prompt design, or LLM-touching code.
+
+## Tier-model fingerprint rotation procedure
+
+Adding imports at the top of `routes.py` (or other files) **will** rotate AST fingerprints in `config/cicd/enforce_tier_model/web.yaml`. The procedure:
+
+1. Run `enforce_tier_model.py check` — capture failing keys.
+2. Grep existing `web.yaml` entries for the same file.
+3. **Count parity per `<file>:<rule>:<context>` prefix:** N_failing must equal N_existing. If `N_failing > N_existing`, a NEW violation slipped in — STOP and review. If `N_failing < N_existing`, some allowlist entries are obsolete — delete them.
+4. Map old fp= → new fp= per prefix (any permutation valid when N==k>1; same allowlist semantics).
+5. Replace each `fp=<old>` substring with `fp=<new>` in `web.yaml`. Append `; FP rotated by <reason>` to the `reason:` field (replacing any prior `; FP changed after ruff-format` annotation — don't stack).
+6. Re-run check, must exit 0.
+
+Phase 4 Task 4.5 rotated 33 fingerprints; reusable script in commit `89286d0d`'s commit message. The tool's "Allowlist key:" hint in the failure output is the source of truth for the new fp=.
+
+## CI gates (run before declaring any task done)
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/integration/web/composer/guided/ tests/unit/web/composer/guided/ -v
+.venv/bin/python -m mypy src/elspeth/web/composer/ src/elspeth/web/sessions/routes.py
+.venv/bin/python -m ruff check src/elspeth/web/composer/ src/elspeth/web/sessions/
+.venv/bin/python scripts/cicd/enforce_tier_model.py check --root src/elspeth --allowlist config/cicd/enforce_tier_model
+.venv/bin/python scripts/cicd/enforce_freeze_guards.py check --root src/elspeth --allowlist config/cicd/enforce_freeze_guards
+.venv/bin/python -m pytest tests/unit/web/sessions/ -q  # regression check (359 baseline)
+```
+
+## Open follow-ups carried from Phase 4 (not blocking Phase 5)
+
+1. **Real-LLM gated test deferred.** `pytest.mark.real_llm` is unregistered; no `--run-real-llm` CLI flag; no CI lane. Pre-existing gap — the demo runs real-LLM interactively, not in CI.
+2. **Pre-existing `getattr(request.app.state, "session_compose_lock_registry", None)` at routes.py:~162.** Same CLAUDE.md violation as the I1 closeout in Phase 3 fixed elsewhere. Worth a hygiene ticket but not new.
+3. **`_build_get_guided_turn` is function-local inside `create_session_router`.** If Phase 5 or 6 needs it from elsewhere, promote to module-level first.
+
+## First action when you start
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline RC5.2..HEAD | head -10        # verify branch state (expect 29 commits, top = 89286d0d)
+.venv/bin/python -m pytest tests/unit/web/composer/guided/ tests/integration/web/composer/guided/ tests/unit/web/sessions/ -q   # confirm green baseline (expect 495 passed)
+```
+
+If the baseline isn't 495 passing and CI gates aren't clean, **stop and investigate** before adding anything — the handover may be stale or someone else may have touched the branch.
+
+Then: read Phase 5 in the plan (lines 3685–3863), spot-check the plan-vs-reality gotchas table above, decide on Task 5.1's repair-prompt architecture (option (a) vs (b) above), and dispatch the Task 5.1 implementer with a brief that explicitly overrides the plan body where it diverges from reality. Pay particular attention to:
+
+- The seam in `routes.py`'s STEP_3_TRANSFORMS dispatcher branch (added in `89286d0d`) — that's where Task 5.1 plugs in.
+- The fake LiteLLM response shape for the repair-attempt test (mirror `test_chain_solver.py::test_returns_chain_proposal` exactly).
+- Audit emission: the auto-drop event is `guided_dropped_to_freeform` via `emit_dropped_to_freeform` helper, with `drop_reason="solver_exhausted"`.
+
+Expect to dispatch 3 implementer subagents (one per Phase 5 task) plus reality-verification grep work between each. Phase 5 should close in fewer tasks than Phase 4 because it has half the deliverables.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic, no migration scripts. If you add a field to `GuidedSession` for Task 5.2's `transition_consumed`, the operator deletes the old sessions DB. See `project_db_migration_policy.md`.
+- **Default to worktree.** You're already in one; stay here.
+- **No git stash.** The prohibition was lifted per `feedback_no_git_stash.md` but the underlying caution remains — commit work to a branch if you need to preserve it.
+- **Don't recommend `slog` as a diagnostic channel.** Audit/telemetry first per CLAUDE.md primacy order.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done; ADR SLAs are governance devices, not deadlines.
+- **Correctness beats performance always.** Don't frame correctness work as a perf tradeoff.
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.

--- a/docs/superpowers/handovers/2026-05-12-phase-6-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-6-complete.md
@@ -1,0 +1,138 @@
+# Handover — Composer Guided Mode (Phase 6 complete; Phase 7 onward)
+
+## TL;DR
+
+Phase 6 is **complete and green**. The frontend foundation is closed:
+TypeScript types mirroring the backend pydantic protocol, two `apiClient`
+free functions wrapping `GET /api/sessions/:id/guided` and `POST
+/api/sessions/:id/guided/respond`, and three new fields + three new
+actions on the flat `useSessionStore` zustand store. Server-authoritative
+atomic 4-field replace pattern is wired into both `startGuided` and
+`respondGuided`. Three new test files (10 + 5 + 8 = 23 new tests) ride
+alongside the implementation; full vitest suite is 211 / 211 green.
+
+Phases 7–10 ship the React widget surface on top of this foundation:
+turn-type widgets, the `GuidedTurn` dispatcher, the chat-pane integration,
+the e2e Playwright lane, and the operator UX polish.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (42 commits ahead of RC5.2 as of Phase 6 close; top commit `cc074420`)
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results.
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). `vitest` is the test runner. The canonical typecheck is `npx tsc -p tsconfig.app.json --noEmit` — NOT `npx tsc --noEmit` at the root (which trips on pre-existing tsconfig composite-project misconfiguration).
+- **ESLint is broken** on this worktree due to v9 flat-config migration debt — not Phase 6's job to fix. Don't run `npx eslint src/`; rely on vitest + tsc for the per-task gate.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 7 starts line ~4190)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (Phase 7 relevant: §7.1–§7.3 component layout, §10 e2e flow)
+- **Inbound handover:** `docs/superpowers/handovers/2026-05-12-phase-6-start.md` — the Phase 6 brief; references back to Phase 5 close.
+
+## What's delivered in Phase 6
+
+Six commits on top of Phase 5 closure (`8c0f7527`):
+
+| Commit | Task | What |
+|--------|------|------|
+| `80bee5dd` | 6.1 feat | TypeScript types in `src/types/guided.ts` mirroring `schemas.py:213-296` + `protocol.py` enums + `state_machine.py` terminal enums; `step_index: number` verified against `emitters.py:_step_index` (0-based ordinal); both response envelopes include `composition_state` (the handover-original missed it). Test file with 10 type-assertion tests. |
+| `a01cd69e` | 6.1 fix-up | `TurnRecord.emitter: "server" | "llm"` closed union (was open `string`; verified against `state_machine.py:75-82` + 15 producer sites in `routes.py`). `GuidedSession`-keys exhaustiveness test replaced with compile-time `Equals<A,B>` mutual-extends check (the prior `Keys[]` tuple form was inert — silently green on field drift). Two trivially-true runtime assertions sharpened. |
+| `f4fd3c94` | 6.2 feat | Two free async functions in `client.ts` — `getGuided(sessionId, signal?)` and `respondGuided(sessionId, body, signal?)` — mirroring the existing `sendMessage`/`recompose` convention. Both pass `AbortSignal` through to `fetch`. First `src/api/*.test.ts` file in the codebase: 5 tests via `vi.spyOn(globalThis, "fetch")`. |
+| `9617a5f1` | 6.2 fix-up | File-level strategy banner in `client.guided.test.ts` explaining producer-side spy vs. consumer-side `vi.mock` (locks the convention for future API tests). `fetchSpy` lifecycle hoisted into an outer describe to remove byte-identical duplication across inner suites. Raw-string body assertion replaced with parsed-shape `toEqual` check (JSON key ordering is incidental). |
+| `20662208` | 6.3 feat | Three new state fields (`guidedSession`, `guidedNextTurn`, `guidedTerminal`) + three new actions (`startGuided`, `respondGuided`, `exitToFreeform`) added directly to the flat `SessionState` interface — no slice composition. Server-authoritative 4-field atomic replace on each action (includes `compositionState` from response). `respondGuided` throws on null `activeSessionId` (offensive programming per CLAUDE.md). Wired into all three session-transition clear sites (`createSession`, `selectSession`, `archiveSession`) so guided state cannot leak across session switches. New consumer-side test file with 8 tests including the cross-session-leak regression guard. |
+| `cc074420` | 6.3 fix-up | Dead unreachable string-match re-throw removed from `respondGuided`'s catch block (the offensive guard fires before `try` — the catch can only see network errors, never the guard's literal). Section marker added to the guided action block. Interface field declarations relocated to sit adjacent to companion actions, restoring the `state + companion-action` pairing convention. |
+
+### Gate state at close
+
+- **Vitest:** 211 / 211 pass (29 test files; +23 from Phase 5 baseline of 188)
+- **`npx tsc -p tsconfig.app.json --noEmit`:** clean
+- **Backend pytest** (narrow guided + sessions slice): 522 / 522 pass — unchanged from Phase 5 close (Phase 6 is frontend-only)
+- **Backend mypy** on `src/elspeth/web/composer/` + `src/elspeth/web/sessions/routes.py`: clean
+- **ESLint:** not run — broken on this worktree (v9 flat-config migration debt); pre-existing infra issue unrelated to Phase 6
+
+### Per-task review iteration count (data point for future planning)
+
+| Task | Implementer dispatches | Why iteration was needed |
+|------|------------------------|---------------------------|
+| 6.1 | 2 (initial + fix-up) | Code-quality reviewer caught inert exhaustiveness test (`Keys[]` form passed on field drift) and open `emitter: string` symmetry-break with `step`/`turn_type` |
+| 6.2 | 2 (initial + fix-up) | Convention-setting test file: missing file-level strategy comment, duplicated `beforeEach`/`afterEach` across describe blocks, raw-string body assertion brittle to key reordering |
+| 6.3 | 2 (initial + fix-up) | Unreachable dead code in catch block (string-match re-throw after offensive guard already exited the function); missing section marker; interface field placement broke pairing |
+
+Pattern: every Phase 6 task needed exactly one fix-up cycle. Both reviewers (spec + code-quality) ran on each cycle. Spec compliance passed first time on all three tasks; code-quality findings drove every fix-up.
+
+## End-to-end frontend capability (post Phase 6)
+
+Phase 6 lands no UI — it is purely the data-plane foundation. After Phase 6:
+
+1. Frontend can fetch the active guided session via `getGuided(sessionId)` → returns `GuidedSession`, `TurnPayload` (the next turn), `TerminalState`, and `CompositionState`.
+2. Frontend can post a typed `GuidedRespondRequest` via `respondGuided(sessionId, body)` and atomically replace cached state from the response.
+3. The store exposes the guided state for component subscription: `useSessionStore.guidedSession`, `.guidedNextTurn`, `.guidedTerminal`.
+4. Session switches and resets clear guided state cleanly (regression-tested).
+5. The `exitToFreeform()` shortcut posts a `control_signal: "exit_to_freeform"` payload — the backend handles the progressive-disclosure transition.
+
+No widget exists yet. The next chat turn through the existing freeform UI is unchanged — guided mode is only reachable programmatically until Phase 7 wires it into the UI.
+
+## What's pending — Phase 7 onward
+
+Phase 7 builds the React widget surface — one component per `TurnType`, plus the `GuidedTurn` dispatcher that routes by `guidedNextTurn.type`. Plan body starts at line ~4190 (`Task 7.1: GuidedTurn dispatcher`).
+
+## Final cross-task review notes (decisions, not open questions)
+
+A final cross-task reviewer was run after the three per-task review cycles. They surfaced five items framed as "Phase 7 readiness gaps." After CLAUDE.md scrutiny, **three were rejected as speculative or wrong, one was deferred to Phase 7's natural scope, and one is a deferrable nit**. Recording the reasoning so Phase 7's author doesn't relitigate:
+
+1. **Rejected — "Add `isGuided: boolean` selector to the store."** Speculative API design. CLAUDE.md: "Don't design for hypothetical future requirements. Three similar lines is better than a premature abstraction." We have zero call sites today. Phase 7's first widget will reveal the actual selector shape needed (could be `isGuided`, could be `isInStep1`, could be a `useGuidedTurn()` hook — we don't yet know). Until then, `state => state.guidedSession !== null` at the call site is the honest answer.
+
+2. **Rejected — "Re-export `guided.ts` types from `@/types/api` for a single barrel convention."** The barrel premise is false: the codebase already imports types from three paths today (`@/types/api`, `@/types/index`, and now `@/types/guided`). `sessionStore.ts:11` uses `@/types/api`; `client.ts:33` uses `@/types/index`. There is no single-barrel convention to consolidate to. The Task 6.1 brief explicitly decided to leave `guided.ts` self-contained — a 7th commit reversing that for a stylistic preference is churn, not correctness. Phase 7 components can import from `@/types/guided` directly; if a future cleanup wants to merge barrels, that's its own discrete task.
+
+3. **Rejected — "JSDoc warning on the `respondGuided` store action about the name collision with `client.respondGuided`."** Cheap one-liner but the collision is not load-bearing: the store implementation uses `api.respondGuided` via the `import * as api` alias, and component code will never reach into `@/api/client` directly — it'll use the store action via `useSessionStore`. The architectural separation is enforced by import structure, not by comments. If Phase 7 author somehow imports `client.respondGuided` directly into a component, that's a code-review catch, not a comment-prevention concern.
+
+4. **Deferred to Phase 7 — Error messages lack session-id context.** `startGuided` and `respondGuided` produce generic "Failed to load / submit" strings on failure. Phase 7 wires up the error-banner component; that's the right time to add session-id context for support triage. Premature in Phase 6 (no consumer yet).
+
+5. **Deferred (minor nit) — Cross-reference comment in `sessionStore.guided.test.ts` pointing to the test-strategy banner in `client.guided.test.ts`.** Genuinely cheap, genuinely low-value: a Phase 7 author touching either file will absorb the pattern naturally. Not worth a 7th commit.
+
+The verdict from the final reviewer was **READY-WITH-NOTES** — Phase 7 can start. The "notes" above are the decisions, not the open questions.
+
+## Phase 7 starting brief
+
+Read this in conjunction with the plan file's Phase 7 section.
+
+### Convention reminders inherited from Phase 6
+
+1. **Types module is `@/types/guided`.** Import there directly: `import type { TurnPayload, TurnType, GuidedRespondRequest } from "@/types/guided"`. Don't plumb a re-export through `types/api.ts` unless the Phase 7 work has an independent reason to consolidate.
+2. **The store is flat, not slice-composed.** Add fields and actions directly to `SessionState` in `sessionStore.ts`. The Phase 6 path is the template; do not introduce slice abstractions.
+3. **Producer tests use `vi.spyOn(globalThis, "fetch")`. Consumer tests use `vi.mock("@/api/client")`.** The strategy banner is in `client.guided.test.ts:1-14`. Component tests for Phase 7 widgets are consumers of the store, so they'll mock `@/stores/sessionStore` similarly — different module, same pattern.
+4. **Atomic 4-field replace from server response.** Any new action that calls a guided endpoint replaces `guidedSession`, `guidedNextTurn`, `guidedTerminal`, AND `compositionState` in a single `set({...})` call. No optimistic updates (spec §7.3).
+5. **Offensive programming on null `activeSessionId`.** Any new store action that requires a session must `throw new Error("…")` on null, not silent early-return, not `?.` defend.
+6. **`payload: unknown`** on `TurnPayload` discriminates only at the consumer. Phase 7 widgets will discriminate via `guidedNextTurn.type` (the `TurnType` enum) and narrow `payload` to the per-turn-type shape declared in `protocol.py` (`InspectAndConfirmPayload`, `SingleSelectPayload`, etc). Consider whether per-payload TS interfaces should land in `guided.ts` during Phase 7 — likely yes — but discover the right ergonomic shape from the first widget rather than pre-defining all six.
+
+### Plan-vs-reality drift expected in Phase 7
+
+The plan body has shown drift in every prior phase. Expect the same in Phase 7:
+
+- The plan likely shows class-based React components. Existing convention is hooks-based function components.
+- The plan likely references `apiClient.x` calls. Reality is bare named imports.
+- The plan likely shows `compositionState` accessed as `state.composition_state`. Reality is `state.compositionState` on the store (camelCase) but `state.composition_state` from the wire response (snake_case) — the store transcribes during the 4-field replace.
+
+The implementer dispatch brief for each Phase 7 task should pre-emptively override these.
+
+### First action when you start Phase 7
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline 8c0f7527..HEAD                          # expect 6 commits, top = cc074420
+cd src/elspeth/web/frontend
+npm test -- --run                                          # expect 211 / 211 pass
+npx tsc -p tsconfig.app.json --noEmit                      # expect clean
+```
+
+If any baseline gate fails, **stop and investigate** before starting Phase 7.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic; no migration scripts; no `from_dict` backward-compat defaults. (Phase 6 didn't touch the DB — but the constraint applies if Phase 7 somehow finds itself there.)
+- **Default to worktree.** Stay here; do not work in `/home/john/elspeth` main.
+- **No git stash.** Commit work to a branch if preservation is needed.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done.
+- **Correctness beats performance always.**
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **`any` is forbidden in TypeScript.** Use `unknown` for opaque, closed unions or interfaces otherwise.
+- **No optimistic updates.** Server is authoritative.
+- **snake_case wire field names in interfaces; camelCase store-internal fields.** Established in Phase 6.
+- **ESLint is broken on this worktree.** Don't try to fix it inside Phase 7 unless a separate task is opened for the v9 flat-config migration.

--- a/docs/superpowers/handovers/2026-05-12-phase-6-start.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-6-start.md
@@ -1,0 +1,323 @@
+# Handover — Composer Guided Mode (Phase 6 onward)
+
+## TL;DR
+
+You're inheriting a green branch with Phase 5 just landed. Phases 1–5 are complete (backend feature-complete: protocol + state machine + HTTP endpoints + LLM chain solver + auto-drop + progressive disclosure + audit-emission tests). Phases 6–10 ship the frontend.
+
+**Phase 6 is the frontend foundation**: three tasks delivering TypeScript types mirroring the backend protocol, two `apiClient` functions for the guided endpoints, and a guided slice added to the existing `sessionStore`. Phase 6 is the smallest of the frontend phases — Phases 7+ build the React widget surface on top of it.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (36 commits ahead of RC5.2 as of Phase 5 close)
+- **Top commit:** `8c0f7527`
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results.
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). Vitest is the test runner; Playwright drives e2e but isn't needed for Phase 6. The TypeScript checker is `tsc --noEmit` (NOT a wrapper script). Lint is `eslint src/`.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 6 starts line 3866, ends line 4189)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (Phase 6 relevant: §6.2 endpoints, §7.1–§7.3 component layout / state management)
+- **Inbound handover:** `docs/superpowers/handovers/2026-05-12-phase-5-complete.md` — read it first; covers Phase 5 deliverables and the conventions the backend established.
+
+## Read these BEFORE writing any code
+
+1. **CLAUDE.md** at the worktree root. Frontend code is held to the same standards as backend: No-Legacy-Code policy applies, no `try/catch` swallowing errors, no defensive `?.` chains over fields you control, etc. The Three-Tier Trust Model translates to the frontend as: backend response shapes are Tier 1 (trust the pydantic strict-validated response) and user input is Tier 3 (validate before posting).
+
+2. **The canonical pydantic response models** at `src/elspeth/web/sessions/schemas.py` lines 213–296. **These are the ground truth for the wire shapes** — your TypeScript types must mirror them exactly, not the plan body's illustrative samples (the plan body has drift; see below).
+
+3. **The plan body's Phase 6 sample code (lines 3866–4189) contains substantial drift.** Trust the actual code paths over the plan samples. Section "Plan-vs-reality" below enumerates every divergence I've spotted; verify the rest by reading before drafting.
+
+4. **Recent project memory** — your auto-memory dir. Especially `project_phase5_implementation_complete.md` (predecessor handover with architectural notes), `project_phase4_implementation_complete.md`, `feedback_default_is_fix_not_ticket.md`, `feedback_no_scope_dumping.md`.
+
+## What's delivered (Phases 1–5 — don't redo)
+
+Phase 5 (this branch's most recent work) added 7 commits on top of Phase 4 closure (`89286d0d`):
+
+| Commit | Task | What |
+|--------|------|------|
+| `8c132210` | 5.1 feat | Auto-drop on solver-exhausted |
+| `84705d3c` | 5.1 fix | `step_index` → `prev_step` audit-payload spec-§9.1 fix |
+| `49be61ae` | 5.1 polish | `assert` → `raise`; `_DATA_ERROR_KEY` constant; docstring trims |
+| `8bfd9f66` | 5.2 feat | Progressive-disclosure transition prompt |
+| `407cb089` | 5.2 fix | `Any` → `TerminalState` typing; recompose handler gap closure |
+| `21d970d7` | 5.2 polish | Hoist lazy imports; docstring trim |
+| `8c0f7527` | 5.3 | Full-session audit emission tests (6 tests) |
+
+**Gate state at handover:**
+- 1748 backend tests pass (163 in `tests/integration/web/composer/guided/`)
+- mypy clean on `src/elspeth/web/composer/` and `src/elspeth/web/sessions/routes.py`
+- ruff clean
+- `enforce_tier_model.py check`: clean
+- `enforce_freeze_guards.py check`: clean
+
+**Demo path runs end-to-end** through the backend: CSV source → JSON sink → (recipe match OR LLM-proposed chain with auto-drop on failure) → COMPLETED terminal with rendered YAML. Audit events back every protocol decision per spec §9.1.
+
+## Frontend project structure (orient first)
+
+```
+src/elspeth/web/frontend/
+├── package.json                         # npm scripts: "test" (vitest run), "test:watch", "test:e2e"
+├── src/
+│   ├── api/
+│   │   ├── client.ts                    # 719 lines; module of EXPORTED FREE FUNCTIONS (NOT a class)
+│   │   └── websocket.ts                 # WebSocket bindings (not relevant for Phase 6)
+│   ├── stores/
+│   │   ├── sessionStore.ts              # 575 lines; single zustand store (NOT a slice composition pattern)
+│   │   ├── sessionStore.test.ts         # existing pattern for store tests
+│   │   ├── executionStore.ts            # another zustand store — read for convention reference
+│   │   ├── authStore.ts                 # auth state
+│   │   ├── blobStore.ts                 # blob handling
+│   │   ├── secretsStore.ts
+│   │   └── subscriptions.ts
+│   ├── types/
+│   │   ├── api.ts                       # existing API type definitions (your new guided.ts joins here)
+│   │   ├── index.ts                     # re-exports
+│   │   └── runStatus.test.ts            # vitest pattern for type tests
+│   ├── components/                      # Phase 7+ work (not Phase 6)
+│   ├── hooks/
+│   ├── styles/
+│   └── ...
+└── tests/playwright/                    # E2E (Phase 9 work, not Phase 6)
+```
+
+## What's still pending — Phase 6 scope
+
+Phase 6 has **three tasks**. Plan body at lines 3866–4189 but expect drift on every task (see "Plan-vs-reality" below).
+
+### Task 6.1 — TypeScript types mirroring the backend protocol (plan lines 3872–4014)
+
+Create `src/elspeth/web/frontend/src/types/guided.ts` with TS mirrors of the pydantic models. Add a vitest type-assertion test at `src/elspeth/web/frontend/src/types/guided.test.ts`.
+
+**Canonical sources of truth** (READ THESE before drafting types):
+
+- `src/elspeth/web/sessions/schemas.py:213-296` — pydantic response models:
+  - `TurnRecordResponse`, `TerminalStateResponse`, `GuidedSessionResponse`, `TurnPayloadResponse`, `GetGuidedResponse`, `GuidedRespondRequest`, `GuidedRespondResponse`
+- `src/elspeth/web/composer/guided/protocol.py:77-110` — backend enums:
+  - `TurnType` (6 values), `ControlSignal` (3 values), `GuidedStep` (4 values)
+- `src/elspeth/web/composer/guided/state_machine.py:29-50` — `TerminalKind` (2 values), `TerminalReason` (3 values: `user_pressed_exit | protocol_violation | solver_exhausted` — NOT `completed_pipeline`; that's a prompt-rendering string, not a wire value)
+
+**Critical wire-shape correctness items:**
+
+1. `Turn.step_index` is **`int`**, NOT a string like `"step_1_source"`. The wire transmits 1, 2, 3, or some integer mapping. **VERIFY** by reading `build_*_turn` helpers (e.g., `build_step_1_source_inspect_turn` in routes.py around line 3000+) — find one such function and check what int it puts into `step_index`. Mirror exactly in TS. (Plan body shows `step_index: string` — that's WRONG.)
+
+2. `GuidedSessionResponse` wire fields are **only `step`, `history`, `terminal`**. It does NOT carry `step_1_result`, `step_2_result`, or `step_3_proposal` (those are internal server state). Plan body's `GuidedSession` interface (lines 3971–3984) is WRONG on this — strip those fields.
+
+3. `TerminalState.reason` is `TerminalReason | null`. The four-value union in the plan body (`"user_pressed_exit" | "protocol_violation" | "solver_exhausted" | null`) is correct. **Do NOT include `"completed_pipeline"`** — that's a prompt-rendering literal used in `build_mode_transition_system_prompt`, not a wire value. When `kind=COMPLETED`, `reason` is `null`.
+
+4. `GuidedRespondRequest.control_signal` is `string | null` on the wire (per the pydantic schema's comment: "stale clients sending an unknown signal value fail gracefully"). On the TS side, type it `ControlSignal | null` to enforce client-side discipline; the server still validates.
+
+5. `step` field on `GuidedSessionResponse` is the string enum (`"step_1_source"` etc.), NOT an int. Unlike `Turn.step_index` (int), the session's current step pointer comes back as the string value of `GuidedStep`.
+
+**There is NO `GuidedStartResponse` shape.** Plan body uses one; reality has only `GetGuidedResponse` (returned from `GET /api/sessions/{id}/guided`) and `GuidedRespondResponse` (returned from `POST /api/sessions/{id}/guided/respond`). There is no `/guided/start` endpoint — see Task 6.2 reality below.
+
+### Task 6.2 — API client methods (plan lines 4016–4094)
+
+Add two functions to `src/elspeth/web/frontend/src/api/client.ts`. The plan body shows class-based methods (`apiClient.postGuidedStart`); **reality is a module of exported free functions**. Mirror the existing pattern from `sendMessage` (client.ts:277) and `recompose` (client.ts:298).
+
+**Critical endpoint-path correctness:**
+
+| Plan body says | Reality |
+|----------------|---------|
+| `POST /composer/guided/start` | **DOES NOT EXIST.** Initial fetch is `GET /api/sessions/{session_id}/guided` (returns `GetGuidedResponse`) — no separate "start" endpoint. |
+| `POST /composer/guided/respond` | Wrong path. Reality: `POST /api/sessions/{session_id}/guided/respond` |
+| `apiClient.postGuidedStart` class method | Reality: bare `export async function getGuided(sessionId)` returning `Promise<GetGuidedResponse>` |
+| `apiClient.postGuidedRespond` class method | Reality: bare `export async function respondGuided(sessionId, turnResponse)` returning `Promise<GuidedRespondResponse>` |
+
+**Convention to mirror (from `sendMessage` at client.ts:277):**
+
+```typescript
+export async function getGuided(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<GetGuidedResponse> {
+  const response = await fetch(`/api/sessions/${sessionId}/guided`, {
+    method: "GET",
+    headers: authHeaders(),
+    signal,
+  });
+  return parseResponse<GetGuidedResponse>(response);
+}
+
+export async function respondGuided(
+  sessionId: string,
+  turnResponse: TurnResponse,
+  signal?: AbortSignal,
+): Promise<GuidedRespondResponse> {
+  const response = await fetch(`/api/sessions/${sessionId}/guided/respond`, {
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify(turnResponse),
+    signal,
+  });
+  return parseResponse<GuidedRespondResponse>(response);
+}
+```
+
+**VERIFY** by reading the actual request schema: the POST `/guided/respond` body shape is `GuidedRespondRequest` (schemas.py:264), which has the same fields as `TurnResponse` (chosen, edited_values, custom_inputs, accepted_step_index, edit_step_index, control_signal). So passing `turnResponse` directly as the body is correct IF the TS `TurnResponse` type matches the pydantic `GuidedRespondRequest` shape exactly (which it should after Task 6.1).
+
+**Helpers already in client.ts:**
+
+- `authHeaders(contentType?: string): HeadersInit` at line 47 — injects auth bearer token. Pass `"application/json"` for POST/PUT bodies; pass nothing for GET.
+- `parseResponse<T>(response: Response): Promise<T>` at line 73 — handles non-OK responses by throwing `ApiError`, parses JSON otherwise.
+
+**Test pattern** (mirror `sessionStore.test.ts` or look for `client.test.ts` if it exists):
+
+The plan body uses `vi.spyOn(globalThis, "fetch")` — that's the right pattern. Mock the response shape, assert the URL + body + headers, assert the parsed return value.
+
+### Task 6.3 — `sessionStore` guided slice (plan lines 4096–4186)
+
+The plan body assumes a **zustand slice composition pattern** (separate `GuidedSlice` interface merged into a multi-slice store). **Reality is a single flat zustand store**: `useSessionStore = create<SessionState>((set, get) => ({...}))` at sessionStore.ts:120.
+
+**Real approach:** Add fields to the existing `SessionState` interface (sessionStore.ts:74) and actions to the existing `create()` body. Don't introduce a new "slice" abstraction — it'll be inconsistent with the rest of the store.
+
+**Fields to add to `SessionState`:**
+
+```typescript
+guidedSession: GuidedSessionResponse | null;
+guidedNextTurn: TurnPayloadResponse | null;   // server's next-turn, replaced atomically
+guidedTerminal: TerminalStateResponse | null; // mirror of guidedSession.terminal for fast access
+```
+
+Note the types are the **wire response types** (`GuidedSessionResponse`, `TurnPayloadResponse`), not the spec-level abstract types. The store holds what the server sent.
+
+**Actions to add:**
+
+```typescript
+startGuided: (sessionId: string) => Promise<void>;       // calls getGuided (GET /guided)
+respondGuided: (turnResponse: TurnResponse) => Promise<void>;  // calls respondGuided POST
+exitToFreeform: () => Promise<void>;                     // shortcut: respondGuided with control_signal
+```
+
+**Implementation guidance:**
+
+- After each call, **replace** `guidedSession`, `guidedNextTurn`, and `guidedTerminal` from the server response. **No optimistic updates** — server is authoritative (spec §7.3).
+- `exitToFreeform` is sugar for `respondGuided({ control_signal: "exit_to_freeform", chosen: null, edited_values: null, ... })`. All other fields null.
+- The existing `activeSessionId` field in `SessionState` is where `respondGuided` reads the session ID. If it's null, throw — that's an offensive programming check (invariant: no respond without an active session).
+- Per CLAUDE.md offensive programming, **don't use `?.` chains** to defend against null sessionId — throw a `RuntimeError`-equivalent (`throw new Error("respondGuided called without active session")`).
+
+**Test pattern** (look at `sessionStore.test.ts` for convention):
+
+- Use `vi.spyOn(apiClient, "getGuided")` and `respondGuided` — but `apiClient` is the module namespace. Import like:
+  ```typescript
+  import * as apiClient from "../api/client";
+  vi.spyOn(apiClient, "getGuided").mockResolvedValue(...);
+  ```
+- Reset store state in `beforeEach` via `useSessionStore.setState({ guidedSession: null, ... })`.
+- Assert state shape after each action.
+
+### Phase 6 exit criterion (plan line 3870)
+
+> "Vitest store-slice tests pass; types compile cleanly; manual smoke against the running backend (curl the start endpoint, assert the store updates)."
+
+The "manual smoke" is a one-off check against the running `elspeth.foundryside.dev` staging service or local `elspeth-web` (per project memory `project_staging_deployment.md`). Not load-bearing for Phase 6 closure — the vitest + tsc gates are the mechanical criterion.
+
+## Plan-vs-reality gotchas observed (verified before this handover)
+
+| Plan body says | Reality |
+|----------------|---------|
+| Endpoint paths `/composer/guided/start` and `/composer/guided/respond` | `GET /api/sessions/{id}/guided` and `POST /api/sessions/{id}/guided/respond`. There is no separate "start" endpoint — GET handles initial fetch. |
+| `class ApiClient` with `this._post<T>(...)` helper | `client.ts` is a module of free `export async function fooBar()` — `_post` does NOT exist. Use `fetch(...)` + `authHeaders()` + `parseResponse<T>()`. |
+| `apiClient.postGuidedStart(...)` import as object | Bare named import: `import { getGuided, respondGuided } from "@/api/client"`. |
+| `Turn.step_index: string` (`"step_1_source"`) | `int` on the wire. Verify with `build_*_turn` helpers in routes.py. |
+| `GuidedSession.step_1_result / step_2_result / step_3_proposal` on the wire | These DO NOT cross the boundary. `GuidedSessionResponse` has only `step`, `history`, `terminal`. |
+| `TerminalState.reason` includes `"completed_pipeline"` | NO. Wire enum is `user_pressed_exit | protocol_violation | solver_exhausted | null`. `"completed_pipeline"` is a prompt-rendering literal. |
+| zustand "slice" pattern with separate `GuidedSlice` interface | `sessionStore.ts` is a flat `create<SessionState>(...)` — add fields directly to `SessionState`, don't introduce slice composition. |
+| `useSessionStore.getState().startGuided("sess-1")` in tests | Real store-test pattern uses `useSessionStore.setState({...})` for setup and `useSessionStore.getState()` for invocations — verify in `sessionStore.test.ts`. |
+| Test sample showing `vi.spyOn(apiClient, "postGuidedStart")` | Need `import * as apiClient from "../api/client"` since the module exports free functions, not a class instance. |
+
+## Phase 6–specific conventions to follow
+
+### TypeScript type discipline
+
+- **Use the canonical pydantic response model field names verbatim** in TS interfaces (e.g., `guided_session` not `guidedSession` for wire shapes; `step_index` not `stepIndex`). The frontend reads JSON-decoded objects directly without camelCase transformation.
+- If you want camelCase at the consumer boundary (component code), provide a converter — but that's Phase 7+ work, not Phase 6.
+- For enum mirrors, use **string-literal union types** matching the backend's `StrEnum` values exactly:
+  ```typescript
+  export type ControlSignal = "exit_to_freeform" | "request_advisor" | "reject";
+  ```
+- `unknown` for genuinely opaque payloads (e.g., the `payload` inside `TurnPayloadResponse` which is shaped per turn type). Avoid `any` — it disables checking silently.
+
+### API function convention
+
+- Always pass `signal?: AbortSignal` as the last parameter, even if unused — mirrors `sendMessage` / `recompose` for retry-cancellation consistency.
+- Use `authHeaders()` for GET, `authHeaders("application/json")` for POST/PUT with bodies.
+- Always `return parseResponse<T>(response)` — never check `response.ok` manually. `parseResponse` throws on non-2xx.
+
+### zustand store convention
+
+- All mutations via `set({ ... })` — never mutate fields directly.
+- All reads via `get()` inside actions or via selector hooks at the call site.
+- Per CLAUDE.md offensive programming: throw on invariant violations (e.g., `activeSessionId` null when it shouldn't be), don't `?.` over them.
+
+### Test conventions
+
+- Vitest + `vi.spyOn` for HTTP mocks (no msw needed for these unit-level tests).
+- `beforeEach` resets store state to known clean values.
+- Each test exercises a single behavior; descriptive names that point to the broken behavior on failure.
+- Test imports at module top (mirrors `sessionStore.test.ts` — not per-method).
+
+## CI gates (run before declaring any task done)
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode/src/elspeth/web/frontend
+npm test -- --run                                                  # vitest unit tests
+npx tsc --noEmit                                                    # TypeScript type-check (no emit)
+npx eslint src/                                                     # ESLint
+
+# Plus the backend gates (must remain green — Phase 6 should not touch backend):
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+.venv/bin/python -m pytest tests/integration/web/composer/guided/ tests/unit/web/composer/guided/ tests/unit/web/sessions/ -q
+.venv/bin/python -m mypy src/elspeth/web/composer/ src/elspeth/web/sessions/routes.py
+.venv/bin/python scripts/cicd/enforce_tier_model.py check --root src/elspeth --allowlist config/cicd/enforce_tier_model
+.venv/bin/python scripts/cicd/enforce_freeze_guards.py check --root src/elspeth --allowlist config/cicd/enforce_freeze_guards
+```
+
+Phase 6 is frontend-only — the backend gates should stay green throughout (1748 tests, mypy/ruff/tier-model/freeze-guards all clean). If a backend gate flips red, something is wrong; investigate before continuing.
+
+The frontend lacks an enforce_tier_model-equivalent — TypeScript/ESLint coverage is shallower than the backend's CI scaffolding. Be especially vigilant about:
+- `any` types creeping in (eslint will warn but the warning is sometimes suppressed)
+- Missing null checks where pydantic shapes have `| None`
+- Unused imports / dead code
+
+## Open follow-ups (NOT blocking Phase 6)
+
+1. **`_replace_dc` 4-site lazy-import normalisation in routes.py.** Pre-existing pattern, out of Phase 5 scope. Future hygiene ticket.
+2. **`ValidationSummary.to_dict()` consolidation.** Three call sites duplicate the shape; recommended in Phase 5 code review. Out of scope for Task 5.1, deferred.
+3. **Stale filigree observation `elspeth-obs-2bbdb1ddba`.** Filed during Phase 5 about the recompose handler gap, but the gap was fixed in commit `407cb089`. Dismiss it via `mcp__filigree__dismiss_observation`.
+4. **Frontend types directory needs a re-export update.** When you add `types/guided.ts`, check `types/index.ts` and decide whether to re-export the new module from there. Look at how `types/api.ts` is exposed for the convention.
+
+## First action when you start
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline RC5.2..HEAD | head -10                # expect 36 commits, top = 8c0f7527
+.venv/bin/python -m pytest tests/integration/web/composer/guided/ tests/unit/web/composer/guided/ tests/unit/web/sessions/ -q   # expect ~1742 passed
+
+cd src/elspeth/web/frontend
+npm test -- --run                                       # expect all existing frontend tests passing
+npx tsc --noEmit                                        # expect clean
+```
+
+If any baseline gate fails, **stop and investigate** before starting Phase 6 — the handover may be stale or someone else may have touched the branch.
+
+Then:
+1. Read Phase 6 in the plan (lines 3866–4189) **alongside** the canonical sources of truth (pydantic schemas + backend enums). Note every plan-body divergence before writing TS.
+2. **Verify `Turn.step_index` actual wire value** — find a `build_*_turn` helper and see what `int` it returns. This is the one item I haven't verified end-to-end in this handover; the plan body has it wrong but I'm not certain whether the wire value is the int position (1, 2, 3) or some other mapping.
+3. Dispatch the Task 6.1 implementer (types + test) with a brief that explicitly overrides the plan body's interface samples with the pydantic shapes. Pay particular attention to:
+   - `Turn.step_index: number` (not string)
+   - `GuidedSession` shape stripped to `{ step, history, terminal }` only
+   - `TerminalReason` union excludes `"completed_pipeline"`
+   - No `GuidedStartResponse` type — only `GetGuidedResponse` and `GuidedRespondResponse`
+
+Expect to dispatch 3 implementer subagents (one per Phase 6 task). Each task is small (≤200 lines of new code) but each has multiple reality-overrides that the plan body won't surface.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic; no migration scripts; no `from_dict` backward-compat defaults. (Phase 6 doesn't touch the DB — but the constraint applies if you somehow find yourself there.)
+- **Default to worktree.** You're already in one; stay here.
+- **No git stash.** Commit work to a branch if you need to preserve it.
+- **Don't recommend `slog` as a diagnostic channel** (on the backend). The frontend has its own logging conventions — read existing components for the established pattern (probably `console.log`/`console.warn` for dev-only diagnostics).
+- **No calendar shipping commitments.** ELSPETH ships work-until-done.
+- **Correctness beats performance always.**
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **Type annotations must be concrete.** `any` in TypeScript is the moral equivalent of `Any | None` on the backend — silently disables checking. Use `unknown` for genuinely opaque payloads; use precise union types otherwise.
+- **No optimistic updates in the store** — server is authoritative for guided session state (spec §7.3).
+- **Don't camelCase wire field names in interfaces.** The pydantic shapes use `snake_case` and the JSON decoder doesn't transform them. Mirror exactly.

--- a/docs/superpowers/handovers/2026-05-12-phase-7-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-7-complete.md
@@ -1,0 +1,174 @@
+# Handover — Composer Guided Mode (Phase 7 complete; Phase 8 onward)
+
+## TL;DR
+
+Phase 7 is **complete and green**. The frontend widget surface is closed: six leaf turn-type widgets (`SingleSelectTurn`, `InspectAndConfirmTurn`, `MultiSelectWithCustomTurn`, `SchemaFormTurn`, `ProposeChainTurn`, `RecipeOfferTurn`), the `GuidedTurn` dispatcher routing all six, plus three peer components (`ExitToFreeformButton`, `GuidedHistory`, `CompletionSummary`). Twenty commits on top of `cc074420` deliver +193 frontend tests (211 → 404 cumulative), no critical or important issues, four cross-layer follow-ups durably tracked in Filigree, three deferred-polish observations, and zero unresolved blockers.
+
+Phase 8 (ChatPanel integration) wires these widgets into the freeform-vs-guided mode discriminator established in Phase 6. Phase 9 lands the Playwright E2E + demo-SLA assertions. Phase 10 closes documentation and CHANGELOG.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (62 commits ahead of `RC5.2` as of Phase 7 close; top commit `acf712d2`)
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results.
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). `vitest` is the test runner. The canonical typecheck is `npx tsc -p tsconfig.app.json --noEmit` — NOT `npx tsc --noEmit` at the root (which trips on pre-existing tsconfig composite-project misconfiguration).
+- **ESLint is broken** on this worktree due to v9 flat-config migration debt — not Phase 7's job to fix. Don't run `npx eslint src/`; rely on vitest + tsc for the per-task gate.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 8 starts line ~4457)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (Phase 8 relevant: §7.2 ChatPanel discriminator)
+- **Inbound handover:** `docs/superpowers/handovers/2026-05-12-phase-6-complete.md` — the Phase 7 brief; references back to Phase 5 close.
+
+## What's delivered in Phase 7
+
+Twenty commits on top of Phase 6 closure (`cc074420` + docs `d60f7797`):
+
+### Per-task commit summary
+
+| Task | Component | Commits | Notes |
+|------|-----------|---------|-------|
+| 7.2 | `SingleSelectTurn` (template) | `6703e47d` + `ee125918` (fix-up) | Establishes chip-group conventions: `<fieldset>`+`<legend>`, `aria-pressed`, `useId()` per-instance scoping, shared `nullResponse()` fixture, prefers-reduced-motion shared block. |
+| 7.3 | `InspectAndConfirmTurn` | `8c0427f3` + `afdbc245` (fix-up) | Establishes single-nullable-struct state pattern (collapsed `editorState: { columns } \| null`); focus management on view toggle via `firstRunRef`; aria-described warnings region relying on parent ChatPanel `aria-live`. |
+| 7.4 | `MultiSelectWithCustomTurn` | `0c5baeff` + `539a21df` (fix-up) | Reuses chip-group family with `aria-pressed` toggle visual extension. **Escape button deferred** — backend wire-shape contradiction (see Filigree follow-ups below). Custom-chip removal with focus restoration. |
+| 7.5 | `SchemaFormTurn` (largest widget) | `b0b88b8c` + `acd6c7f2` (self-fix-up) + `9548ef3f` + `283726d3` (3 review fix-ups) | Auto-generates form fields from Pydantic JSON Schema. Required-vs-advanced split with `aria-controls` resolving cross-state via `hidden` attribute (the canonical fix that GuidedHistory inherits). JSON-fallback for non-scalar types. Tier 2 numeric coercion (`""`/NaN → `null`). |
+| 7.6 | `ProposeChainTurn` (Accept-only) | `f27bf2e5` + `e54372fc` (fix-up) | Card-list layout introducing `guided-propose-step-card` (later shared with 7.7). **3 of 4 buttons deferred** — backend Step-3 handler partial (see follow-ups). Plugin name as `<h3>` for SR landmark navigation. |
+| 7.7 | `RecipeOfferTurn` | `375d5df2` | Card layout reusing `guided-propose-step-card`. **Wire-shape correction:** plan body said `edited_values: null` for Apply, backend at `routes.py:1965-1967` requires the recipe-data echo. Documented at three sites. |
+| 7.1 | `GuidedTurn` dispatcher | `a0fdea4b` + `48b485c7` (nullResponse alignment) | Routes six turn types via switch + exhaustiveness assertion. **Option A** (per-case `as` casts) chosen over Option B (discriminated union) — cascade rationale documented; refactor candidate filed as observation. |
+| 7.8 | `ExitToFreeformButton` | `e101b9ff` + `c6ed5795` (tautology removal) | Smallest widget (36 LOC). Self-contained; reads `exitToFreeform` from store directly; no-confirmation contract pinned with negative-space tests for `alertdialog`/`dialog`/`/cancel/i`. First widget to read action directly from store. |
+| 7.9 | `GuidedHistory` (step+type+emitter only) | `904bb4f6` + `1a578f5b` (tracker swap) | Collapsible read-only list. Inherits the 7.5 I2 `aria-controls`+`hidden` cross-state pattern (the canonical reason 7.5 I2 was fixed). **Rich summaries deferred** — backend `TurnRecordResponse` is hash-only by design (audit-trail integrity). |
+| 7.10 | `CompletionSummary` (FINAL) | `acf712d2` | Outer/inner component split for React hooks-rules compliance. Two buttons with **identical wire** semantics (verified at `state_machine.py:382-398`); UX-distinct labels with the wire-identity invariant pinned by tests. `prism-react-renderer` integration matches `YamlView.tsx` pattern. |
+
+### Gate state at close
+
+- **Vitest:** **404 / 404 pass** (39 test files; +193 from Phase 6 baseline of 211)
+- **`npx tsc -p tsconfig.app.json --noEmit`:** clean
+- **Backend pytest** (narrow guided + sessions slice): unchanged from Phase 6 close (Phase 7 is frontend-only — backend file modifications are zero)
+- **Backend mypy** on `src/elspeth/web/composer/` + `src/elspeth/web/sessions/routes.py`: clean (no Phase-7 changes)
+- **ESLint:** not run — broken on this worktree (v9 flat-config migration debt); pre-existing infra issue unrelated to Phase 7
+
+### Per-task review iteration count (data point for future planning)
+
+| Task | Implementer dispatches | Why iteration was needed |
+|------|------------------------|---------------------------|
+| 7.2 | 2 (initial + fix-up) | Code-quality reviewer caught template-quality items: missing `prefers-reduced-motion`, document-global IDs (`useId()` introduction), dead-defence keydown duplication, `nullResponse()` extraction to shared fixture. Critical to fix in template before 5 siblings copied. |
+| 7.3 | 2 (initial + fix-up) | Two-state encoding (`editing` boolean + `editedColumns` array) collapsed to single nullable struct (per CLAUDE.md "make-illegal-states-unrepresentable"); focus management on view toggle established the pattern; warnings `aria-live` relationship documented. |
+| 7.4 | 2 (initial + fix-up) | **Operator-adjudication mid-task:** backend mismatch on escape-button wire shape required Option C (drop the button + queue follow-up issue). Then standard fix-up: tracker-ID citation, focus-on-removal a11y, distinctness test rigor. |
+| 7.5 | 4 (initial + self-fix-up + review fix-up + I2 completion fix-up) | Most complex widget: implementer caught their own defensive `??` and tautological `errorId` in the second commit. Review surfaced Tier 2 numeric coercion bug (empty optional numeric → `""` to numeric slot) and `aria-controls`-references-non-existent-element bug. The I2 completion required a TDD Red→Green verification cycle that the reviewer independently confirmed by reverting and re-running. |
+| 7.6 | 2 (initial + fix-up) | **Operator-adjudication mid-task:** backend Step-3 handler is incomplete (consumes only `chosen: ["accept"]`); 3 of 4 planned buttons dropped + tracked. Then tracker-ID swap (observation → promoted issue) + heading semantics (`<span>` → `<h3>`). |
+| 7.7 | 1 (initial only) | Cleanest review pass: implementer corrected the plan-body's `edited_values: null` Apply submit to send the verified backend-required echo. Cross-task discipline. |
+| 7.1 | 2 (initial + nullResponse alignment) | Convention nit only: forwarding test used flat object literal instead of `...nullResponse()` spread-FIRST. Mechanical 5-line refactor. |
+| 7.8 | 2 (initial + tautology removal) | One genuine improvement: dropped the 9th test asserting "two simultaneous instances render distinct DOM nodes" (always true in React). Tests should earn their keep. |
+| 7.9 | 2 (initial + tracker swap) | Mid-task scope reduction (rich summaries → step+type+emitter only); fix-up swapped observation citation to promoted Filigree issue. |
+| 7.10 | 1 (initial only) | Wire-identity decision documented thoroughly; outer/inner hooks-rules split applied cleanly. No fix-up needed. |
+
+Pattern: every Phase 7 task either landed cleanly or needed exactly one iteration cycle. SchemaFormTurn (4 cycles) is the outlier — combinatorial surface (5 field types × 2 visibility states × prefill precedence × focus management × JSON-fallback) genuinely warrants the iteration. Three tasks (7.7, 7.10) cleared on first review pass — convention internalization paid off in the second half of the phase.
+
+## End-to-end frontend capability (post Phase 7)
+
+Phase 7 lands the full widget surface but does NOT integrate it into ChatPanel. After Phase 7:
+
+1. All six per-`TurnType` React widgets exist with matching prop signatures: `{ payload: <PerTypePayload>; onSubmit: (body: GuidedRespondRequest) => void }` (sync onSubmit; widgets construct full 6-field wire bodies).
+2. `GuidedTurn` dispatcher routes by `turn.type` to the matching widget; exhaustiveness assertion catches future TurnType additions at compile time.
+3. `ExitToFreeformButton` is rendered as a peer in ChatPanel (Phase 8 work); it reads `exitToFreeform` from the store and emits a parameterless action call.
+4. `GuidedHistory` is a peer that consumes `guidedSession.history` (the array of `TurnRecord` from Phase 6 store fields).
+5. `CompletionSummary` is a peer that renders when `terminal.kind === "completed"` and shows the YAML preview with two freeform-transition buttons.
+6. All widgets pass full `tsc -p tsconfig.app.json --noEmit` clean and 404/404 vitest tests.
+
+The chat surface (`ChatPanel.tsx`) is **unchanged**; guided mode is reachable only programmatically until Phase 8 wires it into the mode discriminator described in spec §7.2.
+
+## What's pending — Phase 8 onward
+
+Phase 8 wires the dispatcher + peer components into `ChatPanel.tsx` via the top-level mode discriminator. Plan body starts at line ~4457 (`Task 8.1: ChatPanel mode discriminator`).
+
+The integration sketch (per spec §7.2):
+
+```tsx
+if (guidedSession && !guidedSession.terminal) {
+  return (
+    <div className="chat-panel guided-mode">
+      <GuidedHistory history={guidedSession.history} />
+      {guidedNextTurn && (
+        <GuidedTurn turn={guidedNextTurn} onSubmit={(body) => respondGuided(body)} />
+      )}
+      <ExitToFreeformButton />
+    </div>
+  );
+}
+if (guidedSession?.terminal?.kind === "completed") {
+  return <CompletionSummary terminal={guidedSession.terminal} />;
+}
+return <ExistingChatPanelBody />;
+```
+
+Phase 9 lands Playwright E2E + the demo-SLA assertion. Phase 10 closes docs + CHANGELOG.
+
+## Cross-layer follow-ups (active Filigree issues)
+
+Three durably-tracked issues for Phase 5 backend completion work that surfaced during Phase 7 widget implementation:
+
+| Issue | Surface | Phase impact |
+|---|---|---|
+| **`elspeth-5e905f3c9d`** | `MultiSelectWithCustomTurn` escape button — wire shape (`{edited_values: {schema_mode, required_fields}}` per plan) contradicts backend `_advance_step_2` (reads `outputs[]` shape). Widget defers rendering. | Phase 9 demo path requires Step 2 escape if user wants to skip required-fields collection. Resolve before Phase 9 E2E. |
+| **`elspeth-2c08408170`** | `ProposeChainTurn` Step-3 backend handler completion (Reject + per-step Edit + Ask advisor). Backend `routes.py:2030-2137` consumes only `chosen: ["accept"]` (success) and `["reject"]` (501 stub). 3 of 4 planned buttons absent. | Phase 9 E2E cannot exercise Reject/Edit/Ask-advisor flows until backend lands. Hand-built path test (Task 9.2) will need the Edit button. |
+| **`elspeth-611fc01d94`** | `GuidedHistory` rich step summaries — wire `TurnRecordResponse` is hash-only by audit-trail design. Decision needed: wire extension (`summary` field) or payload-fetch endpoint. | Phase 8 ChatPanel integration ships hash-only history; Phase 9 demo can describe but not show "Step 1: CSV with cols [price, qty]" until this lands. |
+
+All three are likely best resolved as a single bundled "Phase 5 backend completion" task with three sub-deliverables. Phase 8 dispatch should consider whether to surface this bundling decision before starting widget integration.
+
+## Deferred-polish observations (non-blocking, 14-day expiry unless promoted)
+
+| Observation | Description |
+|---|---|
+| **`elspeth-obs-510a4fbdeb`** | `TurnPayload` discriminated-union refactor (Option B). Eliminates 6 `as` casts in `GuidedTurn.tsx`. Cascade cost: test fixtures in `client.guided.test.ts:71` and `sessionStore.guided.test.ts:54-56` use shorthand `payload: {options: [...]}` literals that need rewriting. Defer to post-Phase-8 cleanup. |
+| **`elspeth-obs-0a1002de6d`** | Phase 8 ChatPanel must suppress persistent `ExitToFreeformButton` when `terminal.kind === "completed"` — `CompletionSummary`'s "Drop to freeform to keep editing" button has wire-identical behavior; rendering both produces three identical-action buttons. Phase 8 implementer alert. |
+| **`elspeth-obs-f9e991f517`** | `useNonInitialEffect` hook extraction candidate. `firstRunRef` initial-mount-skip pattern landed in 7.3/7.4/7.5 (rule of three met). Cross-task reviewer recommended deferring past Phase 8 because 7.4's per-instance focus-target Map complicates a clean hook shape. |
+
+The first two should remain visible to the Phase 8 implementer; the third is a polish item. Promote any to durable issues as needed.
+
+## Phase 8 starting brief
+
+Read this in conjunction with the plan file's Phase 8 section.
+
+### Convention reminders inherited from Phase 7
+
+1. **Widget prop signature:** every leaf widget accepts `{ payload: <PerTypePayload>; onSubmit: (body: GuidedRespondRequest) => void }`. Sync onSubmit (NOT Promise — widgets construct bodies; the store action awaits). The dispatcher's prop is `{ turn: TurnPayload; onSubmit: (body: GuidedRespondRequest) => void }`.
+2. **Store-action delegation:** peer components (`ExitToFreeformButton`) read store actions directly via `useSessionStore((s) => s.actionName)`. Do NOT construct wire bodies in peer components — the store action owns the wire shape.
+3. **Wire-shape verification convention:** before locking any widget's wire body to the plan body, verify against the actual backend handler (`state_machine.py:_advance_step_*` or `routes.py`). Three of the four cross-layer gaps in Phase 7 surfaced because the plan was written aspirationally before backend implementation pinned the contracts. Phase 8 ChatPanel integration touches the store action wiring — same discipline applies.
+4. **`aria-controls` + `hidden` pattern:** any collapsible region MUST render the id-bearing container unconditionally with `hidden={!expanded}`; only children are gated. The `{expanded && <div id={...}>...}` pattern is BROKEN — `aria-controls` becomes a dangling reference in collapsed state. See `SchemaFormTurn.tsx:600` and `GuidedHistory.tsx:112-118` for the canonical pattern.
+5. **Suppress `ExitToFreeformButton` when `terminal.kind === "completed"`** — observation `elspeth-obs-0a1002de6d` flags this; otherwise three identical-action buttons appear. The discriminator JSX in spec §7.2 should add an explicit branch.
+6. **`<h3>` for primary entity headings:** Task 7.6 M3 set the precedent (plugin name → `<h3>`). RecipeOfferTurn (recipe_name) and CompletionSummary follow. ChatPanel may want an `<h2>` parent above the turn surface for SR landmark hierarchy.
+7. **`useTheme()` for Prism integration:** `CompletionSummary.tsx:67-68` matches `YamlView.tsx:164`. Any new Prism use should follow the convention.
+8. **Distinctness pin:** any element-level IDs use `useId()` per-instance scoping. Tests assert `expect(document.getElementById(id0)).not.toBe(document.getElementById(id1))` — node identity, not just string distinctness (Task 7.4 I4 lesson).
+
+### Plan-vs-reality drift expected in Phase 8
+
+The plan body has shown drift in every prior phase. Expect the same in Phase 8:
+
+- The plan likely shows `GuidedTurn`/`ExitToFreeformButton` import paths that don't match the actual `@/components/chat/guided/...` structure. Override with verified paths.
+- The plan likely shows `respondGuided` returning `Promise<void>` (correct) but the dispatcher wrapper as `(body) => respondGuided(body)` — make sure the void-promise floating warning is silenced (e.g., `(body) => void respondGuided(body)`).
+- The plan may not call out the `terminal.kind === "completed"` branch having to suppress ExitToFreeformButton (per `elspeth-obs-0a1002de6d`).
+
+The implementer dispatch brief for each Phase 8 task should pre-emptively override these.
+
+### First action when you start Phase 8
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline cc074420..HEAD                          # expect 20 commits, top = acf712d2
+cd src/elspeth/web/frontend
+npm test -- --run                                          # expect 404 / 404 pass
+npx tsc -p tsconfig.app.json --noEmit                      # expect clean
+```
+
+If any baseline gate fails, **stop and investigate** before starting Phase 8.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic; no migration scripts; no `from_dict` backward-compat defaults. (Phase 7 didn't touch the DB — but the constraint applies if Phase 8 finds itself there.)
+- **Default to worktree.** Stay here; do not work in `/home/john/elspeth` main.
+- **No git stash.** Commit work to a branch if preservation is needed.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done.
+- **Correctness beats performance always.**
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **`any` is forbidden in TypeScript.** Use `unknown` for opaque, closed unions or interfaces otherwise.
+- **No optimistic updates.** Server is authoritative.
+- **snake_case wire field names in interfaces; camelCase store-internal fields.** Established in Phase 6.
+- **ESLint is broken on this worktree.** Don't try to fix it inside Phase 8 unless a separate task is opened for the v9 flat-config migration.
+- **No PR-open at the end of Phase 7.** This handover + project memory entry close Phase 7. PR is deferred per project convention; the branch will accumulate Phases 8-10 before PR-open consideration.

--- a/docs/superpowers/handovers/2026-05-12-phase-8-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-8-complete.md
@@ -1,0 +1,159 @@
+# Handover — Composer Guided Mode (Phase 8 complete; Phase 9 onward)
+
+## TL;DR
+
+Phase 8 is **complete and green**. The `ChatPanel.tsx` top-level mode discriminator is wired: a three-branch router (completed → `<CompletionSummary>`; active guided → `<GuidedHistory>` + `<GuidedTurn>` inside a `role="log" aria-live="polite"` region + `<ExitToFreeformButton>`; else → unmodified freeform body) plus a Phase 7 contract honoured (the parent-hosted aria-live region that `InspectAndConfirmTurn` documented as load-bearing). Five commits on top of `e28aedbe` deliver +8 frontend tests (404 → 412 cumulative), no critical or important reviewer issues at close, two new deferred-polish observations filed, three active Phase-5 cross-layer follow-ups still pending (unchanged from Phase 7 close), and zero unresolved blockers.
+
+Phase 9 (Playwright E2E + demo-SLA assertions) is the next phase. Phase 10 closes documentation and CHANGELOG.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode` (67 commits ahead of `RC5.2` as of Phase 8 close; top commit `cdee530f`)
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results.
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). `vitest` is the test runner. The canonical typecheck is `npx tsc -p tsconfig.app.json --noEmit` — NOT `npx tsc --noEmit` at the root.
+- **ESLint is broken** on this worktree due to v9 flat-config migration debt — not Phase 8's job to fix. Don't run `npx eslint src/`; rely on vitest + tsc for the per-task gate.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` (Phase 9 starts line ~4560)
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` (Phase 9 relevant: §10 "Ring 3 + demo SLA")
+- **Inbound handover:** `docs/superpowers/handovers/2026-05-12-phase-7-complete.md` — the Phase 8 brief; references back to Phase 6 close.
+
+## What's delivered in Phase 8
+
+Five commits on top of Phase 7 closure (`acf712d2` + handover doc `e28aedbe`):
+
+### Per-task commit summary
+
+| Task | Component | Commits | Notes |
+|------|-----------|---------|-------|
+| 8.1 | `ChatPanel` mode discriminator | `a46f05c9` (initial) + `35850ace` (fix-up) | Three-branch router with completed-first precedence. The plan body had five drift points (`<ExistingChatPanelBody />` pseudocomponent, Rules-of-Hooks violation, wrong prop name on `GuidedHistory`, missing `void` wrapper on `respondGuided`, missing `id="chat-main"` preservation); all overridden in the dispatch brief. Six new tests pin all three branches plus the obs-0a1002de6d regression invariant. Fix-up added discriminator-anchored `chat-panel--guided` class assertion (parallel to test 2's `chat-panel--completed` check) and rewrote the regression-pin comment to describe the correct failure mode. |
+| 8.2 | A11y audit pass + `role="log" aria-live="polite"` region | `ff388128` (initial) + `23e7df5c` (cross-ref fix-up) + `cdee530f` (cross-ref completion sweep) | The audit pass surfaced one concrete a11y regression: `InspectAndConfirmTurn.tsx:39-46` documented a parent-ChatPanel `role="log" aria-live="polite"` region as a load-bearing contract for its `<aside>` warnings, but Task 8.1's discriminator had NOT honoured it. Wrapping ONLY `<GuidedTurn>` (not `<GuidedHistory>`, not `<ExitToFreeformButton>`) inside the region closes the contract. Two cross-ref fix-ups symbol-anchored five total stale `Filename.tsx:LL-LL` references across `ChatPanel.tsx`, `ChatPanel.test.tsx`, and `InspectAndConfirmTurn.tsx`. Spec §7.4 items 1-5 verified PASS with evidence; item 6 (focus on first interactive after step advance) deferred as `elspeth-obs-5ea21f94af`. |
+
+### Gate state at close
+
+- **Vitest:** **412 / 412 pass** (39 test files; +8 from Phase 7 baseline of 404)
+- **`npx tsc -p tsconfig.app.json --noEmit`:** clean
+- **Backend pytest** (narrow guided + sessions slice): unchanged from Phase 7 close (Phase 8 is frontend-only — backend file modifications are zero)
+- **Backend mypy** on `src/elspeth/web/composer/` + `src/elspeth/web/sessions/routes.py`: clean (no Phase-8 changes)
+- **ESLint:** not run — broken on this worktree (v9 flat-config migration debt); pre-existing infra issue unrelated to Phase 8
+
+### Per-task review iteration count (data point for future planning)
+
+| Task | Implementer dispatches | Why iteration was needed |
+|------|------------------------|---------------------------|
+| 8.1 | 2 (initial + fix-up) | Code-quality reviewer caught three Important comment-precision items: (a) discriminator block comment should add an explicit `exited_to_freeform` boolean walkthrough; (b) regression-pin test 3 comment misdescribed the failure mode ("three identical-action buttons" — actual: a button with literal label "Exit to freeform"); (c) test 1 should add a `chat-panel--guided` class assertion parallel to test 2's. All three landed mechanically with the recommended phrasing verbatim. |
+| 8.2 | 3 (initial + 2 fix-ups) | Code-quality reviewer (Task 8.2) caught two Important stale-line-number cross-references in `InspectAndConfirmTurn.tsx:42` and `ChatPanel.tsx`'s new comment block; `23e7df5c` retargeted them by symbol. Cross-task reviewer (whole-Phase-8 final pass) then caught three more stale `Filename.tsx:LL-LL` references that survived the first sweep, including the very `InspectAndConfirmTurn.tsx:39-46` references the prior fix-up had introduced as outbound pointers; `cdee530f` closed the loop by symbol-anchoring all three. |
+
+Pattern: every Phase 8 task landed with exactly one fix-up cycle per reviewer. The Task 8.2 cross-reference chain (initial → outbound retarget → inbound retarget) is a structural quirk worth flagging: when a fix-up replaces line-number references with symbol references, the *inbound* references to the moved symbol also become candidates for retargeting. Three sequential commits (`ff388128` → `23e7df5c` → `cdee530f`) all touching the same comment chain is unusually iterative but each step closed a discrete reviewer-named issue.
+
+## End-to-end frontend capability (post Phase 8)
+
+Phase 8 wires the Phase 7 widget surface into `ChatPanel.tsx`. After Phase 8:
+
+1. The three-branch mode discriminator is live at the top of `ChatPanel`. When `guidedSession?.terminal?.kind === "completed"`, the chat surface is replaced by `<CompletionSummary terminal={guidedSession.terminal} />` inside `<div id="chat-main" className="chat-panel chat-panel--completed" aria-label="Pipeline summary">`.
+2. When `guidedSession && !guidedSession.terminal && guidedNextTurn`, the chat surface is replaced by:
+   ```tsx
+   <div id="chat-main" className="chat-panel chat-panel--guided" aria-label="Guided composer">
+     <GuidedHistory history={guidedSession.history} />
+     <div className="chat-panel-guided-log" role="log" aria-label="Guided wizard step" aria-live="polite" aria-relevant="additions">
+       <GuidedTurn turn={guidedNextTurn} onSubmit={(body) => void respondGuided(body)} />
+     </div>
+     <ExitToFreeformButton />
+   </div>
+   ```
+3. Otherwise the existing freeform body renders unchanged (byte-identical to pre-Phase-8 — verified by structural diff).
+4. The new `chat-panel--guided`, `chat-panel--completed`, and `chat-panel-guided-log` classes are placeholder CSS hooks — **no CSS rules added in Phase 8**. They exist for future styling and as testable discriminator-anchored signals.
+5. The `id="chat-main"` skip-link target is preserved across all three branches.
+6. The session-title header (lines 136-140 of pre-Phase-8 `ChatPanel.tsx`) is dropped in the guided/completed branches and retained in the freeform branch (the spec implies guided mode replaces the FULL chat surface; freeform keeps the session-title affordance).
+7. `<GuidedTurn>` lives inside the `role="log" aria-live="polite"` region; `<GuidedHistory>` and `<ExitToFreeformButton>` live outside it. Rationale: historical context and persistent action buttons are not announced on turn change; only the live turn surface is.
+
+The chat surface is now fully wired for guided mode. The only remaining frontend work is Phase 9's Playwright E2E coverage and Phase 10's documentation.
+
+## What's pending — Phase 9 onward
+
+Phase 9 lands three Playwright flows + the demo-SLA assertion test:
+
+1. **Recipe-match happy path** (Task 9.1) — CSV → classify-rows-llm-jsonl in ≤7 clicks, <30s. Demo SLA assertion at the bottom of the test.
+2. **Hand-built path** (Task 9.2) — LLM-driven Step 3 with stubbed LLM, drive `<ProposeChainTurn>` through Accept. **Blocked by `elspeth-2c08408170`** — the backend Step-3 handler only consumes `chosen: ["accept"]` (success) and `["reject"]` (501 stub); the per-step Edit / Ask-advisor buttons remain absent. A full hand-built path test that exercises Edit/Ask-advisor cannot land until backend completes.
+3. **Auto-drop path** (Task 9.3) — Force LLM stub to return invalid chains twice; assert wizard auto-drops to freeform with partial pipeline state intact.
+
+Phase 10 closes docs + CHANGELOG (Tasks 10.1–10.3). Tasks 10.1 and 10.2 are doc-only commits (`--no-verify` permitted per project memory `feedback_doc_only_commits_no_ci`). Task 10.3 runs the full sweep and opens the umbrella PR — see the project memory `project_adr010_umbrella_branch` for the umbrella-branch scope convention.
+
+## Cross-layer follow-ups (active Filigree issues — unchanged from Phase 7 close)
+
+Three durably-tracked issues for Phase 5 backend completion work that surfaced during Phase 7 widget implementation. **All three remain open at Phase 8 close.** Phase 8 did not touch any of them (correct scope discipline).
+
+| Issue | Surface | Phase impact |
+|---|---|---|
+| **`elspeth-5e905f3c9d`** | `MultiSelectWithCustomTurn` escape button — wire shape (`{edited_values: {schema_mode, required_fields}}` per plan) contradicts backend `_advance_step_2` (reads `outputs[]` shape). Widget defers rendering. | Phase 9 demo path requires Step 2 escape if user wants to skip required-fields collection. Resolve before Phase 9 E2E. |
+| **`elspeth-2c08408170`** | `ProposeChainTurn` Step-3 backend handler completion (Reject + per-step Edit + Ask advisor). Backend `routes.py:2030-2137` consumes only `chosen: ["accept"]` (success) and `["reject"]` (501 stub). 3 of 4 planned buttons absent. | Phase 9 E2E cannot exercise Reject/Edit/Ask-advisor flows until backend lands. Task 9.2 hand-built path test will need the Edit button. |
+| **`elspeth-611fc01d94`** | `GuidedHistory` rich step summaries — wire `TurnRecordResponse` is hash-only by audit-trail design. Decision needed: wire extension (`summary` field) or payload-fetch endpoint. | Phase 8 ChatPanel integration ships hash-only history (which Phase 7 already delivered); Phase 9 demo can describe but not show "Step 1: CSV with cols [price, qty]" until this lands. |
+
+Same recommendation as Phase 7 close: bundle as a single "Phase 5 backend completion" task with three sub-deliverables.
+
+## New deferred-polish observations from Phase 8 (14-day expiry unless promoted)
+
+Two new observations filed at Phase 8 close. Together with the three Phase-7-era observations still active, the running deferred-polish list is now five items.
+
+| Observation | Description | Priority |
+|---|---|---|
+| **`elspeth-obs-5ea21f94af`** (NEW) | Spec §7.4 "Maintain focus on the first interactive element of the new turn after step advance" deferred from Task 8.2. When `respondGuided` resolves and a new turn arrives, focus falls to `<body>` and users must Tab through the whole document to reach the new turn's first interactive. Three implementation options documented in the observation (ref-forwarding from `<GuidedTurn>`; `autoFocus` per leaf widget; `useEffect` in ChatPanel keyed on `step_index`). Likely best tackled BEFORE Phase 9 E2E because Tab-cycling between steps will inflate demo-SLA timing measurements. | P2 |
+| **`elspeth-obs-a076365f64`** (NEW) | `ChatPanel.test.tsx` grew 85 → 404 lines across Phase 8. Each test reproduces ~10 lines of `useSessionStore.setState({...})` boilerplate. Helper extraction (`setupGuidedActive(turn?)` / `setupCompleted(terminal?)` / `setupFreeform()`) recommended before Phase 9 adds more discriminator-side tests. | P3 |
+| **`elspeth-obs-510a4fbdeb`** (carried) | `TurnPayload` discriminated-union refactor (Option B). Eliminates 6 `as` casts in `GuidedTurn.tsx`. Cascade cost: test fixtures in `client.guided.test.ts` and `sessionStore.guided.test.ts` use shorthand `payload: {options: [...]}` literals that need rewriting. Phase 7 deferred; no Phase 8 movement. | (Phase 7 era) |
+| **`elspeth-obs-0a1002de6d`** (RESOLVED in Phase 8) | "Phase 8 ChatPanel must suppress persistent `ExitToFreeformButton` when `terminal.kind === "completed"`" — **honoured** by the discriminator design (completed branch renders `CompletionSummary` alone). Regression pin test 3 (`ChatPanel.test.tsx`) catches future re-introduction of the button on the completed surface. The observation can be dismissed; the contract is enforced by test. | (now closed) |
+| **`elspeth-obs-f9e991f517`** (carried) | `useNonInitialEffect` hook extraction candidate. `firstRunRef` initial-mount-skip pattern in 7.3/7.4/7.5. Phase 7 deferred past Phase 8; still unaddressed. | (Phase 7 era) |
+
+The first two (Phase 8 era) should remain visible to the Phase 9 implementer. The first one in particular (`elspeth-obs-5ea21f94af`) likely **should be addressed before Phase 9 E2E** because demo-SLA flakiness is directly tied to focus management.
+
+The third Phase-7-era observation (`obs-0a1002de6d`) is now structurally enforced by Phase 8 — it can be dismissed from `list_observations`. Promotion is not needed because the contract is pinned by test.
+
+## Phase 9 starting brief
+
+Read this in conjunction with the plan file's Phase 9 section (line ~4560).
+
+### Convention reminders inherited from Phase 8
+
+All eight conventions from the Phase 7 handover §"Convention reminders inherited from Phase 7" remain in force. Phase 8 adds these:
+
+9. **Three-branch discriminator order is completed-first → active-guided → fall-through.** If Phase 9 adds a fourth branch (unlikely but possible — e.g., for a `kind: "exited_to_freeform"` terminal that needs its own UI affordance), the precedence rule (more-specific before less-specific) must be preserved.
+10. **The `chat-panel-guided-log` region wraps `<GuidedTurn>` ONLY.** Future code that introduces new live regions (e.g., per-widget aria-live for warnings) must not nest inside this region (the "don't nest live regions" convention documented at `InspectAndConfirmTurn.tsx:48-50` and `ComposingIndicator.test.tsx` "ComposingIndicator live region scope" describe block).
+11. **Symbol-anchored cross-references, never line numbers.** Five line-number references rotted across Phase 8's commit chain and required three follow-up commits to clean up. Any cross-file comment pointing at a referenced symbol should use the class name, function name, or describe-block name — never `Filename.tsx:LL-LL`.
+12. **Discriminator-anchored test assertions.** Discriminator tests assert on `chat-panel--guided` / `chat-panel--completed` / `chat-panel-guided-log` class presence, NOT on widget-internal DOM choices. A widget-DOM refactor (e.g., swapping `<fieldset>` to `<div role="radiogroup">`) should not silently fail a discriminator test that was meant to assert routing.
+
+### Plan-vs-reality drift expected in Phase 9
+
+Phase 9 is Playwright E2E. The drift patterns expected:
+
+- The plan's recipe-match happy path (`Task 9.1`) at line 4565 assumes ~7 clicks and <30s. The Phase 8 cross-task reviewer flagged that without `elspeth-obs-5ea21f94af` (focus-on-step-advance), additional Tab cycles will inflate click count and timing. Either resolve the observation before Phase 9, or adjust the SLA budget with explicit rationale.
+- The plan's hand-built path (`Task 9.2`) at line 4612 assumes the Phase-5 Step-3 backend handler is complete. As of Phase 8 close, **it is not** — only `chosen: ["accept"]` works. Either land `elspeth-2c08408170` first, or rescope 9.2 to test only the Accept-all path until backend completion.
+- The plan's auto-drop path (`Task 9.3`) at line 4622 is the most decoupled — the auto-drop logic was finalized in Phase 5 and the discriminator's "fall through to freeform when guidedSession is null" behavior is verified by `ChatPanel.test.tsx` Test 4. Playwright should be able to verify end-to-end with a stubbed LLM.
+- The Playwright LLM-stub fixture mentioned at `Task 9.2 Step 1` should be verified to exist before starting — the plan asserts "existing Playwright LLM-stub fixture" but Phase 7/8 didn't touch it.
+
+### First action when you start Phase 9
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline acf712d2..HEAD                          # expect 26 commits, top = cdee530f (Phase 8 sweep) or a new handover doc commit
+cd src/elspeth/web/frontend
+npm test -- --run                                          # expect 412 / 412 pass
+npx tsc -p tsconfig.app.json --noEmit                      # expect clean
+ls tests/playwright/                                       # verify Playwright infra exists; check for `composer-guided.spec.ts` (Phase 9 creates this)
+```
+
+If any baseline gate fails, **stop and investigate** before starting Phase 9.
+
+Strongly consider addressing `elspeth-obs-5ea21f94af` (focus-on-step-advance) as the FIRST task of Phase 9 — before any Playwright work. Without it, the demo SLA assertion is unstable.
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** No Alembic; no migration scripts; no `from_dict` backward-compat defaults.
+- **Default to worktree.** Stay here; do not work in `/home/john/elspeth` main.
+- **No git stash.** Commit work to a branch if preservation is needed.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done.
+- **Correctness beats performance always.**
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session. (Phase 8 honoured this: the cross-task reviewer's three stale line-number references were fixed in `cdee530f` rather than deferred.)
+- **`any` is forbidden in TypeScript.** Use `unknown` for opaque, closed unions or interfaces otherwise.
+- **No optimistic updates.** Server is authoritative.
+- **snake_case wire field names in interfaces; camelCase store-internal fields.**
+- **ESLint is broken on this worktree.** Don't try to fix it inside Phase 9 unless a separate task is opened for the v9 flat-config migration.
+- **Symbol-anchored cross-references, never line numbers.** Established Phase 8.
+- **No PR-open at the end of Phase 8.** This handover + project memory entry close Phase 8. PR is deferred per project convention; the branch will accumulate Phases 9-10 before PR-open consideration.

--- a/docs/superpowers/handovers/2026-05-12-phase-9-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-9-complete.md
@@ -2,8 +2,8 @@
 
 **Status: complete with deferrals.** Phase 9 surfaced six integration bugs in the recipe-match happy path; five were fixed in-session, the sixth is the explicit gating blocker for the demo SLA assertion and is deferred to a follow-up phase. The Phase 9 dispatch brief's three-task scope (9.1 + 9.2 + 9.3) collapsed under the weight of the bug discoveries. What Phase 9 actually delivered is described below in honest terms — it is not what the dispatch brief envisioned, but it is what the system needed.
 
-**Top of branch at close:** `888624d8 test(frontend/e2e): re-fixme spec: Gap 5 fixed, Gap 6 blocks Apply recipe`
-**Phase 9 commit range:** `616545f2..HEAD` (8 commits inclusive of the dispatch-brief landing).
+**Top of branch at close:** the handover commit (`138fee54`) sits on top of `888624d8 test(frontend/e2e): re-fixme spec: Gap 5 fixed, Gap 6 blocks Apply recipe`.
+**Phase 9 commit range:** `616545f2..HEAD` (9 commits — the eight substantive commits below plus this handover).
 
 ---
 
@@ -16,7 +16,7 @@
 
 ---
 
-## What landed (8 commits)
+## What landed (9 commits — 8 substantive + this handover)
 
 | Commit | Subject | Class |
 |---|---|---|
@@ -28,6 +28,7 @@
 | `9ae407a2` | `test(frontend/e2e): guided demo path recipe-match E2E + SLA assertion (fixme)` | E2E spec scaffolding + uploadBlob helper + sessionStore guided wiring (Gap 1) |
 | `74ea68eb` | `fix(web/composer): recipe slot resolver reads composer-canonical blob_ref` | Gap 5 (HTTP 400 at Apply recipe) — resolves elspeth-obs-a8a9bc010a, also injects blob_ref through source resolver path |
 | `888624d8` | `test(frontend/e2e): re-fixme spec: Gap 5 fixed, Gap 6 blocks Apply recipe` | Documentation of Gap 6 in spec header; test re-fixme |
+| `138fee54` | `docs(handover): land composer guided-mode phase 9 complete handover` | This document. |
 
 ### Two notable commits with broader-than-headline blast radius
 

--- a/docs/superpowers/handovers/2026-05-12-phase-9-complete.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-9-complete.md
@@ -1,0 +1,187 @@
+# Phase 9 close — Composer Guided Mode (E2E + demo SLA)
+
+**Status: complete with deferrals.** Phase 9 surfaced six integration bugs in the recipe-match happy path; five were fixed in-session, the sixth is the explicit gating blocker for the demo SLA assertion and is deferred to a follow-up phase. The Phase 9 dispatch brief's three-task scope (9.1 + 9.2 + 9.3) collapsed under the weight of the bug discoveries. What Phase 9 actually delivered is described below in honest terms — it is not what the dispatch brief envisioned, but it is what the system needed.
+
+**Top of branch at close:** `888624d8 test(frontend/e2e): re-fixme spec: Gap 5 fixed, Gap 6 blocks Apply recipe`
+**Phase 9 commit range:** `616545f2..HEAD` (8 commits inclusive of the dispatch-brief landing).
+
+---
+
+## TL;DR for the Phase 10 inheritor
+
+1. The demo SLA assertion (Task 9.1) is **scaffolded but not green.** `tests/e2e/composer-guided.spec.ts` exists and drives steps 1–5 successfully (HTTP 200 through the chain). It is `test.fixme()` because step 6 (Apply recipe) returns HTTP 400 due to Gap 6.
+2. **Gap 6 — `elspeth-obs-f626607b13` (P1) — is your first task.** It needs a wire-contract extension: `RecipeOfferPayload` must include slot specs for unsatisfied required slots; `RecipeOfferTurn` must render editable inputs for them. Multi-component frontend+backend work. Once that lands, un-fixme is a one-line change.
+3. The LLM-stub Playwright fixture and Tasks 9.3 (auto-drop) and 9.2 (hand-built) are **all deferred to a follow-up phase.** They were not started. 9.2 remains hard-blocked on `elspeth-2c08408170` (Step-3 backend handler completion) — see filigree comment 921.
+4. **Six integration bugs in one phase is a quality signal worth flagging in CI strategy.** This codebase's unit/integration split tested components in isolation; the bugs lived at the seams. The fix is more than "write more integration tests" — it's "decide what level of integration coverage is mandatory before declaring a feature complete." That's an SDLC observation, not a code change, but it belongs here so Phase 10 can avoid repeating the pattern.
+
+---
+
+## What landed (8 commits)
+
+| Commit | Subject | Class |
+|---|---|---|
+| `2b692cab` | `fix-up(frontend/chat): focus first interactive on guided step advance` | Phase 8 deferral (spec §7.4 acceptance) |
+| `27af549d` | `fix-up(frontend/chat): post-review polish on focus-on-step-advance` | Code-review fix-up |
+| `e05e02b2` | `fix(web/frontend): SchemaFormTurn submits guided wire shape backend expects` | Bug 1 (HTTP 422 at Step-1 SCHEMA_FORM) |
+| `a5df0b6c` | `fix(web/composer): persist step-2 sink intent through MultiSelectWithCustomTurn` | Bug 2 (HTTP 500 at Step-2 MULTI_SELECT) — resolves elspeth-5e905f3c9d |
+| `df5306cf` | `docs(plan): correct Phase 9 Task 9.1 happy path against verified flow` | Plan correction (no InspectAndConfirmTurn; ≤9 clicks) |
+| `9ae407a2` | `test(frontend/e2e): guided demo path recipe-match E2E + SLA assertion (fixme)` | E2E spec scaffolding + uploadBlob helper + sessionStore guided wiring (Gap 1) |
+| `74ea68eb` | `fix(web/composer): recipe slot resolver reads composer-canonical blob_ref` | Gap 5 (HTTP 400 at Apply recipe) — resolves elspeth-obs-a8a9bc010a, also injects blob_ref through source resolver path |
+| `888624d8` | `test(frontend/e2e): re-fixme spec: Gap 5 fixed, Gap 6 blocks Apply recipe` | Documentation of Gap 6 in spec header; test re-fixme |
+
+### Two notable commits with broader-than-headline blast radius
+
+**`a5df0b6c` (Bug 2 fix)** — 9 files, +299/-183. Adds a new frozen dataclass `SinkIntent` (with `freeze_fields(self, "options")` per project policy), a new field `step_2_sink_intent: SinkIntent | None = None` on `GuidedSession`, populates it in the SCHEMA_FORM Step-2 dispatcher branch via `dataclasses.replace`, and consumes-and-clears it in `_advance_step_2`. Updates `to_dict`/`from_dict` for round-trip. The strict (no `.get()` default) `from_dict` is intentional: pre-fix sessions crash on load, signaling the user to delete the old DB per `project_db_migration_policy`. Tests: `test_guided_session_roundtrip_with_sink_intent` covers the audit-trail boundary; `test_step_2_advances_after_required_fields_declared` covers the cross-turn-boundary persistence. 165 guided tests pass.
+
+**`74ea68eb` (Gap 5 fix)** — touches `recipe_match.py` + `tools.py` + `steps.py` + `routes.py` + tests + the tier-model allowlist (FP rotation). The headline "fix the slot resolver to read `blob_ref`" was insufficient on its own — the implementer's pre-fix verification surfaced that **`blob_ref` isn't even written by `_execute_set_source`** (the guided SchemaForm path). Only `_execute_set_source_from_blob` writes it. So the deeper fix added `_sync_get_blob_by_storage_path` (authoritative DB lookup by `storage_path`) and made `handle_step_1_source` inject `blob_ref` into `SourceResolved.options` after a successful `_execute_set_source` if the source `path` matches a known blob. Both peer slot resolvers (`_classify_slot_resolver` and `_split_threshold_slot_resolver`) had the identical bug; both fixed in the same commit. Module docstring updated to distinguish Tier-2 direct-access (blob_ref) from Tier-3 boundary-coercion (output paths). This is **load-bearing architectural alignment**, not scope creep.
+
+---
+
+## Six integration bugs surfaced; status of each
+
+| # | Severity | Description | Status | Issue |
+|---|---|---|---|---|
+| Bug 1 | High | SchemaFormTurn submitted flat `edited_values`; backend expected `{plugin, options, observed_columns, sample_rows}`. HTTP 422 at Step-1 SCHEMA_FORM. | **Fixed** (`e05e02b2`) | — |
+| Bug 2 | High | GuidedSession didn't persist sink plugin/options across SCHEMA_FORM → MULTI_SELECT_WITH_CUSTOM. Widget couldn't construct `outputs[]`. HTTP 500 at Step 2. | **Fixed** (`a5df0b6c`) | resolves `elspeth-5e905f3c9d` |
+| Gap 1 | Medium | `startGuided()` was implemented in Phase 6's sessionStore but never called from any component. Guided wizard surface never rendered regardless of session state. | **Fixed** (in `9ae407a2` alongside the spec) | resolves `elspeth-obs-d3d0d7fa70` |
+| Gap 2 | Low | S2 path-allowlist requires source path under `data_dir/blobs/`. The 9.1 spec works around by constructing the exact blob storage path from session_id + blob.id. | **Worked around in spec** | (file as observation if Phase 10 wants to relax/document the allowlist) |
+| Gap 3 | Low | `on_validation_failure` is required by the CSV SchemaForm but not pre-filled. The 9.1 spec fills it explicitly. | **Worked around in spec** | (file as observation in polish phase) |
+| Gap 4 | Low | `collision_policy` is mandatory in composer mode but hidden behind a "Show advanced" toggle. Adds 1 click to the budget. | **Worked around in spec** | (file as observation in polish phase) |
+| Gap 5 | P0 | `_classify_slot_resolver` (and `_split_threshold_slot_resolver`) read `source.options.get("blob_id", "")`; canonical key is `blob_ref`. AND `blob_ref` wasn't written by the guided SchemaForm path at all. HTTP 400 at Apply recipe. | **Fixed** (`74ea68eb`) | resolves `elspeth-obs-a8a9bc010a` |
+| Gap 6 | P1 | `RecipeOfferPayload.slots` carries only the derivable slots; recipes with required slots that have no derivable defaults (e.g. `classifier_template`, `model`, `api_key_secret`) cannot be satisfied. The widget has no UI for unsatisfied required slots; the wire type has no slot-schema field. HTTP 400 at Apply recipe (different cause than Gap 5). | **Deferred to Phase 10** | `elspeth-obs-f626607b13` |
+
+**The fact pattern:** Phase 9 ran integration tests against a system that had never been integration-tested end-to-end. Six bugs surfaced. Each was contained, each was fixed (or scoped for follow-up). The unit suite was honest about what it tested — components in isolation. The bugs lived at the seams. **This is exactly why integration tests exist; this is exactly what Phase 9 was for.** No apology required.
+
+---
+
+## What was deferred and why
+
+### Task 9.2 — Hand-built path E2E (LLM-driven Step 3)
+
+Hard-blocked on `elspeth-2c08408170` (Step-3 backend handler completion). The dispatch brief's three-option framing (option 1: land the backend first; option 2: rescope to Accept-only; option 3: defer entirely) was resolved as **option 3** with operator-precedent reasoning: option 1 is "several backend tasks" per the brief — a phase of its own — and option 2 ships demo content that misrepresents what the user can actually do. Defer until the backend lands.
+
+A comment was added to `elspeth-2c08408170` (filigree comment 921) noting the Phase 9 deferral and the dependency ordering (Gap 6 → 9.1 → 9.2).
+
+### Task 9.3 — Auto-drop path E2E
+
+Deferred together with the LLM-stub fixture (which it depends on). Phase 9's stop condition was "if the demo SLA assertion lands working, close Phase 9." It didn't land working — Gap 6 blocks it. Continuing into 9.3 would unbound the phase further. Per the advisor consulted at the stop point: "9.3 is auto-drop on invalid LLM chain — it's failure-path coverage, not the demo anchor."
+
+### LLM-stub Playwright fixture (Task 9.x-stub)
+
+Backend env-var hook design was scoped (use `errorworks.llm.server.ChaosLLMServer` launched in globalSetup; URL passed via `composerSettingsEnv`). Implementation deferred — the fixture is foundational for 9.3 and a useful for `compose-happy-path.spec.ts` (currently `test.fixme()`), but no pressing user need without 9.3 landing.
+
+---
+
+## sessionStore.ts wiring change in `9ae407a2` — scrutiny outcome
+
+The 9.1 implementer added `startGuided()` calls to `sessionStore.createSession` and `sessionStore.selectSession` as load-bearing for the guided wizard to render. This bypassed the SDD per-task review cycle. A bundled review pass during the Gap 5 dispatch confirmed:
+
+- **Refire-on-switch:** `selectSession` clears guided state to null first, then fires `startGuided` unconditionally. Each switch reloads from the authoritative backend. Per spec §7.3 (server is authoritative), this is intentional and safe — no mid-flow user state is lost permanently because the backend persists progress.
+- **Fire-and-forget error handling:** `startGuided`'s catch block sets `error` without clobbering any non-null guided state. ChatPanel's discriminator falls through to freeform safely when `guidedSession === null`.
+- **Deliberate-choice check:** Phase 6 and Phase 7 handovers explicitly noted "guided mode is reachable only programmatically until Phase 8" — the unwiring was a conscious deferral, not an oversight. The 9.1 implementer correctly fixed it.
+
+**Verdict: clean.** The change stands as-is.
+
+One adjacent gap surfaced during review (pre-existing, not introduced by `9ae407a2`): `forkFromMessage` does not clear or restart guided state for the new session. Filed as `elspeth-obs-83d97315a7` (P3).
+
+---
+
+## Observations filed during Phase 9
+
+| Observation | Priority | Description | When promoted? |
+|---|---|---|---|
+| `elspeth-obs-134474dfcb` | P2 | InspectAndConfirmTurn is unreachable on the live emission path (`routes.py:_build_get_guided_turn` hardcodes `blob_inspection=None`). | When InspectAndConfirmTurn is a demo requirement; otherwise can dismiss. |
+| `elspeth-obs-d3d0d7fa70` | P1 | `startGuided()` was unwired in Phase 6/7. **Resolved by `9ae407a2`** — can dismiss. | Already resolved. |
+| `elspeth-obs-a8a9bc010a` | P0 | Slot resolver `blob_id` vs `blob_ref` mismatch. **Resolved by `74ea68eb`** — can dismiss. | Already resolved. |
+| `elspeth-obs-f626607b13` | P1 | `RecipeOfferTurn` missing editable form for unsatisfied required slots; `RecipeOfferPayload` missing slot-schema. **Gating blocker for demo SLA E2E.** | Phase 10 first task — promote to issue immediately. |
+| `elspeth-obs-83d97315a7` | P3 | `forkFromMessage` doesn't clear/restart guided state for the new session. | Polish phase. |
+
+Two earlier Phase-8-era observations remain unresolved at Phase 9 close:
+- `elspeth-obs-5ea21f94af` — focus-on-step-advance — **resolved by `2b692cab`**, can dismiss.
+- `elspeth-obs-a076365f64` — test-file fixture extraction (P3) — unchanged; polish phase.
+- `elspeth-obs-510a4fbdeb` — TurnPayload discriminated-union refactor — unchanged; no Phase-9 impact.
+- `elspeth-obs-f9e991f517` — useNonInitialEffect hook extraction — unchanged; no Phase-9 impact.
+
+---
+
+## Verification gates at Phase 9 close
+
+| Gate | Result |
+|---|---|
+| `pytest tests/unit/web/composer/guided/ tests/integration/web/composer/guided/` | 165 passed |
+| `mypy src/` | Success (391 source files) |
+| `enforce_tier_model.py check` | No bug-hiding patterns detected |
+| `enforce_freeze_guards.py check` | No forbidden freeze patterns detected |
+| `npm test -- --run` | 418 passed (39 test files) — was 412/412 at Phase 8 close; +6 from new SchemaFormTurn + ChatPanel-focus tests |
+| `tsc -p tsconfig.app.json --noEmit` | Clean |
+| `playwright test composer-guided` | 3 passed, 10 skipped (the recipe-match SLA spec is `test.fixme()` per Gap 6) |
+
+The Phase 9 baseline is cleanly green. The skipped Playwright spec is the demo SLA assertion; un-fixme is a one-line change once Gap 6 lands.
+
+---
+
+## Conventions remaining in force (inherited from Phases 7 + 8)
+
+All twelve conventions from the Phase 8 handover §"Convention reminders inherited from Phase 7" + the four added in Phase 8 remain in force. Phase 9 added two operationally:
+
+13. **Backend integration bugs at the seams require curl probes against the live backend to find.** Unit and integration tests cover components in isolation; the Phase 9 bug pattern proves the seams need explicit end-to-end coverage. Phase 10 dispatches that drive the full guided flow MUST verify via curl OR via a Playwright run before declaring a feature complete.
+
+14. **Backend wire-shape changes (e.g. extending `RecipeOfferPayload` for Gap 6) must touch the L0 contract type, the backend builder, the frontend type, the widget, the widget tests, the schema-compliance tests, AND the validator-error explanation tool — in the same commit.** Partial wire-contract changes are a known failure mode; the Phase 9 bugs were rooted in incomplete contract propagation across previous phases.
+
+---
+
+## Active follow-ups at Phase 9 close
+
+| Issue | Status | Phase 10 priority |
+|---|---|---|
+| `elspeth-obs-f626607b13` (RecipeOfferTurn editable slots) | Open (P1) | **First task of Phase 10.** Gates the demo SLA assertion. |
+| `elspeth-obs-134474dfcb` (InspectAndConfirmTurn unreachable) | Open (P2) | Demo-relevance dependent. |
+| `elspeth-2c08408170` (Step-3 backend handler) | Open + Phase 9 deferral note (filigree comment 921) | Gates Task 9.2 — schedule after Gap 6 lands. |
+| `elspeth-obs-83d97315a7` (forkFromMessage doesn't restart guided state) | Open (P3) | Polish. |
+| `elspeth-obs-a076365f64` (test-file fixture extraction) | Open (P3) | Polish; deferred since Phase 8. |
+| `elspeth-obs-510a4fbdeb` (TurnPayload discriminated-union refactor) | Open | No urgency. |
+| `elspeth-obs-f9e991f517` (useNonInitialEffect hook extraction) | Open | No urgency. |
+| `elspeth-obs-5ea21f94af` (focus on step advance) | **Resolved by `2b692cab`** | Dismiss. |
+| `elspeth-obs-d3d0d7fa70` (startGuided unwired) | **Resolved by `9ae407a2`** | Dismiss. |
+| `elspeth-obs-a8a9bc010a` (slot resolver blob_id) | **Resolved by `74ea68eb`** | Dismiss. |
+
+---
+
+## Important constraints (do not relitigate)
+
+Inherited from CLAUDE.md and prior handovers; reaffirmed by Phase 9 experience:
+
+- **DB migration = delete the DB.** The strict `from_dict` on the new `step_2_sink_intent` field intentionally crashes on pre-Bug-2 sessions, signaling the user to wipe the DB.
+- **Default to worktree.** Phase 9 stayed in `/home/john/elspeth/.worktrees/composer-guided-mode` throughout.
+- **No git stash.** No commits in Phase 9 used stash.
+- **No calendar shipping commitments.** Phase 9 ran until the work was actually done (and stopped when continuing would have ballooned scope), not until a date.
+- **Correctness beats performance always.** The demo SLA budget was bumped to ≤9 (from ≤7) to match the actual happy path under verified UX. The wall-clock SLA is unchanged at <30s.
+- **Default answer is never "log a ticket."** Phase 9 fixed every fixable bug it surfaced in-session. The two bugs it deferred (Gap 6, `elspeth-2c08408170`) are scoped at "this is its own phase" — not deferred for convenience.
+- **`any` is forbidden.** All Phase-9 TypeScript additions are typed.
+- **No optimistic updates.** Server is authoritative. The 9.1 spec waits for state transitions, not hard-coded sleeps.
+- **snake_case wire / camelCase store.** All wire-shape fixes (Bug 1, Bug 2) preserve snake_case.
+- **ESLint broken; rely on vitest + tsc.** Verification used vitest + tsc + Playwright throughout.
+- **Symbol-anchored cross-references in comments.** Multiple fix-ups landed on this discipline; convention 11 from Phase 8 holds.
+- **No PR-open at end of Phase 9.** Phase 10 (or a polish phase between) opens the umbrella PR.
+
+---
+
+## First action when Phase 10 starts
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline 888624d8..HEAD | head -10                           # confirm Phase 9 close commits + handover
+git log -1 --format='%H' docs/superpowers/handovers/2026-05-12-phase-9-complete.md   # confirm this handover landed
+cd src/elspeth/web/frontend
+npm test -- --run                                                     # expect 418 / 418 pass
+npx tsc -p tsconfig.app.json --noEmit                                 # expect clean
+npx playwright test composer-guided                                   # expect 3 passed, 10 skipped (the fixme demo SLA)
+```
+
+Then open `elspeth-obs-f626607b13`, scope the wire-contract extension for `RecipeOfferPayload`, and dispatch the first Phase 10 task.
+
+The advisor consulted at Phase 9 close said it best:
+
+> *Phase 9's value is making Phase 10 small.*
+
+Phase 10 inherits a single tight target. Phase 9 did the messy seam-discovery work. Be glad of it.

--- a/docs/superpowers/handovers/2026-05-12-phase-9-dispatch-brief.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-9-dispatch-brief.md
@@ -1,0 +1,245 @@
+# Dispatch brief — Composer Guided Mode Phase 9 (Playwright E2E + demo SLA)
+
+**Companion doc.** This is a forward-looking brief for the Phase 9 implementer. The retrospective handover at `docs/superpowers/handovers/2026-05-12-phase-8-complete.md` captures what landed at Phase 8 close; this doc tells you what Phase 9 needs to deliver and how to sequence it.
+
+Read both. Where they disagree, this brief wins (it's the more recent document).
+
+## TL;DR
+
+Phase 9 lands three Playwright E2E flows plus the demo-SLA timing assertion that anchors the whole guided-mode feature:
+
+1. **Task 9.1 — Recipe-match happy path.** CSV → JSONL via recipe pre-match. ≤7 clicks, <30s. SLA assertion at the bottom of the test.
+2. **Task 9.2 — Hand-built path.** LLM-driven Step 3 via `<ProposeChainTurn>`. **HARD-BLOCKED** by `elspeth-2c08408170` (backend Step-3 handler is partial); cannot land meaningfully until backend completes. See §"Sequencing decisions" below.
+3. **Task 9.3 — Auto-drop path.** LLM stub returns invalid chains twice; assert wizard auto-drops to freeform with `compositionState` intact.
+
+Before any Playwright work, **strongly consider landing the focus-on-step-advance fix** (`elspeth-obs-5ea21f94af`). The demo-SLA assertion is structurally fragile without it — Tab cycling between steps inflates both click count and timing.
+
+Phase 10 closes documentation + CHANGELOG + (per `project_adr010_umbrella_branch` memory) umbrella PR open. Phase 9 does **NOT** open a PR.
+
+## Environment
+
+- **Worktree:** `/home/john/elspeth/.worktrees/composer-guided-mode`
+- **Branch:** `feat/composer-guided-mode`
+- **Top commit at start of Phase 9:** `06faa8e8` (Phase 8 handover doc) — or whatever has accumulated since.
+- **Python:** `.venv/bin/python` in the worktree. **Do NOT use main's venv** — Python-version mismatch corrupts `enforce_tier_model.py` results. The worktree venv is Python 3.13 (per `project_tier_model_python_version` memory).
+- **Frontend toolchain:** `npm` (NOT pnpm/yarn). `vitest` is the unit/integration runner. `playwright` is the E2E runner (likely; verify before starting — see §"Playwright infrastructure verification").
+- **Canonical frontend typecheck:** `npx tsc -p tsconfig.app.json --noEmit` — NOT `npx tsc --noEmit` at the root.
+- **ESLint is broken** on this worktree (v9 flat-config migration debt). Don't try to fix it as part of Phase 9. Rely on vitest + tsc for unit/integration; Playwright's own type-check for E2E.
+- **Plan file:** `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` — Phase 9 starts line ~4560.
+- **Spec file:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` — Phase 9 relevant: §1.3 (demo SLA), §10 "Ring 3 + demo SLA".
+
+## State at Phase 9 start (post Phase 8)
+
+- ChatPanel `mode discriminator` is wired (Task 8.1, commits `a46f05c9` + `35850ace`).
+- `role="log" aria-live="polite"` region wraps `<GuidedTurn>` in the guided-active branch (Task 8.2, commits `ff388128` + `23e7df5c` + `cdee530f`).
+- Vitest baseline at Phase 9 start: **412 / 412 pass**. `tsc -p tsconfig.app.json --noEmit`: clean.
+- Backend: unchanged from Phase 5 close. Step-3 handler in `src/elspeth/web/sessions/routes.py:2030-2137` consumes only `chosen: ["accept"]` (success) and `chosen: ["reject"]` (501 stub).
+- Three Phase-5 follow-ups durably tracked in Filigree: `elspeth-5e905f3c9d`, `elspeth-2c08408170`, `elspeth-611fc01d94`. None resolved.
+- Two new Phase-8 observations: `elspeth-obs-5ea21f94af` (P2 focus-on-step-advance) and `elspeth-obs-a076365f64` (P3 test-file fixture extraction).
+- `elspeth-obs-0a1002de6d` is now structurally enforced by `ChatPanel.test.tsx` regression-pin test 3 — can be dismissed.
+
+## Playwright infrastructure verification (do this FIRST)
+
+The Phase 9 plan (line 4567) assumes `tests/playwright/composer-guided.spec.ts` is a new file to create AND assumes an "existing Playwright LLM-stub fixture" is available for Task 9.2. **Both assumptions are unverified.** Before dispatching any Phase 9 implementer, verify:
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode/src/elspeth/web/frontend
+ls tests/playwright/                                       # does the directory exist?
+cat playwright.config.* 2>/dev/null                        # is there a Playwright config?
+grep -rn "page.route\|page.setExtraHTTPHeaders\|LLM.*stub\|stub.*LLM" tests/playwright/ 2>/dev/null
+npx playwright --version                                   # is it installed?
+```
+
+Possible states:
+- **(a) Full Playwright infra exists + LLM-stub fixture exists:** proceed straight to Task 9.1.
+- **(b) Playwright infra exists, no LLM-stub fixture:** Task 9.1 (recipe-match path, no LLM needed) can proceed; Task 9.2 needs the fixture built first.
+- **(c) No Playwright infra at all:** Phase 9 has an implicit Task 9.0a (set up Playwright) that the plan does not call out. Scope this explicitly before starting; the plan body has shown drift in every prior phase.
+
+If you find state (c), pause and brief the operator before scaffolding Playwright unilaterally — it's a non-trivial dev-dep addition and may interact with the worktree's broken ESLint v9 migration.
+
+## Sequencing decisions
+
+### Recommended Task 0 — Focus-on-step-advance (`elspeth-obs-5ea21f94af`)
+
+The Phase 8 cross-task reviewer flagged this as the most actionable Phase-9-blocking deferral. Reasoning:
+
+- Spec §7.4 line 484 says: *"Maintain focus on the first interactive element of the new turn after step advance (reuse existing `useFocusTrap` patterns)."*
+- Today, when `respondGuided` resolves and a new turn arrives, focus stays wherever the user was — typically the just-clicked button (now unmounted). Focus then falls to `<body>`.
+- Task 9.1's demo SLA assertion is `expect(clicks).toBeLessThanOrEqual(7); expect(Date.now() - start).toBeLessThan(30_000);`. Without focus management, the user has to Tab through the document body to reach each new turn's first interactive — Tab counts as a keypress, not a click, but the **timing** budget will absorb the user-thinking time of "where did focus go?"
+- Three implementation options are documented in the observation. Recommended: option (c) — a `useEffect` in `ChatPanel` keyed on `guidedNextTurn.step_index` that queries the log region for the first focusable element. Centralized, decoupled, doesn't require new widget contracts.
+
+If you decide to skip this and address it post-Phase-9, document the decision in the dispatch brief for the Task 9.1 implementer so they know to budget extra Tab time in the SLA assertion (or to set up keyboard-driven E2E navigation differently).
+
+### Task 9.1 — Recipe-match happy path (UNBLOCKED — safe to dispatch)
+
+The plan body at line 4564 sketches the test. The path:
+1. Create new session
+2. Attach CSV blob
+3. **Step 1 (source):** pick CSV via `SingleSelectTurn`; confirm columns via `InspectAndConfirmTurn`
+4. **Step 2 (sink):** pick JSONL via `SingleSelectTurn`; declare required field "category" via `MultiSelectWithCustomTurn`
+5. **Step 2.5 (recipe pre-match):** recipe found → `RecipeOfferTurn` → Apply
+6. **Termination:** `CompletionSummary` → Save and exit
+
+Backend dependencies for 9.1:
+- Step 1/2/2.5 handlers all complete at Phase 5 close. ✅
+- Recipe pre-match logic complete at Phase 2.3. ✅
+- `CompletionSummary` wired at Phase 7 + ChatPanel integration at Phase 8. ✅
+
+**No blockers.** Task 9.1 is the obvious starting point.
+
+### Task 9.2 — Hand-built path (HARD-BLOCKED)
+
+The plan body at line 4612 says: *"Use the existing Playwright LLM-stub fixture. Force pre-match to fail (e.g., DB sink), drive Step 3 through the chain proposal, accept, complete."*
+
+**Blocker:** `elspeth-2c08408170`. The backend Step-3 handler in `routes.py:2030-2137` consumes only `chosen: ["accept"]` (success path) and `chosen: ["reject"]` (501 stub). The per-step Edit and Ask-advisor buttons remain absent from `ProposeChainTurn` widget UI (Phase 7 deferred them). A Playwright test of the hand-built path can only exercise Accept-all today.
+
+Three options:
+1. **Land `elspeth-2c08408170` first** (preferred per project memory `feedback_default_is_fix_not_ticket`). This is several backend tasks; consult the spec §3 Step 3 transforms and `routes.py:2030-2137` for the missing handlers.
+2. **Rescope Task 9.2 to Accept-only.** Document that Reject/Edit/Ask-advisor paths are deferred. The Playwright test exercises only the success path of Step 3.
+3. **Defer Task 9.2 entirely.** Phase 9 ships 9.1 + 9.3; 9.2 lands once backend completes.
+
+The right choice depends on demo timing. If the demo needs the hand-built path to demonstrate LLM-driven chain proposal, option 1 is required. If the demo only needs to show that hand-built exists as a fallback (without full button surface), option 2 is sufficient. **Surface this decision to the operator before starting 9.2** — it's a sequencing call, not a technical one.
+
+### Task 9.3 — Auto-drop path (UNBLOCKED)
+
+The plan body at line 4623 says: *"Force LLM stub to return invalid chains twice; assert wizard auto-drops and freeform `<ChatInput>` appears with the partial pipeline state in `compositionState`."*
+
+The auto-drop logic was finalized in Phase 5 (per `project_phase5_implementation_complete` memory: "auto-drop + progressive disclosure + audit-emission tests"). The discriminator's fall-through-to-freeform branch is verified by `ChatPanel.test.tsx` test 4 (Phase 8). 
+
+**Blocker:** depends on LLM-stub fixture availability (see §"Playwright infrastructure verification" state b/c). If the fixture exists, 9.3 is unblocked. If not, building the fixture is shared work with Task 9.2.
+
+## Per-task dispatch hints
+
+### For Task 9.1 dispatch
+
+**Files to read first:**
+- `docs/superpowers/plans/2026-05-11-composer-guided-mode.md:4564-4610` — plan body
+- `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md:1.3` — demo SLA spec (≤4 user actions for source/sink/required-fields/recipe in <30s; the plan's "≤7 clicks" budget adds session-creation + blob-attach overhead)
+- `tests/playwright/composer-guided.spec.ts` if it exists (it shouldn't yet; Phase 9 creates it)
+- `src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx` — the discriminator surfaces and class hooks (`chat-panel--guided`, `chat-panel--completed`, `chat-panel-guided-log`)
+
+**Plan-vs-reality drift to override:**
+- The plan's `page.click('button:has-text("CSV")')` selectors may break if the SingleSelectTurn widget's button labels differ from "CSV" / "JSONL" — verify against `list_sources` / `list_sinks` MCP tool output OR the test fixtures in `src/api/client.guided.test.ts` for actual option labels.
+- The plan's `page.fill('[placeholder*="custom"]', "category")` selector assumes the MultiSelectWithCustomTurn's custom input has placeholder containing "custom" — verify against `src/components/chat/guided/MultiSelectWithCustomTurn.tsx` (look for `placeholder=`).
+- The plan's `expect(page.locator("text=Save and exit")).toBeVisible()` assumes CompletionSummary's button label is "Save and exit" — confirmed correct (verified in Phase 7 `CompletionSummary.tsx`).
+
+**Demo-SLA budget reasoning:**
+- Plan budget: ≤7 clicks. Source pick (1) + columns confirm (1) + sink pick (1) + required-field type+add (counts as 1 user action with the input + add button, but Playwright counts the button click as 1 — plus the `.fill` doesn't count as a click) + continue (1) + apply recipe (1) + save and exit (1) = 7. New session + blob attach are the slack.
+- Plan budget: <30s. End-to-end including network round-trips. If the worktree's backend is running locally with no LLM call on the recipe-match path (deterministic pre-match), 30s is loose. If anything in the chain hits an LLM, you'll blow the budget.
+- If `elspeth-obs-5ea21f94af` is unresolved, add Tab-cycle time to your mental budget — each step advance forces the user to navigate to the new turn's first interactive.
+
+### For Task 9.2 dispatch (only if unblocked)
+
+**Pre-condition:** `elspeth-2c08408170` landed (option 1) OR the dispatch brief explicitly rescopes 9.2 to Accept-only (option 2).
+
+**Files to read first:**
+- `docs/superpowers/plans/2026-05-11-composer-guided-mode.md:4612-4620` — plan body
+- `src/elspeth/web/sessions/routes.py:2030-2137` — Step-3 backend handler current state
+- `src/elspeth/web/composer/llm_chain_solver.py` — LLM chain solver (Phase 4 deliverable)
+- `src/elspeth/web/composer/guided/state_machine.py` — guided state machine
+- `src/components/chat/guided/ProposeChainTurn.tsx` — widget; note 3 deferred buttons
+
+**LLM stub fixture pattern (if it exists):**
+Look for `MockLLM`, `stubLLM`, `page.route('**/api/**llm**', ...)`, or similar in `tests/playwright/` or `tests/` more broadly. If you find a pattern, use it; if not, building one is non-trivial and should be a separate task.
+
+**Force pre-match to fail:** the plan suggests `DB sink` as an example. Verify what sinks are in the deterministic recipe table (`src/elspeth/web/composer/recipes.py` or similar) and pick something NOT in it. CSV → DB sink, or JSONL → S3 sink, are likely candidates.
+
+### For Task 9.3 dispatch
+
+**Files to read first:**
+- `docs/superpowers/plans/2026-05-11-composer-guided-mode.md:4622-4628` — plan body
+- `src/elspeth/web/composer/guided/auto_drop.py` (or wherever auto-drop logic lives — search for `auto_drop` or `solver_exhausted`)
+- `tests/integration/web/composer/guided/test_*auto_drop*.py` — Phase 5 auto-drop tests for assertion shape
+- `src/components/chat/ChatPanel.test.tsx` test 4 (freeform fall-through) — what the post-drop state should look like
+
+**Force LLM stub to return invalid chains twice:**
+The auto-drop trigger (per spec §3.5 and §9.4) is `solver_exhausted` after a configured retry budget. Verify the budget config (likely 2 retries → 3rd failure triggers drop) and stub the LLM to return chains that the chain validator rejects (e.g., missing required slots, wrong shape, hallucinated plugin names).
+
+**Assert partial state in compositionState:**
+After auto-drop, the freeform `<ChatInput>` should appear (verified by Phase 8 discriminator test 4), and `compositionState.guided_session` should carry the audit trail of what got accomplished pre-drop (per spec §8.2 progressive disclosure: "do not re-run any work it already accomplished"). The test should fetch `compositionState` via the API after drop and assert non-null `guided_session` with completed turns.
+
+## Convention reminders (inherited from Phase 8)
+
+All eight conventions from the Phase 7 handover §"Convention reminders inherited from Phase 7" remain in force. Phase 8 added four more (carried forward to Phase 9):
+
+9. **Three-branch discriminator order is completed-first → active-guided → fall-through.** Phase 9 should NOT add a fourth branch unless absolutely necessary; if it does, more-specific-before-less-specific precedence must hold.
+10. **`chat-panel-guided-log` wraps `<GuidedTurn>` only.** No nesting of additional live regions inside (the "don't nest live regions" convention).
+11. **Symbol-anchored cross-references in comments, never `Filename.tsx:LL-LL`.** Phase 9 will add a Playwright spec file with likely cross-references to widgets and store actions; use class names and function names.
+12. **Discriminator-anchored test assertions over widget-DOM assertions.** Playwright tests for Phase 9 may be tempted to assert on widget internals because they're easier to grab; prefer asserting on the discriminator's class hooks (`chat-panel--guided`, `chat-panel-guided-log`) where possible.
+
+## Plan-vs-reality drift expected in Phase 9
+
+Phase 9 is Playwright E2E. The drift patterns most likely:
+
+- **LLM-stub fixture assumed but not verified.** Plan asserts "existing Playwright LLM-stub fixture" — see §"Playwright infrastructure verification".
+- **Selector specificity assumed in plan body.** Plan uses `button:has-text("CSV")` etc. — actual button labels may differ; verify before locking in.
+- **Demo SLA budget assumed achievable.** The plan's ≤7 clicks / <30s assumes focus management works (otherwise budget the Tab cycles). Surface to operator if focus-on-step-advance is unresolved at Phase 9 start.
+- **`elspeth-2c08408170` blocker not flagged in plan.** Plan body for Task 9.2 assumes a complete Step-3 backend; reality at Phase 9 start is partial. See §"Sequencing decisions".
+- **`elspeth-611fc01d94` (rich step summaries) cosmetic gap.** Plan body for Task 9.1 doesn't assert on GuidedHistory's display content because the wire is hash-only. Demo can describe but not show "Step 1: CSV with cols [price, qty]" until backend extends `TurnRecordResponse`.
+
+## Active follow-ups at Phase 9 start
+
+| Issue | Status | Phase-9 impact |
+|---|---|---|
+| `elspeth-5e905f3c9d` (MultiSelect escape button wire) | Open | Task 9.1 doesn't exercise; Task 9.3 may need workaround if auto-drop scenario depends on Step 2 escape. |
+| `elspeth-2c08408170` (Step-3 backend handler) | Open | **Hard blocker for Task 9.2.** |
+| `elspeth-611fc01d94` (GuidedHistory rich summaries) | Open | Cosmetic gap visible in 9.1's recorded demo; not a Playwright test blocker. |
+| `elspeth-obs-5ea21f94af` (focus on step advance) | Open (P2) | **Soft blocker for Task 9.1 SLA assertion stability.** Strongly recommend landing first. |
+| `elspeth-obs-a076365f64` (test-file fixture extraction) | Open (P3) | Affects `ChatPanel.test.tsx` only; Phase 9 adds Playwright tests in a different file, so not direct. Still worth landing before Phase 9 grows the unit-test file further. |
+| `elspeth-obs-510a4fbdeb` (TurnPayload discriminated-union refactor) | Open | No Phase-9 impact. |
+| `elspeth-obs-f9e991f517` (useNonInitialEffect hook extraction) | Open | No Phase-9 impact. |
+| `elspeth-obs-0a1002de6d` (suppress ExitToFreeformButton on completed) | Resolved by Phase 8 test pin; can be dismissed. | None. |
+
+## Important constraints (do not relitigate)
+
+- **DB migration = delete the DB.** Phase 9 likely won't touch the DB, but if it does (e.g., adding an E2E-only seed fixture), no Alembic / no migration scripts.
+- **Default to worktree.** Stay in `/home/john/elspeth/.worktrees/composer-guided-mode`; do not work in main.
+- **No git stash.** Commit work to a branch if preservation is needed.
+- **No calendar shipping commitments.** ELSPETH ships work-until-done.
+- **Correctness beats performance always.** Even if the demo-SLA assertion fails because of Tab-cycle timing, fix the focus management — don't lower the SLA budget to make a flaky test green.
+- **Default answer is never "log a ticket."** Investigation surfacing a fixable defect MUST fix in-session.
+- **`any` is forbidden in TypeScript.** Playwright specs are TypeScript; same rule.
+- **No optimistic updates.** Server is authoritative.
+- **snake_case wire field names; camelCase store-internal.**
+- **ESLint broken; rely on vitest + tsc.** Playwright's own type-check covers E2E specs.
+- **Symbol-anchored cross-references in comments.**
+- **No PR-open at end of Phase 9.** Phase 10's Task 10.3 opens the umbrella PR.
+
+## First action when you start Phase 9
+
+```bash
+cd /home/john/elspeth/.worktrees/composer-guided-mode
+git log --oneline acf712d2..HEAD | head -10                # confirm Phase 8 close commits + handovers
+cd src/elspeth/web/frontend
+npm test -- --run                                          # expect 412 / 412 pass
+npx tsc -p tsconfig.app.json --noEmit                      # expect clean
+ls tests/playwright/ 2>/dev/null || echo "no playwright dir"
+test -f playwright.config.ts && echo "playwright config exists" || echo "no playwright config"
+npx playwright --version 2>/dev/null || echo "playwright not installed"
+```
+
+If any baseline gate fails, **stop and investigate** before starting Phase 9.
+
+Then make four decisions, in order:
+
+1. **Playwright infra:** state (a), (b), or (c) per §"Playwright infrastructure verification". If (c), brief the operator before scaffolding.
+2. **Focus management:** address `elspeth-obs-5ea21f94af` first, OR proceed without it (with explicit Tab-budget acknowledgement in the Task 9.1 dispatch brief).
+3. **Task 9.2 sequencing:** land `elspeth-2c08408170` backend completion (option 1), rescope 9.2 to Accept-only (option 2), or defer 9.2 entirely (option 3). Surface to operator.
+4. **Task ordering:** with the above decisions, the most likely ordering is: Task 0 (focus) → Task 9.1 (recipe path) → Task 9.3 (auto-drop) → Task 9.2 (hand-built, if option 1/2). Auto-drop before hand-built because 9.3 is unblocked and 9.2 might still be waiting on backend.
+
+## How to dispatch Phase 9 implementers
+
+Phase 9 differs from Phases 6–8 in that the deliverables are **integration tests against a running backend**, not standalone frontend components. The implementer needs:
+
+- A running ELSPETH dev server (typically `elspeth-web` service or `npm run dev`).
+- A way to seed/reset the audit DB between tests (per project memory `project_db_migration_policy`: delete the DB rather than migrate it; the test harness can do this via the API or via direct SQLite file replacement).
+- LLM stub control (per Task 9.2/9.3 — see fixture verification above).
+
+The dispatch brief for each Task 9.X should explicitly tell the implementer:
+- The Playwright test file path (`tests/playwright/composer-guided.spec.ts`)
+- The selector strategy (data-testid > role > text — in that order of preference)
+- The SLA budget reasoning (for 9.1)
+- The expected backend state (running on which port; auth or no auth)
+- The audit-DB-reset mechanism
+
+Phase 8 used the subagent-driven-development skill with general-purpose implementers. Phase 9 may benefit from the same pattern; consider whether you want a Playwright-specialist agent if one exists in the skill marketplace.

--- a/docs/superpowers/handovers/2026-05-12-phase-9-dispatch-brief.md
+++ b/docs/superpowers/handovers/2026-05-12-phase-9-dispatch-brief.md
@@ -104,7 +104,7 @@ The right choice depends on demo timing. If the demo needs the hand-built path t
 
 The plan body at line 4623 says: *"Force LLM stub to return invalid chains twice; assert wizard auto-drops and freeform `<ChatInput>` appears with the partial pipeline state in `compositionState`."*
 
-The auto-drop logic was finalized in Phase 5 (per `project_phase5_implementation_complete` memory: "auto-drop + progressive disclosure + audit-emission tests"). The discriminator's fall-through-to-freeform branch is verified by `ChatPanel.test.tsx` test 4 (Phase 8). 
+The auto-drop logic was finalized in Phase 5 (per `project_phase5_implementation_complete` memory: "auto-drop + progressive disclosure + audit-emission tests"). The discriminator's fall-through-to-freeform branch is verified by `ChatPanel.test.tsx` test 4 (Phase 8).
 
 **Blocker:** depends on LLM-stub fixture availability (see §"Playwright infrastructure verification" state b/c). If the fixture exists, 9.3 is unblocked. If not, building the fixture is shared work with Task 9.2.
 

--- a/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
+++ b/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
@@ -4564,7 +4564,18 @@ Manual: in Chrome devtools, set `prefers-reduced-motion: reduce`; verify step-ad
 ### Task 9.1: Recipe-match happy path
 
 **Files:**
-- Create: `src/elspeth/web/frontend/tests/playwright/composer-guided.spec.ts`
+- Create: `src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts`
+
+> **Plan-vs-reality drift correction (logged 2026-05-12 by Phase 9 controller):**
+> The original plan body assumed (a) the test path lives at `tests/playwright/`, (b) `data-testid="new-session"` and `data-testid="blob-upload"` exist, (c) Step 1 includes `InspectAndConfirmTurn` ("Looks right" button), and (d) ≤7 clicks suffices for the happy path. None of those held when verified empirically.
+>
+> 1. **Path:** the existing E2E suite lives at `src/elspeth/web/frontend/tests/e2e/`, not `tests/playwright/`. Patterns: `tests/e2e/helpers/api.ts` (out-of-band auth + REST), `tests/e2e/page-objects/composer-page.ts`. The `playwright.config.ts` auto-launches uvicorn (:8451) + Vite (:5173) under `webServer` with `composerSettingsEnv` isolation. Use those.
+> 2. **Selectors:** no `data-testid` exists on any guided widget (verified). Use role/text selectors (`getByRole("button", { name: "..." })`) per the existing E2E pattern. Do NOT add testids to production widgets.
+> 3. **InspectAndConfirmTurn is unreachable on the live emission path:** `routes.py:_build_get_guided_turn` hardcodes `blob_inspection=None`, so the only call site of `build_initial_step_1_turn` never takes the `inspect_and_confirm` branch. The widget's response handler exists, but the server never emits it. Filed as a follow-up. The actual happy path is `SINGLE_SELECT (source)` → `SCHEMA_FORM (source options)` → `SINGLE_SELECT (sink)` → `SCHEMA_FORM (sink options)` → `MULTI_SELECT_WITH_CUSTOM (required fields)` → `RECIPE_OFFER (Apply recipe)` → `CompletionSummary (Save and exit)`.
+> 4. **Click budget:** ≤9 clicks under the actual happy path (each SCHEMA_FORM step adds a fill-and-Continue not present in the original plan; required-fields adds an Add+Continue pair). The 30s wall-clock SLA is unchanged and still well within reach (recipe match is deterministic — zero LLM calls).
+> 5. **Backend wire-shape bugs blocked the original plan**: HTTP 422 at SchemaFormTurn submission, HTTP 500 at MultiSelectWithCustomTurn submission. Both fixed pre-Task-9.1 (commits `e05e02b2` + `a5df0b6c`).
+>
+> The pseudocode below has been rewritten against the corrected happy path. Treat it as illustrative — verify actual button labels by reading widget source or probing the running backend before locking in selectors.
 
 - [ ] **Step 1: Write the happy-path E2E**
 
@@ -4573,27 +4584,39 @@ test("guided demo path: CSV → classify-rows-llm-jsonl", async ({ page }) => {
   const start = Date.now();
   let clicks = 0;
 
-  await page.goto("/");
-  // 1. Create new session
-  await page.click('[data-testid="new-session"]'); clicks++;
-  // 2. Attach CSV blob
-  await page.setInputFiles('[data-testid="blob-upload"]', "fixtures/orders.csv");
-  // 3. Step 1: pick CSV, confirm columns
-  await page.click('button:has-text("CSV")'); clicks++;
-  await page.click('button:has-text("Looks right")'); clicks++;
-  // 4. Step 2: pick JSONL, declare required field "category"
-  await page.click('button:has-text("JSONL")'); clicks++;
-  await page.fill('[placeholder*="custom"]', "category");
-  await page.click('button:has-text("Add")');
-  await page.click('button:has-text("Continue")');
-  // 5. Step 2.5: apply recipe
-  await page.click('button:has-text("Apply recipe")'); clicks++;
-  // 6. Termination: save and exit
-  await expect(page.locator("text=Save and exit")).toBeVisible();
-  await page.click('button:has-text("Save and exit")'); clicks++;
+  // Out-of-band: create session + upload CSV blob via REST helpers in
+  // tests/e2e/helpers/api.ts (authedContext, createSession, uploadBlob).
+  // Session-create + blob-upload are NOT counted as clicks.
+  // Then navigate the SPA to the session URL.
+
+  // 1. Step 1 source: pick "csv" chip in SingleSelectTurn.
+  await page.getByRole("button", { name: /csv/i }).click(); clicks++;
+
+  // 2. Step 1 source options: SchemaFormTurn — fill required fields, Continue.
+  await page.getByLabel(/path/i).fill("/tmp/playwright-orders.csv");
+  await page.getByRole("button", { name: /continue/i }).click(); clicks++;
+
+  // 3. Step 2 sink: pick "json" (or "jsonl") chip in SingleSelectTurn.
+  await page.getByRole("button", { name: /json/i }).click(); clicks++;
+
+  // 4. Step 2 sink options: SchemaFormTurn — fill required fields, Continue.
+  await page.getByLabel(/path/i).fill("/tmp/playwright-output.jsonl");
+  await page.getByRole("button", { name: /continue/i }).click(); clicks++;
+
+  // 5. Step 2 required fields: declare "category" via custom input + Add, Continue.
+  await page.getByPlaceholder(/custom/i).fill("category");
+  await page.getByRole("button", { name: /^add$/i }).click(); clicks++;
+  await page.getByRole("button", { name: /continue/i }).click(); clicks++;
+
+  // 6. Step 2.5 recipe pre-match offer: Apply recipe.
+  await page.getByRole("button", { name: /apply recipe/i }).click(); clicks++;
+
+  // 7. Termination: CompletionSummary — Save and exit.
+  await expect(page.getByRole("button", { name: /save and exit/i })).toBeVisible();
+  await page.getByRole("button", { name: /save and exit/i }).click(); clicks++;
 
   // Demo SLA assertions
-  expect(clicks).toBeLessThanOrEqual(7); // a few more than 4 because of session creation + blob attach
+  expect(clicks).toBeLessThanOrEqual(9);  // happy path under corrected step sequence
   expect(Date.now() - start).toBeLessThan(30_000);
 });
 ```
@@ -4604,7 +4627,7 @@ test("guided demo path: CSV → classify-rows-llm-jsonl", async ({ page }) => {
 
 ```bash
 git add -u
-git commit -m "test(frontend/playwright): guided demo path E2E + SLA assertion
+git commit -m "test(frontend/e2e): guided demo path recipe-match E2E + SLA assertion
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ```

--- a/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
+++ b/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
@@ -12,6 +12,153 @@
 
 ---
 
+## Errata & Post-Review Corrections (2026-05-11, rev 2)
+
+**Status:** This plan was reviewed against the actual source tree on 2026-05-11. The architectural shape, phase ordering, and pure-data tasks (Phases 1–2) are correct. **The HTTP routing layer, tool-handler signatures, audit interface, and frontend conventions are wrong in the original draft.** Read this errata block before starting any task. Each correction is referenced inline in the affected tasks below with the marker **[ERRATA Cn — see top of file]**.
+
+Until the inline tasks are revised, treat the errata block as authoritative when the two disagree.
+
+### C1. `_execute_*` tool-handler signatures — all task descriptions in Phases 3 and 4 are wrong
+
+Plan writes `new_state, tool_result = _execute_set_source(state, payload)`. Actual signature (`tools.py:2371`) is:
+
+```python
+def _execute_set_source(
+    args: dict[str, Any],
+    state: CompositionState,
+    catalog: CatalogService,
+    data_dir: str | None = None,
+) -> ToolResult: ...
+```
+
+Every `_execute_*` function in `tools.py` follows the `(args: dict, state, catalog, data_dir, **kwargs)` pattern. `ToolResult` (defined at `tools.py:347`) is a single dataclass — `result.success`, `result.updated_state`, `result.validation`, `result.affected_nodes`, `result.data`, `result.prior_validation`, `result.runtime_preflight` — NOT a `(state, result)` tuple.
+
+Step handlers in `composer/guided/steps.py` must (a) accept `catalog: CatalogService` and `data_dir: str | None` parameters passed in from the route handler, and (b) construct the `args` dict and read `ToolResult` attributes correctly. Tasks 3.1, 3.2, 3.3, 4.4 affected.
+
+### C2. Use `_execute_apply_pipeline_recipe`, not raw `apply_recipe` + `_execute_set_pipeline`
+
+`tools.py:3748` already wraps recipe application with full validation, audit emission via `ComposerToolInvocation`, and a `replaced_pipeline_note`. Task 3.3 (`handle_step_2_5_recipe_apply`) calls:
+
+```python
+result = _execute_apply_pipeline_recipe(
+    {"recipe_name": match.recipe_name, "slots": dict(match.slots)},
+    state, catalog, data_dir,
+    session_engine=session_engine, session_id=session_id,
+)
+```
+
+Reusing the canonical executor — not a two-step manual application — means audit records emit automatically through existing plumbing.
+
+### C3. HTTP routes live in `sessions/routes.py`, not `service.py`; prefix is `/api/sessions/{session_id}/...`
+
+The plan's "`@router.post` decorators in `service.py`" pattern is wrong:
+
+- `service.py` contains `ComposerServiceImpl` (a service class). No routing decorators.
+- Composer routes are mounted by `src/elspeth/web/sessions/routes.py:1499` under `APIRouter(prefix="/api/sessions", tags=["sessions"])`. The freeform chat endpoint is `POST /api/sessions/{session_id}/messages` at line 1629.
+- Composer state loads via `service.get_current_state(session.id)`; new sessions construct `CompositionState(source=None, nodes=(), edges=(), outputs=(), metadata=PipelineMetadata(), version=1)` — required-arg constructor, NOT the no-arg `CompositionState()` the plan's tests assume.
+
+Phase 3 tasks 3.4 and 3.5 must mount:
+- `POST /api/sessions/{session_id}/guided/start` (likely redundant per C7; see below)
+- `POST /api/sessions/{session_id}/guided/respond`
+
+…and reuse `_verify_session_ownership`, `_get_session_compose_lock_registry`, and the rate limiter — the same dependency-injection block as `send_message`. Test URLs prefixed `/composer/sessions/...` and `/composer/guided/...` throughout Phase 3, 5, 9 must become `/api/sessions/.../guided/...`.
+
+### C4. Audit emission: reuse `ComposerToolInvocation` with `tool_name` discriminator (Option A)
+
+The plan invents `BufferingRecorder.record_guided_event(GuidedAuditEvent(...))`. This method doesn't exist. `BufferingRecorder` (audit.py:179) only has `record(ComposerToolInvocation)` and `record_llm_call(ComposerLLMCall)`. Persistence routes through `audit_envelope` into the `tool_calls` JSON column on the assistant message row.
+
+**Decision: Option A — reuse `ComposerToolInvocation` with a `tool_name` discriminator.** The four event types become four `tool_name` values: `guided_turn_emitted`, `guided_turn_answered`, `guided_step_advanced`, `guided_dropped_to_freeform`. Payloads slot into the existing `arguments` / `result` fields. No contract type changes, no schema migration. Task 1.6 must construct `ComposerToolInvocation` records and call `recorder.record(invocation)` — there is no `record_guided_event` method.
+
+If the audit consumer side ever needs richer guided-specific replay than `ComposerToolInvocation` exposes, split a `GuidedTurnInvocation` sibling contract type later; not v1.
+
+### C5. Frontend API client is module-level `export async function`, not a class
+
+`src/elspeth/web/frontend/src/api/client.ts` exports `export async function fetchSessions()`, `createSession()`, etc. — no class. Phase 6 task 6.2 needs:
+
+```typescript
+export async function postGuidedStart(sessionId: string): Promise<GuidedStartResponse> { ... }
+export async function postGuidedRespond(sessionId: string, turnResponse: TurnResponse): Promise<GuidedRespondResponse> { ... }
+```
+
+Vitest mocks become `vi.spyOn(api, "postGuidedStart")` (import-namespace), not `vi.spyOn(apiClient, "postGuidedStart")` (class-method).
+
+### C6. `sessionStore`: single `guidedTurn` atomic object, not separate `guidedSession` + `guidedNextTurn`
+
+The plan ends with two store fields (`guidedSession` and `guidedNextTurn`) plus comments admitting the awkwardness — the server response is atomic, so the store should be too. Collapse into one:
+
+```typescript
+interface GuidedTurnState {
+  session: GuidedSession;
+  next_turn: Turn | null;
+  terminal: TerminalState | null;
+}
+
+interface GuidedSlice {
+  guidedTurn: GuidedTurnState | null;
+  startGuided: (sessionId: string) => Promise<void>;
+  respondGuided: (turnResponse: TurnResponse) => Promise<void>;
+  exitToFreeform: () => Promise<void>;
+}
+```
+
+Every server response replaces `guidedTurn` atomically; `compositionState` updates alongside it. ChatPanel reads `guidedTurn` once instead of three separate fields. Affects Phase 6 task 6.3 and Phase 8 task 8.1.
+
+### C7. New sessions default to guided per spec §5.2 — remove `/guided/start` endpoint
+
+The plan adds an explicit `POST .../guided/start` RPC. Spec §5.2 says guided is the default for new sessions: `composition_state.guided_session = GuidedSession.initial()` is attached at session-create time. The two are inconsistent.
+
+**Decision: default-guided.** Modify the session-create route (`sessions/routes.py:1501`) to attach `GuidedSession.initial()` to the freshly-constructed `CompositionState`. The frontend renders guided UI when `composition_state.guided_session != null`. The `/guided/start` endpoint becomes unnecessary; remove from Phase 3 task 3.4 and from the frontend store's `startGuided` action.
+
+The session-create change is one Python edit at line ~1663 (passing `guided_session=GuidedSession.initial()` to the `CompositionState` constructor); add it as the first sub-step of Phase 3 task 3.4 (which becomes "wire `/guided/respond` only — `/guided/start` is dropped").
+
+### C8. Recipe-match predicates must be derived from actual recipe slot schemas
+
+Phase 2 task 2.3 invents predicates from prose. The three registered recipes are in `composer/recipes.py`:
+- `_build_classify_recipe` (line 236) — slots include prompt_template, model, csv_blob_id, output_path, output_field
+- `_build_threshold_recipe` (line 337) — slots include threshold, field_to_check, above/below output paths
+- `_build_fork_coalesce_truncate_recipe` (line 472) — fork shape, truncate-arm config, jsonl outputs
+
+Task 2.3 must add a Step 0: read each recipe's `_build_*` function and its `SlotSpec` declarations to identify which slots are required vs optional, then design predicates whose `slot_resolver` maps observed (Source, Sink) state to exactly the required slot set. Predicates that cannot resolve a required slot from observed state must return `False`. The plan's invented predicates (`_classify_predicate`, `_split_threshold_predicate`) are placeholders only — the implementation must verify against the actual `SlotSpec` lists.
+
+### C9. Step 1 handler must run `inspect_blob_content` before emitting `inspect_and_confirm`
+
+The plan describes the inspection turn but doesn't call out the inspection call. Actual function: `inspect_blob_content(content, filename, mime_type, blob_id=...)` in `composer/source_inspection.py:80` returns `SourceInspectionFacts`. Task 3.1 must:
+1. Before emitting `inspect_and_confirm`, read the attached blob (via existing blob-store API) and call `inspect_blob_content(...)`.
+2. Package the resulting `SourceInspectionFacts` (columns, sample rows, warnings) into the turn's `payload.observed`.
+3. If no blob is attached, emit `schema_form` (manual options) or `single_select` (pick plugin) instead — the inspection path is conditional on blob presence.
+
+### C10. Test fixture inventory check before Phase 3 begins
+
+The plan references `composer_test_client`, `audit_recorder`, and `chaosllm_stub` fixtures. Actual state:
+- `tests/fixtures/chaosllm.py:223` defines `chaosllm_server` (note the fixture name — `chaosllm_server`, not `chaosllm_stub`).
+- No `composer_test_client` or `audit_recorder` fixture exists yet. The closest existing pattern lives in `tests/unit/web/composer/test_route_integration.py` (TestClient construction + recorder wiring). Read this before writing new fixtures.
+
+Add a Phase 3 prerequisite task (3.0): "Read `tests/unit/web/composer/test_route_integration.py` for the established FastAPI TestClient + recorder fixture pattern; create `tests/integration/web/composer/guided/conftest.py` with `composer_test_client` and `audit_recorder` fixtures matching that pattern."
+
+### Phase-level corrections summary
+
+| Phase | Status | Reason |
+|---|---|---|
+| 1 | Keep, fold C4 + C5 (CompositionState construction) | Audit module reuses `ComposerToolInvocation`; state field add still correct |
+| 2 | Keep, fold C8 (read recipes first) | Recipe predicates need real slot schemas |
+| 3 | **Revise** per C1, C2, C3, C7, C9, C10 | Tool signatures, routing layer, source inspection, fixtures |
+| 4 | Keep, fold C1 (handler signatures) | Chain solver structure correct; commit path needs handler-signature fix |
+| 5 | Keep | Auto-drop, progressive disclosure, audit emission test correct |
+| 6 | **Revise** per C5, C6 | Module-level api fns, single atomic store object |
+| 7 | Keep | Widget specs correct |
+| 8 | Revise per C6 | Single guidedTurn read |
+| 9 | Keep, fix URL prefixes per C3 | E2E flows valid; URLs were `/composer/...` instead of `/api/sessions/...` |
+| 10 | Keep | Docs |
+
+### Two pre-flight decisions confirmed (do not relitigate)
+
+1. **C4 Option A — reuse `ComposerToolInvocation` with `tool_name` discriminator.** Cheapest path; ships sooner; replay tooling already understands it.
+2. **C7 default-guided.** Matches spec §5.2; removes `/guided/start` endpoint and `startGuided` store action; new sessions begin in guided mode.
+
+If either decision needs reopening, do it via a plan revision PR before implementation starts.
+
+---
+
 ## Pre-Flight: File Structure Map
 
 ### New files (backend)

--- a/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
+++ b/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
@@ -590,7 +590,7 @@ class Turn(TypedDict):
 .venv/bin/python -m pytest tests/unit/web/composer/guided/test_protocol.py -v
 ```
 
-Expected: 11 passed.
+Expected: 12 passed (8 from Task 1.1 + 4 new).
 
 - [ ] **Step 4: Commit**
 
@@ -739,7 +739,7 @@ def validate_payload(turn_type: TurnType, payload: Mapping[str, Any]) -> str | N
 .venv/bin/python -m pytest tests/unit/web/composer/guided/test_protocol.py -v
 ```
 
-Expected: 17 passed.
+Expected: 19 passed (12 from prior tasks + 7 new).
 
 - [ ] **Step 4: Commit**
 
@@ -828,7 +828,7 @@ class TestGuidedSession:
 
     def test_session_history_is_immutable_tuple(self) -> None:
         s = GuidedSession.initial()
-        with pytest.raises(TypeError):
+        with pytest.raises(AttributeError):
             s.history.append(None)  # type: ignore[attr-defined]
 
     def test_session_with_terminal_set(self) -> None:
@@ -981,7 +981,7 @@ class GuidedSession:
 .venv/bin/python -m pytest tests/unit/web/composer/guided/test_state_machine.py -v
 ```
 
-Expected: 7 passed.
+Expected: 8 passed (3 TestTerminalState + 2 TestTurnRecord + 3 TestGuidedSession).
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
+++ b/docs/superpowers/plans/2026-05-11-composer-guided-mode.md
@@ -4744,4 +4744,3 @@ No spec sections without tasks.
 ---
 
 **End of plan.**
-

--- a/docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md
+++ b/docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md
@@ -348,15 +348,20 @@ Both are pure functions of `(state, response) → (next_state, next_turn)`. The 
 def step_advance(
     session: GuidedSession,
     response: TurnResponse,
-    state: CompositionState,
-) -> tuple[GuidedSession, Turn | None, TerminalState | None, list[GuidedAuditEvent]]:
+    *,
+    current_turn_type: TurnType,
+) -> tuple[GuidedSession, Turn | None, TerminalState | None, list[GuidedAuditDirective]]:
     """
     Apply the user's response to the current guided session. Returns:
-      (new_session, next_turn_or_None, terminal_state_or_None, audit_events_to_emit)
+      (new_session, next_turn_or_None, terminal_state_or_None, directives_to_emit)
     """
 ```
 
-The function encodes the legal-turn matrix, the step transitions, and the terminal-condition checks. It is unit-testable in isolation (no I/O, no LLM, no DB).
+The function encodes the legal-turn matrix, the step transitions, and the terminal-condition checks. It is unit-testable in isolation (no I/O, no LLM, no DB, no clock, no uuid).
+
+`GuidedAuditDirective` (defined in `state_machine.py`) is the pure-function-return shape for audit instructions: a frozen `(tool_name, arguments)` pair where `tool_name` is one of the four discriminator strings (`guided_turn_emitted`, `guided_turn_answered`, `guided_step_advanced`, `guided_dropped_to_freeform`) and `arguments` is the payload mapping. The route handler (§6.2) fans each directive out to the matching `emit_*` helper in `composer/guided/audit.py`, supplying the runtime-only fields (`tool_call_id`, `started_at`/`finished_at`, `version_before`/`version_after`, `actor`) that bind it to a live `ComposerToolInvocation` record per Errata C4. The on-the-wire audit record is still `ComposerToolInvocation`; no new L0 contract type was introduced.
+
+The `state: CompositionState` parameter from earlier drafts of this section was dropped during Phase 2 implementation — `step_advance` is structurally pure over `(session, response, current_turn_type)` alone, with composition-state mutations deferred to the route handler (which already holds the version snapshot needed for the audit record).
 
 ### 6.4 Recipe pre-match
 

--- a/scripts/cicd/check_slot_type_cross_language.py
+++ b/scripts/cicd/check_slot_type_cross_language.py
@@ -1,0 +1,144 @@
+"""Cross-language consistency check: Python SlotType Literal vs TypeScript mirror.
+
+Usage:
+    python scripts/cicd/check_slot_type_cross_language.py
+
+Exit codes:
+    0 — both sets are equal (prints OK + canonical set)
+    1 — sets diverge (prints both sets and the diff)
+
+Design:
+    SlotType is a Literal in recipes.py, not a StrEnum, so extraction is done
+    by importing the module and using ``typing.get_args`` rather than walking
+    enum members.  This is simpler than AST parsing and exercises the real
+    runtime value.
+
+    The TypeScript union is extracted by regex: we locate the ``slot_type``
+    field in the RecipeSlotInput interface in guided.ts and parse the
+    string-literal union members.  This is deliberately lightweight — no
+    TypeScript parser dependency required.
+
+    Both sets are sorted before comparison and before output so the script
+    is byte-stable across runs (deterministic for citation purposes).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, get_args, get_type_hints
+
+# Canonical paths relative to the repository root (where this script is run from)
+_PYTHON_SOURCE = Path("src/elspeth/web/composer/recipes.py")
+_TS_SOURCE = Path("src/elspeth/web/frontend/src/types/guided.ts")
+
+# ---------------------------------------------------------------------------
+# Python side: import SlotType and extract Literal members via get_args
+# ---------------------------------------------------------------------------
+
+
+def _extract_python_members() -> set[str]:
+    """Return the set of SlotType string members from recipes.py.
+
+    Imports the module directly and uses typing.get_args on the Literal type.
+    This is authoritative: it exercises the same value the runtime uses.
+    """
+    # Ensure the src tree is importable from the CWD (repo root)
+    sys.path.insert(0, "src")
+    try:
+        from elspeth.web.composer.recipes import SlotType  # type: ignore[attr-defined]
+
+        args = get_args(SlotType)
+        if not args:
+            # SlotType might be imported as a re-export; try get_type_hints fallback
+            import elspeth.web.composer.recipes as _mod  # type: ignore[import-untyped]
+
+            hints: dict[str, Any] = get_type_hints(_mod)
+            args = get_args(hints.get("SlotType", SlotType))
+        return {str(a) for a in args}
+    finally:
+        if "src" in sys.path:
+            sys.path.remove("src")
+
+
+# ---------------------------------------------------------------------------
+# TypeScript side: regex extraction from guided.ts
+# ---------------------------------------------------------------------------
+
+# Pattern targets the slot_type field in RecipeSlotInput:
+#   slot_type: "blob_id" | "str" | "float" | "int" | "str_list";
+#
+# The interface may span multiple lines; the regex allows for whitespace and
+# newlines between tokens.  It looks for ``slot_type:`` followed by a string-
+# literal union ending at a semicolon.  Groups of ``"value"`` tokens separated
+# by ``|`` are captured greedily.
+_TS_FIELD_RE = re.compile(
+    r"slot_type\s*:\s*((?:\"[^\"]+\"\s*\|?\s*)+?)\s*;",
+    re.MULTILINE | re.DOTALL,
+)
+
+_TS_MEMBER_RE = re.compile(r'"([^"]+)"')
+
+
+def _extract_ts_members(ts_path: Path) -> set[str]:
+    """Return the set of ``slot_type`` union members from guided.ts.
+
+    Parses the string-literal union with a regex; does not require a
+    TypeScript toolchain.  Tolerant of whitespace, newlines, and trailing
+    commas in the union.
+    """
+    content = ts_path.read_text(encoding="utf-8")
+    match = _TS_FIELD_RE.search(content)
+    if not match:
+        raise ValueError(
+            f"Could not locate `slot_type: ...;` field in {ts_path}. "
+            "Check that the RecipeSlotInput interface is present and "
+            "the field uses a string-literal union type."
+        )
+    union_text = match.group(1)
+    members = _TS_MEMBER_RE.findall(union_text)
+    if not members:
+        raise ValueError(f"Regex matched slot_type field in {ts_path} but extracted no string literals from: {union_text!r}")
+    return set(members)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the cross-language consistency check.  Returns 0 on success, 1 on drift."""
+    # Verify expected source files exist from CWD
+    for path in (_PYTHON_SOURCE, _TS_SOURCE):
+        if not path.exists():
+            print(
+                f"ERROR: expected source file not found: {path}\nRun this script from the repository root.",
+                file=sys.stderr,
+            )
+            return 1
+
+    py_members = _extract_python_members()
+    ts_members = _extract_ts_members(_TS_SOURCE)
+
+    if py_members == ts_members:
+        canonical = sorted(py_members)
+        print(f"OK — SlotType members are in sync: {canonical}")
+        return 0
+
+    # Drift detected — report both sets and the diff
+    only_python = sorted(py_members - ts_members)
+    only_ts = sorted(ts_members - py_members)
+    print("FAIL — SlotType / guided.ts mirror has drifted.", file=sys.stderr)
+    print(f"  Python members ({_PYTHON_SOURCE}): {sorted(py_members)}", file=sys.stderr)
+    print(f"  TypeScript members ({_TS_SOURCE}): {sorted(ts_members)}", file=sys.stderr)
+    if only_python:
+        print(f"  In Python only (add to TypeScript): {only_python}", file=sys.stderr)
+    if only_ts:
+        print(f"  In TypeScript only (add to Python or remove from TS): {only_ts}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/elspeth/contracts/audit.py
+++ b/src/elspeth/contracts/audit.py
@@ -737,6 +737,9 @@ class TerminalPairFieldConstraints:
     exact: Mapping[str, object] = field(default_factory=dict)
     forbidden: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        freeze_fields(self, "exact")
+
 
 _DISCRIMINATOR_FIELDS = (
     "sink_name",

--- a/src/elspeth/plugins/transforms/batch_data_quality_report.py
+++ b/src/elspeth/plugins/transforms/batch_data_quality_report.py
@@ -16,6 +16,7 @@ from typing import Any
 from pydantic import Field, field_validator, model_validator
 
 from elspeth.contracts.contexts import TransformContext
+from elspeth.contracts.freeze import freeze_fields
 from elspeth.contracts.schema import SchemaConfig
 from elspeth.contracts.schema_contract import FieldContract, PipelineRow, SchemaContract
 from elspeth.plugins.infrastructure.base import BaseTransform
@@ -54,6 +55,9 @@ class _QualityStats:
     observed_type_counts: Mapping[str, int]
     valid_values: tuple[object, ...]
 
+    def __post_init__(self) -> None:
+        freeze_fields(self, "observed_type_counts", "valid_values")
+
     @property
     def observed_count(self) -> int:
         return sum(self.observed_type_counts.values())
@@ -91,7 +95,7 @@ class BatchDataQualityReport(BaseTransform):
 
     name = "batch_data_quality_report"
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:732ed1d012c5f982"
+    source_file_hash: str | None = "sha256:c9e49d03239b8195"
     config_model = BatchDataQualityReportConfig
     is_batch_aware = True
 

--- a/src/elspeth/web/app.py
+++ b/src/elspeth/web/app.py
@@ -390,6 +390,7 @@ def create_app(settings: WebSettings | None = None) -> FastAPI:
 
     session_service = SessionServiceImpl(session_engine, data_dir=settings.data_dir)
     app.state.session_service = session_service
+    app.state.session_engine = session_engine  # available to guided step handlers
 
     # --- Blob service ---
     app.state.blob_service = BlobServiceImpl(

--- a/src/elspeth/web/composer/guided/__init__.py
+++ b/src/elspeth/web/composer/guided/__init__.py
@@ -1,0 +1,4 @@
+"""Guided-mode composer protocol module.
+
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md.
+"""

--- a/src/elspeth/web/composer/guided/audit.py
+++ b/src/elspeth/web/composer/guided/audit.py
@@ -242,7 +242,7 @@ def emit_dropped_to_freeform(
         actor: Stable identity of the driving actor.
     """
     payload: dict[str, Any] = {
-        "step_index": prev.value,
+        "prev_step": prev.value,
         "drop_reason": drop_reason.value,
     }
     if validation_result is not None:

--- a/src/elspeth/web/composer/guided/audit.py
+++ b/src/elspeth/web/composer/guided/audit.py
@@ -1,0 +1,258 @@
+"""Guided-mode audit event emission.
+
+Per Errata C4: the four event types (turn_emitted, turn_answered,
+step_advanced, dropped_to_freeform) are recorded as
+:class:`~elspeth.contracts.composer_audit.ComposerToolInvocation` records
+with a ``tool_name`` discriminator. No new audit primitive, no schema
+migration, no ``record_guided_event()`` method.
+
+Tier 1 (audit-trust). Coercion forbidden — invalid input crashes.
+Events go through the existing recorder via ``recorder.record(invocation)``.
+
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §9.1.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from elspeth.contracts.composer_audit import (
+    ComposerToolInvocation,
+    ComposerToolRecorder,
+    ComposerToolStatus,
+)
+from elspeth.core.canonical import canonical_json, stable_hash
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
+from elspeth.web.composer.guided.state_machine import TerminalReason
+
+# Closed allowlists for discriminator fields. Checked before construction so
+# the audit trail never records a record with an invalid discriminator value.
+_VALID_EMITTERS: frozenset[str] = frozenset({"server", "llm"})
+_VALID_ADVANCE_REASONS: frozenset[str] = frozenset({"recipe_applied", "user_advanced", "auto_advanced"})
+
+
+def _build_invocation(
+    *,
+    tool_name: str,
+    payload: Mapping[str, Any],
+    composition_version: int,
+    actor: str,
+    now: datetime,
+) -> ComposerToolInvocation:
+    """Construct a ComposerToolInvocation for a synthetic guided event.
+
+    Guided events are observations — there is no result payload (the
+    ``arguments_canonical`` IS the record). ``result_canonical`` and
+    ``result_hash`` are therefore ``None`` on a SUCCESS record, which
+    deviates from the typical pattern (where None signals incomplete
+    dispatch). The deviation is deliberate per Errata C4: these events
+    have no LLM tool-call result; they are audit observations, not
+    tool invocations in the traditional sense.
+
+    ``version_before == version_after``: guided events observe state
+    but do not mutate it. ``latency_ms == 0``: synthetic events have
+    no measurable processing latency. ``started_at == finished_at``
+    captures the wall-clock instant of emission.
+    """
+    args_canonical = canonical_json(payload)
+    args_hash = stable_hash(payload)
+    return ComposerToolInvocation(
+        tool_call_id=uuid.uuid4().hex,
+        tool_name=tool_name,
+        arguments_canonical=args_canonical,
+        arguments_hash=args_hash,
+        result_canonical=None,
+        result_hash=None,
+        status=ComposerToolStatus.SUCCESS,
+        error_class=None,
+        error_message=None,
+        version_before=composition_version,
+        version_after=composition_version,
+        started_at=now,
+        finished_at=now,
+        latency_ms=0,
+        actor=actor,
+    )
+
+
+def emit_turn_emitted(
+    recorder: ComposerToolRecorder,
+    *,
+    step: GuidedStep,
+    turn_type: TurnType,
+    payload_hash: str,
+    payload_payload_id: str,
+    emitter: str,
+    composition_version: int,
+    actor: str,
+) -> None:
+    """Record a ``guided_turn_emitted`` audit event.
+
+    Fires when the guided-mode server (or LLM acting within the guided
+    protocol) emits a turn to the user.
+
+    Args:
+        recorder: The composition session's active recorder.
+        step: The wizard step at which the turn is emitted.
+        turn_type: The taxonomy type of the turn payload.
+        payload_hash: SHA-256 hex digest of the turn payload blob.
+        payload_payload_id: Payload-store ID of the turn payload blob.
+        emitter: Who constructed this turn — ``"server"`` or ``"llm"``.
+        composition_version: Current ``CompositionState.version``.
+        actor: Stable identity of the driving actor.
+
+    Raises:
+        ValueError: If ``emitter`` is not one of ``{"server", "llm"}``.
+    """
+    if emitter not in _VALID_EMITTERS:
+        raise ValueError(f"emitter must be one of {sorted(_VALID_EMITTERS)}, got {emitter!r}")
+    payload: dict[str, Any] = {
+        "step_index": step.value,
+        "turn_type": turn_type.value,
+        "payload_hash": payload_hash,
+        "payload_payload_id": payload_payload_id,
+        "emitter": emitter,
+    }
+    now = datetime.now(UTC)
+    invocation = _build_invocation(
+        tool_name="guided_turn_emitted",
+        payload=payload,
+        composition_version=composition_version,
+        actor=actor,
+        now=now,
+    )
+    recorder.record(invocation)
+
+
+def emit_turn_answered(
+    recorder: ComposerToolRecorder,
+    *,
+    step: GuidedStep,
+    turn_type: TurnType,
+    response_hash: str,
+    response_payload_id: str,
+    control_signal: str | None,
+    composition_version: int,
+    actor: str,
+) -> None:
+    """Record a ``guided_turn_answered`` audit event.
+
+    Fires when the user submits a response to a guided turn.
+
+    Args:
+        recorder: The composition session's active recorder.
+        step: The wizard step at which the turn was answered.
+        turn_type: The taxonomy type of the answered turn.
+        response_hash: SHA-256 hex digest of the user's response payload.
+        response_payload_id: Payload-store ID of the response payload.
+        control_signal: Out-of-band signal if the user sent one; ``None``
+            otherwise. Absent from the canonical record when ``None`` so
+            the absence itself is unambiguous.
+        composition_version: Current ``CompositionState.version``.
+        actor: Stable identity of the driving actor.
+    """
+    payload: dict[str, Any] = {
+        "step_index": step.value,
+        "turn_type": turn_type.value,
+        "response_hash": response_hash,
+        "response_payload_id": response_payload_id,
+    }
+    if control_signal is not None:
+        payload["control_signal"] = control_signal
+    now = datetime.now(UTC)
+    invocation = _build_invocation(
+        tool_name="guided_turn_answered",
+        payload=payload,
+        composition_version=composition_version,
+        actor=actor,
+        now=now,
+    )
+    recorder.record(invocation)
+
+
+def emit_step_advanced(
+    recorder: ComposerToolRecorder,
+    *,
+    prev: GuidedStep,
+    next_: GuidedStep,
+    reason: str,
+    composition_version: int,
+    actor: str,
+) -> None:
+    """Record a ``guided_step_advanced`` audit event.
+
+    Fires when the wizard advances from one step to the next.
+
+    Args:
+        recorder: The composition session's active recorder.
+        prev: The step the wizard is leaving.
+        next_: The step the wizard is entering.
+        reason: Why the advance happened. Must be one of
+            ``{"recipe_applied", "user_advanced", "auto_advanced"}``.
+        composition_version: Current ``CompositionState.version``.
+        actor: Stable identity of the driving actor.
+
+    Raises:
+        ValueError: If ``reason`` is not in the closed allowlist.
+    """
+    if reason not in _VALID_ADVANCE_REASONS:
+        raise ValueError(f"reason must be one of {sorted(_VALID_ADVANCE_REASONS)}, got {reason!r}")
+    payload: dict[str, Any] = {
+        "prev_step": prev.value,
+        "next_step": next_.value,
+        "reason": reason,
+    }
+    now = datetime.now(UTC)
+    invocation = _build_invocation(
+        tool_name="guided_step_advanced",
+        payload=payload,
+        composition_version=composition_version,
+        actor=actor,
+        now=now,
+    )
+    recorder.record(invocation)
+
+
+def emit_dropped_to_freeform(
+    recorder: ComposerToolRecorder,
+    *,
+    prev: GuidedStep,
+    drop_reason: TerminalReason,
+    validation_result: Mapping[str, Any] | None,
+    composition_version: int,
+    actor: str,
+) -> None:
+    """Record a ``guided_dropped_to_freeform`` audit event.
+
+    Fires when the guided wizard exits to freeform composition, for any
+    reason (user exit, protocol violation, solver exhaustion).
+
+    Args:
+        recorder: The composition session's active recorder.
+        prev: The step at which the wizard exited.
+        drop_reason: Why guided mode was abandoned.
+        validation_result: Pipeline validation output at exit time, when
+            present (e.g. for SOLVER_EXHAUSTED). ``None`` is recorded as
+            absent — the absence is meaningful (no validation was run),
+            not a gap to fill with a fabricated default.
+        composition_version: Current ``CompositionState.version``.
+        actor: Stable identity of the driving actor.
+    """
+    payload: dict[str, Any] = {
+        "step_index": prev.value,
+        "drop_reason": drop_reason.value,
+    }
+    if validation_result is not None:
+        payload["validation_result"] = dict(validation_result)
+    now = datetime.now(UTC)
+    invocation = _build_invocation(
+        tool_name="guided_dropped_to_freeform",
+        payload=payload,
+        composition_version=composition_version,
+        actor=actor,
+        now=now,
+    )
+    recorder.record(invocation)

--- a/src/elspeth/web/composer/guided/chain_solver.py
+++ b/src/elspeth/web/composer/guided/chain_solver.py
@@ -62,14 +62,8 @@ async def solve_chain(
     telemetry, and token accounting flow through the same plumbing.
 
     Args:
-        source: Resolved source from Step 1.
-        sink: Resolved sink from Step 2.
-        recipe_match: Optional matched recipe hint from Step 2.5.
-        repair_context: When provided, the LLM is being asked to repair a
-            previously proposed chain that failed validation. The value must
-            be the verbatim validation error text from the failing ToolResult.
-            Appended to the system prompt as a clearly-labelled REPAIR ATTEMPT
-            block so the LLM knows to correct the named errors rather than
+        repair_context: Verbatim validation error text from the failing ToolResult.
+            When set, the LLM is asked to correct the named errors rather than
             propose an independent first-pass chain.
     """
     skill = load_guided_skill()

--- a/src/elspeth/web/composer/guided/chain_solver.py
+++ b/src/elspeth/web/composer/guided/chain_solver.py
@@ -1,0 +1,94 @@
+"""Chain solver: invoke LLM with guided skill + GUIDED CONTEXT block, parse propose_chain."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from elspeth.web.composer.guided.prompts import (
+    build_step_3_context_block,
+    load_guided_skill,
+)
+from elspeth.web.composer.guided.recipe_match import RecipeMatch
+from elspeth.web.composer.guided.state_machine import (
+    ChainProposal,
+    SinkResolved,
+    SourceResolved,
+)
+from elspeth.web.composer.service import _litellm_acompletion
+
+# CLOSED LIST — turn_type enum mirrors TurnType in protocol.py; do not extend
+# without updating the legal-turn matrix.
+_GUIDED_LLM_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "emit_turn",
+            "description": "Emit one turn to the user. The only way to interact in guided mode.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "turn_type": {
+                        "type": "string",
+                        "enum": [
+                            "inspect_and_confirm",
+                            "single_select",
+                            "multi_select_with_custom",
+                            "schema_form",
+                            "propose_chain",
+                            "recipe_offer",
+                        ],
+                    },
+                    "payload": {"type": "object"},
+                },
+                "required": ["turn_type", "payload"],
+            },
+        },
+    },
+]
+
+
+async def solve_chain(
+    *,
+    source: SourceResolved,
+    sink: SinkResolved,
+    recipe_match: RecipeMatch | None = None,
+) -> ChainProposal:
+    """Invoke the LLM with the guided skill, expect a propose_chain turn back.
+
+    Reuses the same _litellm_acompletion path as freeform composer so audit,
+    telemetry, and token accounting flow through the same plumbing.
+    """
+    skill = load_guided_skill()
+    context_block = build_step_3_context_block(source=source, sink=sink, recipe_match=recipe_match)
+    system_prompt = f"{skill}\n\n{context_block}"
+    response = await _litellm_acompletion(
+        model="anthropic/claude-3.5-sonnet",
+        messages=[{"role": "system", "content": system_prompt}],
+        tools=_GUIDED_LLM_TOOLS,
+        tool_choice={"type": "function", "function": {"name": "emit_turn"}},
+    )
+    name, arguments = _extract_tool_call(response)
+    if name != "emit_turn":
+        raise ValueError(f"chain solver expected emit_turn, got {name!r}")
+    if arguments["turn_type"] != "propose_chain":
+        raise ValueError(f"chain solver expected propose_chain turn, got {arguments['turn_type']!r}")
+    payload = arguments["payload"]
+    return ChainProposal(
+        steps=tuple(dict(s) for s in payload["steps"]),
+        why=str(payload["why"]),
+    )
+
+
+def _extract_tool_call(response: Any) -> tuple[str, dict[str, Any]]:
+    """Extract (name, parsed_arguments) from a LiteLLM response.
+
+    LiteLLM returns attribute-access objects (not dicts); see _FakeLLMResponse
+    in tests/unit/web/composer/test_compose_loop_llm_audit.py for the shape.
+    """
+    message = response.choices[0].message
+    tool_calls = message.tool_calls
+    if not tool_calls:
+        raise ValueError("solve_chain: response had no tool_calls")
+    call = tool_calls[0]
+    return call.function.name, json.loads(call.function.arguments)

--- a/src/elspeth/web/composer/guided/chain_solver.py
+++ b/src/elspeth/web/composer/guided/chain_solver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.prompts import (
     build_repair_addendum,
     build_step_3_context_block,
@@ -81,9 +82,9 @@ async def solve_chain(
     )
     name, arguments = _extract_tool_call(response)
     if name != "emit_turn":
-        raise ValueError(f"chain solver expected emit_turn, got {name!r}")
+        raise InvariantError(f"chain solver expected emit_turn, got {name!r}")
     if arguments["turn_type"] != "propose_chain":
-        raise ValueError(f"chain solver expected propose_chain turn, got {arguments['turn_type']!r}")
+        raise InvariantError(f"chain solver expected propose_chain turn, got {arguments['turn_type']!r}")
     payload = arguments["payload"]
     return ChainProposal(
         steps=tuple(dict(s) for s in payload["steps"]),
@@ -100,6 +101,6 @@ def _extract_tool_call(response: Any) -> tuple[str, dict[str, Any]]:
     message = response.choices[0].message
     tool_calls = message.tool_calls
     if not tool_calls:
-        raise ValueError("solve_chain: response had no tool_calls")
+        raise InvariantError("solve_chain: response had no tool_calls")
     call = tool_calls[0]
     return call.function.name, json.loads(call.function.arguments)

--- a/src/elspeth/web/composer/guided/chain_solver.py
+++ b/src/elspeth/web/composer/guided/chain_solver.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from elspeth.web.composer.guided.prompts import (
+    build_repair_addendum,
     build_step_3_context_block,
     load_guided_skill,
 )
@@ -53,15 +54,31 @@ async def solve_chain(
     source: SourceResolved,
     sink: SinkResolved,
     recipe_match: RecipeMatch | None = None,
+    repair_context: str | None = None,
 ) -> ChainProposal:
     """Invoke the LLM with the guided skill, expect a propose_chain turn back.
 
     Reuses the same _litellm_acompletion path as freeform composer so audit,
     telemetry, and token accounting flow through the same plumbing.
+
+    Args:
+        source: Resolved source from Step 1.
+        sink: Resolved sink from Step 2.
+        recipe_match: Optional matched recipe hint from Step 2.5.
+        repair_context: When provided, the LLM is being asked to repair a
+            previously proposed chain that failed validation. The value must
+            be the verbatim validation error text from the failing ToolResult.
+            Appended to the system prompt as a clearly-labelled REPAIR ATTEMPT
+            block so the LLM knows to correct the named errors rather than
+            propose an independent first-pass chain.
     """
     skill = load_guided_skill()
     context_block = build_step_3_context_block(source=source, sink=sink, recipe_match=recipe_match)
-    system_prompt = f"{skill}\n\n{context_block}"
+    if repair_context is not None:
+        repair_addendum = build_repair_addendum(validation_error=repair_context)
+        system_prompt = f"{skill}\n\n{context_block}\n\n{repair_addendum}"
+    else:
+        system_prompt = f"{skill}\n\n{context_block}"
     response = await _litellm_acompletion(
         model="anthropic/claude-3.5-sonnet",
         messages=[{"role": "system", "content": system_prompt}],

--- a/src/elspeth/web/composer/guided/chain_solver.py
+++ b/src/elspeth/web/composer/guided/chain_solver.py
@@ -17,7 +17,11 @@ from elspeth.web.composer.guided.state_machine import (
     SinkResolved,
     SourceResolved,
 )
-from elspeth.web.composer.service import _litellm_acompletion
+from elspeth.web.composer.service import (
+    _COMPOSER_LLM_TEMPERATURE,
+    _composer_llm_seed_for_model,
+    _litellm_acompletion,
+)
 
 # CLOSED LIST — turn_type enum mirrors TurnType in protocol.py; do not extend
 # without updating the legal-turn matrix.
@@ -52,6 +56,7 @@ _GUIDED_LLM_TOOLS: list[dict[str, Any]] = [
 
 async def solve_chain(
     *,
+    model: str,
     source: SourceResolved,
     sink: SinkResolved,
     recipe_match: RecipeMatch | None = None,
@@ -63,6 +68,8 @@ async def solve_chain(
     telemetry, and token accounting flow through the same plumbing.
 
     Args:
+        model: LiteLLM model identifier from settings.composer_model.  Required —
+            callers must be explicit; no hard-coded default.
         repair_context: Verbatim validation error text from the failing ToolResult.
             When set, the LLM is asked to correct the named errors rather than
             propose an independent first-pass chain.
@@ -74,12 +81,17 @@ async def solve_chain(
         system_prompt = f"{skill}\n\n{context_block}\n\n{repair_addendum}"
     else:
         system_prompt = f"{skill}\n\n{context_block}"
-    response = await _litellm_acompletion(
-        model="anthropic/claude-3.5-sonnet",
-        messages=[{"role": "system", "content": system_prompt}],
-        tools=_GUIDED_LLM_TOOLS,
-        tool_choice={"type": "function", "function": {"name": "emit_turn"}},
-    )
+    seed = _composer_llm_seed_for_model(model)
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "system", "content": system_prompt}],
+        "tools": _GUIDED_LLM_TOOLS,
+        "tool_choice": {"type": "function", "function": {"name": "emit_turn"}},
+        "temperature": _COMPOSER_LLM_TEMPERATURE,
+    }
+    if seed is not None:
+        kwargs["seed"] = seed
+    response = await _litellm_acompletion(**kwargs)
     name, arguments = _extract_tool_call(response)
     if name != "emit_turn":
         raise InvariantError(f"chain solver expected emit_turn, got {name!r}")

--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -7,6 +7,7 @@ TurnRecord, and emit the corresponding audit event independently.
 
 Exported:
     build_initial_step_1_turn — build the initial Step 1 turn payload.
+    build_step_1_inspect_and_confirm_turn_from_intent — inspect_and_confirm from SourceIntent.
     build_step_1_schema_form_turn — schema_form for a chosen source plugin.
     build_step_2_single_select_turn — single_select for sink plugin selection.
     build_step_2_schema_form_turn — schema_form for a chosen sink plugin.
@@ -42,7 +43,7 @@ from elspeth.web.composer.guided.protocol import (
 if TYPE_CHECKING:
     from elspeth.web.catalog.protocol import CatalogService as CatalogServiceProtocol
     from elspeth.web.composer.guided.recipe_match import RecipeMatch
-    from elspeth.web.composer.guided.state_machine import ChainProposal
+    from elspeth.web.composer.guided.state_machine import ChainProposal, SourceIntent
     from elspeth.web.composer.source_inspection import SourceInspectionFacts
     from elspeth.web.composer.state import CompositionState
 
@@ -75,6 +76,39 @@ def build_initial_step_1_turn(
     if blob_inspection is not None and blob_inspection.observed_headers is not None:
         return _build_inspect_and_confirm_turn(blob_inspection)
     return _build_step_1_single_select_turn(catalog)
+
+
+def build_step_1_inspect_and_confirm_turn_from_intent(
+    intent: SourceIntent,
+) -> Turn:
+    """Build an ``inspect_and_confirm`` Turn from a persisted SourceIntent.
+
+    Called by GET /guided to rebuild the INSPECT_AND_CONFIRM turn on refresh
+    when ``guided.step_1_source_intent`` is set.  The intent carries the
+    plugin's observed_columns (the key data the widget needs), but not
+    the original blob-inspection warnings — those are not stored on
+    SourceIntent because they are observations about the blob, not about the
+    plugin choices.  The rebuild emits ``warnings=[]`` for this reason.
+    Clients that need the original warnings must resubmit the prior response;
+    the reconstructed turn is functionally equivalent for resuming the flow.
+
+    Args:
+        intent: The staged SourceIntent from GuidedSession.step_1_source_intent.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    observed: _Observed = {
+        "columns": list(intent.observed_columns),
+        "samples": [],
+        "warnings": [],
+    }
+    payload: InspectAndConfirmPayload = {"observed": observed}
+    return Turn(
+        type=TurnType.INSPECT_AND_CONFIRM.value,
+        step_index=_step_index(GuidedStep.STEP_1_SOURCE),
+        payload=payload,
+    )
 
 
 def build_step_1_schema_form_turn(

--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -226,7 +226,6 @@ def build_step_2_5_recipe_offer_turn(
             name=name,
             slot_type=spec.slot_type,
             description=spec.description,
-            required=spec.required,
         )
         for name, spec in match.unsatisfied_slots.items()
     ]

--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -12,6 +12,7 @@ Exported:
     build_step_2_schema_form_turn — schema_form for a chosen sink plugin.
     build_step_2_multi_select_turn — multi_select_with_custom for required fields.
     build_step_2_5_recipe_offer_turn — recipe_offer from a RecipeMatch.
+    build_step_3_propose_chain_turn — propose_chain from a ChainProposal.
 
 Trust tier: L3 web layer.  No upward imports.  Payloads are Tier 2 pipeline
 data constructed from system-owned state; the Turn dict itself is not persisted
@@ -27,6 +28,7 @@ from elspeth.web.composer.guided.protocol import (
     GuidedStep,
     InspectAndConfirmPayload,
     MultiSelectWithCustomPayload,
+    ProposeChainPayload,
     RecipeOfferPayload,
     SchemaFormPayload,
     SingleSelectPayload,
@@ -39,6 +41,7 @@ from elspeth.web.composer.guided.protocol import (
 if TYPE_CHECKING:
     from elspeth.web.catalog.protocol import CatalogService as CatalogServiceProtocol
     from elspeth.web.composer.guided.recipe_match import RecipeMatch
+    from elspeth.web.composer.guided.state_machine import ChainProposal
     from elspeth.web.composer.source_inspection import SourceInspectionFacts
     from elspeth.web.composer.state import CompositionState
 
@@ -225,6 +228,52 @@ def build_step_2_5_recipe_offer_turn(
     return Turn(
         type=TurnType.RECIPE_OFFER.value,
         step_index=_step_index(GuidedStep.STEP_2_5_RECIPE_MATCH),
+        payload=payload,
+    )
+
+
+def build_step_3_propose_chain_turn(
+    proposal: ChainProposal,
+) -> Turn:
+    """Build a ``propose_chain`` Turn from a ChainProposal.
+
+    Emitted at Step 3 after ``solve_chain`` returns a complete chain proposal.
+
+    The ``blockers`` field is always ``[]`` for chain proposals emitted
+    server-side after a successful ``solve_chain`` call.  The LLM may use
+    ``blockers`` when it can only produce a partial chain; for the MVP we
+    do not surface that path — ``solve_chain`` either returns a complete
+    proposal or raises (so the dispatcher punts).
+
+    Args:
+        proposal: The chain proposal returned by ``solve_chain``.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    from elspeth.contracts.freeze import deep_thaw
+    from elspeth.web.composer.guided.protocol import _ProposedStep
+
+    # Thaw the frozen ChainProposal step mappings into plain dicts so the
+    # payload is JSON-serialisable.  ``_ProposedStep`` is a TypedDict so
+    # mypy needs the explicit shape — the chain solver guarantees these
+    # keys (validate against the LLM tool schema at solve_chain time).
+    thawed_steps: list[_ProposedStep] = [
+        _ProposedStep(
+            plugin=str(s["plugin"]),
+            options=dict(deep_thaw(s["options"])),
+            rationale=str(s["rationale"]),
+        )
+        for s in proposal.steps
+    ]
+    payload: ProposeChainPayload = {
+        "steps": thawed_steps,
+        "why": proposal.why,
+        "blockers": [],
+    }
+    return Turn(
+        type=TurnType.PROPOSE_CHAIN.value,
+        step_index=_step_index(GuidedStep.STEP_3_TRANSFORMS),
         payload=payload,
     )
 

--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -36,6 +36,7 @@ from elspeth.web.composer.guided.protocol import (
     TurnType,
     _Observed,
     _Option,
+    _RecipeSlotInput,
 )
 
 if TYPE_CHECKING:
@@ -220,10 +221,20 @@ def build_step_2_5_recipe_offer_turn(
     """
     from elspeth.contracts.freeze import deep_thaw
 
+    unsatisfied: list[_RecipeSlotInput] = [
+        _RecipeSlotInput(
+            name=name,
+            slot_type=spec.slot_type,
+            description=spec.description,
+            required=spec.required,
+        )
+        for name, spec in match.unsatisfied_slots.items()
+    ]
     payload: RecipeOfferPayload = {
         "recipe_name": match.recipe_name,
         "slots": dict(deep_thaw(match.slots)),
         "alternatives": ["build_manually"],
+        "unsatisfied_slots": unsatisfied,
     }
     return Turn(
         type=TurnType.RECIPE_OFFER.value,

--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -1,0 +1,293 @@
+"""Turn-emitter helpers for guided-mode endpoints.
+
+These helpers build Turn payloads deterministically from CompositionState and
+optional blob-inspection facts.  They are pure functions — no I/O, no clock,
+no uuid — so the caller (route handler) can hash the result, persist it as a
+TurnRecord, and emit the corresponding audit event independently.
+
+Exported:
+    build_initial_step_1_turn — build the initial Step 1 turn payload.
+    build_step_1_schema_form_turn — schema_form for a chosen source plugin.
+    build_step_2_single_select_turn — single_select for sink plugin selection.
+    build_step_2_schema_form_turn — schema_form for a chosen sink plugin.
+    build_step_2_multi_select_turn — multi_select_with_custom for required fields.
+    build_step_2_5_recipe_offer_turn — recipe_offer from a RecipeMatch.
+
+Trust tier: L3 web layer.  No upward imports.  Payloads are Tier 2 pipeline
+data constructed from system-owned state; the Turn dict itself is not persisted
+— only its hash (via stable_hash) enters the audit trail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from elspeth.web.composer.guided.protocol import (
+    GuidedStep,
+    InspectAndConfirmPayload,
+    MultiSelectWithCustomPayload,
+    RecipeOfferPayload,
+    SchemaFormPayload,
+    SingleSelectPayload,
+    Turn,
+    TurnType,
+    _Observed,
+    _Option,
+)
+
+if TYPE_CHECKING:
+    from elspeth.web.catalog.protocol import CatalogService as CatalogServiceProtocol
+    from elspeth.web.composer.guided.recipe_match import RecipeMatch
+    from elspeth.web.composer.source_inspection import SourceInspectionFacts
+    from elspeth.web.composer.state import CompositionState
+
+
+def build_initial_step_1_turn(
+    state: CompositionState,
+    *,
+    blob_inspection: SourceInspectionFacts | None,
+    catalog: CatalogServiceProtocol,
+) -> Turn:
+    """Build the initial Step 1 turn for a fresh guided session.
+
+    Decision rule:
+    - If ``blob_inspection`` is not None and carries header information →
+      emit ``inspect_and_confirm`` so the user can confirm the observed schema
+      before proceeding.
+    - Otherwise → emit ``single_select`` listing all registered source plugins
+      so the user can pick one explicitly.
+
+    Args:
+        state: Current CompositionState.  Used for ``step_index`` derivation
+            (version is not used — ``GuidedStep.STEP_1_SOURCE`` is the index).
+        blob_inspection: Result of ``inspect_blob_content`` on an uploaded blob,
+            or ``None`` when no blob is attached to this session.
+        catalog: Plugin catalog for listing registered source plugins.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    if blob_inspection is not None and blob_inspection.observed_headers is not None:
+        return _build_inspect_and_confirm_turn(blob_inspection)
+    return _build_step_1_single_select_turn(catalog)
+
+
+def build_step_1_schema_form_turn(
+    plugin: str,
+    catalog: CatalogServiceProtocol,
+) -> Turn:
+    """Build a ``schema_form`` Turn for the chosen source plugin.
+
+    Emitted after the user picks a source plugin in Step 1's ``single_select``
+    turn.  The schema block is the plugin's full JSON schema (from the catalog);
+    ``prefilled`` seeds ``schema.mode: "observed"`` per spec §3.1 rule 0.
+
+    Args:
+        plugin: The plugin name chosen by the user (e.g. ``"csv"``).
+        catalog: Plugin catalog for retrieving the plugin's JSON schema.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    schema_info = catalog.get_schema("source", plugin)
+    prefilled: dict[str, Any] = {"schema": {"mode": "observed"}}
+    payload: SchemaFormPayload = {
+        "plugin": plugin,
+        "schema_block": dict(schema_info.json_schema),
+        "prefilled": prefilled,
+    }
+    return Turn(
+        type=TurnType.SCHEMA_FORM.value,
+        step_index=_step_index(GuidedStep.STEP_1_SOURCE),
+        payload=payload,
+    )
+
+
+def build_step_2_single_select_turn(
+    catalog: CatalogServiceProtocol,
+) -> Turn:
+    """Build a ``single_select`` Turn listing available sink plugins.
+
+    Emitted when the wizard enters Step 2 (the user has committed their
+    source choice in Step 1).
+
+    Args:
+        catalog: Plugin catalog for listing registered sink plugins.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    sinks = catalog.list_sinks()
+    options: list[_Option] = [
+        _Option(
+            id=plugin.name,
+            label=plugin.name,
+            hint=plugin.description if plugin.description else None,
+        )
+        for plugin in sinks
+    ]
+    payload: SingleSelectPayload = {
+        "question": "What format should the output be in?",
+        "options": options,
+        "allow_custom": False,
+    }
+    return Turn(
+        type=TurnType.SINGLE_SELECT.value,
+        step_index=_step_index(GuidedStep.STEP_2_SINK),
+        payload=payload,
+    )
+
+
+def build_step_2_schema_form_turn(
+    plugin: str,
+    catalog: CatalogServiceProtocol,
+) -> Turn:
+    """Build a ``schema_form`` Turn for the chosen sink plugin.
+
+    Emitted after the user picks a sink plugin in Step 2's ``single_select``
+    turn.  The schema block is the plugin's full JSON schema; ``prefilled``
+    seeds ``schema.mode: "observed"``.
+
+    Args:
+        plugin: The plugin name chosen by the user (e.g. ``"json"``).
+        catalog: Plugin catalog for retrieving the plugin's JSON schema.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    schema_info = catalog.get_schema("sink", plugin)
+    prefilled: dict[str, Any] = {"schema": {"mode": "observed"}}
+    payload: SchemaFormPayload = {
+        "plugin": plugin,
+        "schema_block": dict(schema_info.json_schema),
+        "prefilled": prefilled,
+    }
+    return Turn(
+        type=TurnType.SCHEMA_FORM.value,
+        step_index=_step_index(GuidedStep.STEP_2_SINK),
+        payload=payload,
+    )
+
+
+def build_step_2_multi_select_turn(
+    observed_columns: Sequence[str],
+) -> Turn:
+    """Build a ``multi_select_with_custom`` Turn for declaring required fields.
+
+    Emitted after the user fills in sink options (Step 2 ``schema_form``).
+    The options are pre-populated from Step 1's observed columns; the user
+    ticks which fields must appear in the output, adds custom fields, or
+    clicks the escape label to let the source decide.
+
+    Args:
+        observed_columns: The columns observed from the source in Step 1.
+            Comes from ``GuidedSession.step_1_result.observed_columns``.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    options: list[_Option] = [_Option(id=col, label=col, hint=None) for col in observed_columns]
+    payload: MultiSelectWithCustomPayload = {
+        "question": "Which fields must appear in the output?",
+        "options": options,
+        "default_chosen": list(observed_columns),
+        "escape_label": "Let source decide (pass all fields through)",
+    }
+    return Turn(
+        type=TurnType.MULTI_SELECT_WITH_CUSTOM.value,
+        step_index=_step_index(GuidedStep.STEP_2_SINK),
+        payload=payload,
+    )
+
+
+def build_step_2_5_recipe_offer_turn(
+    match: RecipeMatch,
+) -> Turn:
+    """Build a ``recipe_offer`` Turn from a RecipeMatch.
+
+    Emitted at Step 2.5 when the deterministic recipe matcher finds a
+    registered recipe that fits the (source, sink) topology.
+
+    Args:
+        match: The matched recipe with its partial slot map.
+
+    Returns:
+        A ``Turn`` TypedDict ready for serialisation and hash.
+    """
+    from elspeth.contracts.freeze import deep_thaw
+
+    payload: RecipeOfferPayload = {
+        "recipe_name": match.recipe_name,
+        "slots": dict(deep_thaw(match.slots)),
+        "alternatives": ["build_manually"],
+    }
+    return Turn(
+        type=TurnType.RECIPE_OFFER.value,
+        step_index=_step_index(GuidedStep.STEP_2_5_RECIPE_MATCH),
+        payload=payload,
+    )
+
+
+def _build_inspect_and_confirm_turn(
+    inspection: SourceInspectionFacts,
+) -> Turn:
+    """Build an ``inspect_and_confirm`` Turn from blob inspection facts.
+
+    ``samples`` is intentionally empty: ``SourceInspectionFacts`` carries
+    ``sample_row_count`` (a count) but not the actual row payloads — the
+    inspection layer deliberately redacts row content to avoid passing
+    user data through the audit trail.  The UI renders the count + column
+    list; full row previews are handled by the blob preview endpoint.
+    """
+    observed: _Observed = {
+        "columns": list(inspection.observed_headers or ()),
+        "samples": [],
+        "warnings": list(inspection.warnings),
+    }
+    payload: InspectAndConfirmPayload = {"observed": observed}
+    return Turn(
+        type=TurnType.INSPECT_AND_CONFIRM.value,
+        step_index=_step_index(GuidedStep.STEP_1_SOURCE),
+        payload=payload,
+    )
+
+
+def _build_step_1_single_select_turn(
+    catalog: CatalogServiceProtocol,
+) -> Turn:
+    """Build a ``single_select`` Turn listing available source plugins."""
+    sources = catalog.list_sources()
+    options: list[_Option] = [
+        _Option(
+            id=plugin.name,
+            label=plugin.name,
+            hint=plugin.description if plugin.description else None,
+        )
+        for plugin in sources
+    ]
+    payload: SingleSelectPayload = {
+        "question": "Which data source would you like to use?",
+        "options": options,
+        "allow_custom": False,
+    }
+    return Turn(
+        type=TurnType.SINGLE_SELECT.value,
+        step_index=_step_index(GuidedStep.STEP_1_SOURCE),
+        payload=payload,
+    )
+
+
+def _step_index(step: GuidedStep) -> int:
+    """Map GuidedStep to its 0-based integer index.
+
+    ``Turn.step_index`` is ``int`` (spec §4), not the StrEnum value.
+    The mapping is the canonical ordered position in the wizard sequence.
+    """
+    _ORDER: tuple[GuidedStep, ...] = (
+        GuidedStep.STEP_1_SOURCE,
+        GuidedStep.STEP_2_SINK,
+        GuidedStep.STEP_2_5_RECIPE_MATCH,
+        GuidedStep.STEP_3_TRANSFORMS,
+    )
+    return _ORDER.index(step)

--- a/src/elspeth/web/composer/guided/errors.py
+++ b/src/elspeth/web/composer/guided/errors.py
@@ -1,0 +1,34 @@
+"""Guided-mode exception taxonomy.
+
+Two semantically distinct exception categories arise in guided mode:
+
+``ValueError``
+    **Client fault** — the external caller (HTTP request, wire-shape) provided
+    data that violates the contract.  The route handler should catch these and
+    return HTTP 400.  Examples: ``edited_values`` is ``None`` when required,
+    ``chosen`` carries an unexpected value for the current turn type.
+
+``InvariantError``
+    **Server bug** — a code-internal invariant has been violated.  This always
+    indicates a defect in the server code, not a bad client request.  The route
+    handler (or FastAPI's default unhandled-exception path) should return HTTP
+    500 with a "Server invariant violated" prefix.  Examples: a ``from_dict``
+    method read a malformed Tier-1 record, a staging field that should have
+    been set before the current code path was reached is ``None``, or the
+    recipe-predicate registry references a recipe that isn't registered.
+
+Both exception types extend ``Exception`` directly (not ``AssertionError``).
+``AssertionError`` is elided by ``python -O`` and therefore cannot be relied
+upon as a crash gate for server-bug detection.
+"""
+
+from __future__ import annotations
+
+
+class InvariantError(Exception):
+    """Raised when a server-side invariant is violated.
+
+    This is always a bug in the server code, never a client error.
+    The HTTP dispatcher catches this and returns HTTP 500 with a clear
+    "Server invariant violated" prefix in the detail string.
+    """

--- a/src/elspeth/web/composer/guided/errors.py
+++ b/src/elspeth/web/composer/guided/errors.py
@@ -11,11 +11,16 @@ Two semantically distinct exception categories arise in guided mode:
 ``InvariantError``
     **Server bug** — a code-internal invariant has been violated.  This always
     indicates a defect in the server code, not a bad client request.  The route
-    handler (or FastAPI's default unhandled-exception path) should return HTTP
-    500 with a "Server invariant violated" prefix.  Examples: a ``from_dict``
-    method read a malformed Tier-1 record, a staging field that should have
-    been set before the current code path was reached is ``None``, or the
-    recipe-predicate registry references a recipe that isn't registered.
+    handler returns HTTP 500 with a **static** "Server invariant violated"
+    message — ``str(exc)`` is NOT interpolated into the response body because
+    ``from_dict`` raise sites embed ``{d!r}`` of the corrupted Tier-1 record,
+    which can carry Tier-3 ``sample_rows`` content (PR #37 review finding B1).
+    Diagnostic detail is preserved via ``slog`` with ``exc_class`` + bounded
+    frames only, under the CLAUDE.md audit-system-failure logging exemption.
+    Examples: a ``from_dict`` method read a malformed Tier-1 record, a staging
+    field that should have been set before the current code path was reached
+    is ``None``, or the recipe-predicate registry references a recipe that
+    isn't registered.
 
 Both exception types extend ``Exception`` directly (not ``AssertionError``).
 ``AssertionError`` is elided by ``python -O`` and therefore cannot be relied
@@ -29,6 +34,9 @@ class InvariantError(Exception):
     """Raised when a server-side invariant is violated.
 
     This is always a bug in the server code, never a client error.
-    The HTTP dispatcher catches this and returns HTTP 500 with a clear
-    "Server invariant violated" prefix in the detail string.
+    The HTTP dispatcher catches this and returns HTTP 500 with a **static**
+    "Server invariant violated" detail message — ``str(exc)`` is not echoed
+    to clients because some raise sites (``GuidedSession.from_dict`` et al.)
+    embed ``{d!r}`` of the corrupted record, which can carry Tier-3 source
+    data (see module docstring for the B1 review-finding context).
     """

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -6,8 +6,17 @@ after editing the skill markdown for live changes to take effect.
 
 from __future__ import annotations
 
+import json
 from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from elspeth.web.composer.guided.recipe_match import RecipeMatch
+    from elspeth.web.composer.guided.state_machine import (
+        SinkResolved,
+        SourceResolved,
+    )
 
 _SKILL_PATH = Path(__file__).parent / "skills" / "guided_pipeline.md"
 
@@ -16,3 +25,34 @@ _SKILL_PATH = Path(__file__).parent / "skills" / "guided_pipeline.md"
 def load_guided_skill() -> str:
     """Load the guided-mode skill prompt. Cached per process; restart on edit."""
     return _SKILL_PATH.read_text(encoding="utf-8")
+
+
+def build_step_3_context_block(
+    *,
+    source: SourceResolved,
+    sink: SinkResolved,
+    recipe_match: RecipeMatch | None,
+) -> str:
+    """Render the GUIDED CONTEXT block for the Step 3 LLM prompt."""
+    src_payload = {
+        "plugin": source.plugin,
+        "columns": list(source.observed_columns),
+        "sample": [dict(r) for r in source.sample_rows[:3]],
+    }
+    sink_payload = {
+        "outputs": [
+            {
+                "plugin": o.plugin,
+                "required_fields": list(o.required_fields),
+                "schema_mode": o.schema_mode,
+            }
+            for o in sink.outputs
+        ],
+    }
+    match_repr = "null" if recipe_match is None else json.dumps({"recipe_name": recipe_match.recipe_name})
+    return (
+        "GUIDED CONTEXT (server-resolved):\n"
+        f"source: {json.dumps(src_payload)}\n"
+        f"sink: {json.dumps(sink_payload)}\n"
+        f"recipe_match: {match_repr}\n"
+    )

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -27,6 +27,40 @@ def load_guided_skill() -> str:
     return _SKILL_PATH.read_text(encoding="utf-8")
 
 
+@lru_cache(maxsize=1)
+def _load_freeform_skill() -> str:
+    """Load the freeform pipeline-composer skill. Cached per process; restart on edit."""
+    from elspeth.web.composer.skills import load_skill
+
+    return load_skill("pipeline_composer")
+
+
+def build_mode_transition_system_prompt(*, terminal_reason: str) -> str:
+    """Build the layered system prompt for the first freeform turn after guided mode exits.
+
+    Layer order (spec §8.2):
+      1. Guided-mode skill content (guided_pipeline.md)
+      2. Mode-transition header with reason and rules-lifted signal
+      3. Freeform-composer skill content (pipeline_composer.md)
+
+    Args:
+        terminal_reason: Resolved reason string — one of ``"user_pressed_exit"``,
+            ``"protocol_violation"``, ``"solver_exhausted"``, ``"completed_pipeline"``.
+    """
+    guided = load_guided_skill()
+    freeform = _load_freeform_skill()
+    transition = (
+        f"## Mode Transition — Guided → Freeform\n\n"
+        f"You have just exited guided mode (reason: {terminal_reason}).\n\n"
+        "The protocol restrictions above (closed turn taxonomy, read-only state, "
+        "legal-turn matrix) are LIFTED for the remainder of this session. You now "
+        "have the full freeform tool surface detailed below. The guided session's "
+        "outcome is recorded in `composition_state.guided_session` — "
+        "do not re-run any work it already accomplished."
+    )
+    return f"{guided}\n\n{transition}\n\n{freeform}"
+
+
 def build_repair_addendum(*, validation_error: str) -> str:
     """Render the REPAIR ATTEMPT addendum appended to a repair solve_chain call.
 

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -27,18 +27,27 @@ def load_guided_skill() -> str:
     return _SKILL_PATH.read_text(encoding="utf-8")
 
 
-@lru_cache(maxsize=1)
-def _load_freeform_skill() -> str:
-    """Load the freeform pipeline-composer skill. Cached per process; restart on edit."""
-    from elspeth.web.composer.skills import load_skill
+def build_mode_transition_system_prompt(*, terminal_reason: str, freeform_skill: str) -> str:
+    """Construct the layered guided→freeform transition prompt: guided skill + transition message + freeform skill.
 
-    return load_skill("pipeline_composer")
+    The ``freeform_skill`` parameter must be supplied by the caller — typically via
+    ``build_system_prompt(data_dir, advisor_enabled=advisor_enabled)`` in
+    ``composer/prompts.py``.  This keeps the deployment overlay (``data_dir``) and
+    advisor-strip (``advisor_enabled=False``) correctly threaded into the transition
+    prompt, and avoids a circular import: if this module called ``build_system_prompt``
+    directly it would create a guided/prompts ↔ composer/prompts import cycle.
 
+    Args:
+        terminal_reason: String reason token from the completed guided session
+            (e.g. ``"completed_pipeline"``, ``"user_pressed_exit"``).
+        freeform_skill: Fully processed freeform composer skill string — core skill
+            with deployment overlay appended and advisor content stripped if needed.
+            Produced by ``build_system_prompt(data_dir, advisor_enabled=...)``.
 
-def build_mode_transition_system_prompt(*, terminal_reason: str) -> str:
-    """Construct the layered guided→freeform transition prompt: guided skill + transition message + freeform skill."""
+    Returns:
+        Layered prompt string: guided skill \\n\\n transition header \\n\\n freeform skill.
+    """
     guided = load_guided_skill()
-    freeform = _load_freeform_skill()
     transition = (
         f"## Mode Transition — Guided → Freeform\n\n"
         f"You have just exited guided mode (reason: {terminal_reason}).\n\n"
@@ -48,7 +57,7 @@ def build_mode_transition_system_prompt(*, terminal_reason: str) -> str:
         "outcome is recorded in `composition_state.guided_session` — "
         "do not re-run any work it already accomplished."
     )
-    return f"{guided}\n\n{transition}\n\n{freeform}"
+    return f"{guided}\n\n{transition}\n\n{freeform_skill}"
 
 
 def build_repair_addendum(*, validation_error: str) -> str:

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -1,0 +1,18 @@
+"""Guided-mode skill loading + Step 3 context-block construction.
+
+Module-cached via @lru_cache; per project memory, restart elspeth-web.service
+after editing the skill markdown for live changes to take effect.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+_SKILL_PATH = Path(__file__).parent / "skills" / "guided_pipeline.md"
+
+
+@lru_cache(maxsize=1)
+def load_guided_skill() -> str:
+    """Load the guided-mode skill prompt. Cached per process; restart on edit."""
+    return _SKILL_PATH.read_text(encoding="utf-8")

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -27,6 +27,26 @@ def load_guided_skill() -> str:
     return _SKILL_PATH.read_text(encoding="utf-8")
 
 
+def build_repair_addendum(*, validation_error: str) -> str:
+    """Render the REPAIR ATTEMPT addendum appended to a repair solve_chain call.
+
+    The addendum appears after the GUIDED CONTEXT block in the system prompt.
+    It signals to the LLM that the previous proposal failed validation and
+    carries the verbatim validation error so the model can address the
+    specific problems rather than re-generating a generic first-pass chain.
+
+    Args:
+        validation_error: Verbatim validation error text from the failing
+            ToolResult. Must not be paraphrased or fabricated — the text
+            comes from the audit trail (Tier 1 data).
+    """
+    return (
+        "REPAIR ATTEMPT — your previous proposal failed validation:\n"
+        f"{validation_error}\n\n"
+        "Propose a corrected chain that fixes the named validation errors."
+    )
+
+
 def build_step_3_context_block(
     *,
     source: SourceResolved,

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -30,15 +30,9 @@ def load_guided_skill() -> str:
 def build_repair_addendum(*, validation_error: str) -> str:
     """Render the REPAIR ATTEMPT addendum appended to a repair solve_chain call.
 
-    The addendum appears after the GUIDED CONTEXT block in the system prompt.
-    It signals to the LLM that the previous proposal failed validation and
-    carries the verbatim validation error so the model can address the
-    specific problems rather than re-generating a generic first-pass chain.
-
     Args:
-        validation_error: Verbatim validation error text from the failing
-            ToolResult. Must not be paraphrased or fabricated — the text
-            comes from the audit trail (Tier 1 data).
+        validation_error: Validation error text, taken verbatim from the failing
+            ToolResult; Tier 1 audit data, no paraphrasing.
     """
     return (
         "REPAIR ATTEMPT — your previous proposal failed validation:\n"

--- a/src/elspeth/web/composer/guided/prompts.py
+++ b/src/elspeth/web/composer/guided/prompts.py
@@ -36,17 +36,7 @@ def _load_freeform_skill() -> str:
 
 
 def build_mode_transition_system_prompt(*, terminal_reason: str) -> str:
-    """Build the layered system prompt for the first freeform turn after guided mode exits.
-
-    Layer order (spec §8.2):
-      1. Guided-mode skill content (guided_pipeline.md)
-      2. Mode-transition header with reason and rules-lifted signal
-      3. Freeform-composer skill content (pipeline_composer.md)
-
-    Args:
-        terminal_reason: Resolved reason string — one of ``"user_pressed_exit"``,
-            ``"protocol_violation"``, ``"solver_exhausted"``, ``"completed_pipeline"``.
-    """
+    """Construct the layered guided→freeform transition prompt: guided skill + transition message + freeform skill."""
     guided = load_guided_skill()
     freeform = _load_freeform_skill()
     transition = (

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -79,12 +79,18 @@ class _RecipeSlotInput(TypedDict):
     emitter, and (mirrored manually) in ``guided.ts``. The frontend renders an
     editable input keyed by ``name`` and submits the typed value back as part
     of ``edited_values.slots``.
+
+    ``required`` is intentionally absent from this wire shape: every entry in
+    ``RecipeOfferPayload.unsatisfied_slots`` is guaranteed required by the
+    :class:`~elspeth.web.composer.guided.recipe_match.RecipeMatch` invariant
+    (commit 83b17ca6, ``__post_init__`` Invariant 2). Sending a field that is
+    always ``True`` is dead information on the wire — the frontend can treat
+    all entries as required without reading a flag.
     """
 
     name: str
     slot_type: SlotType
     description: str
-    required: bool
 
 
 class RecipeOfferPayload(TypedDict):

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -1,0 +1,74 @@
+"""Guided-mode protocol: turn types, payloads, responses, legal-turn matrix.
+
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §4.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from enum import StrEnum
+from typing import Any, TypedDict
+
+
+class TurnType(StrEnum):
+    """The closed taxonomy of turn types the protocol allows."""
+
+    INSPECT_AND_CONFIRM = "inspect_and_confirm"
+    SINGLE_SELECT = "single_select"
+    MULTI_SELECT_WITH_CUSTOM = "multi_select_with_custom"
+    SCHEMA_FORM = "schema_form"
+    PROPOSE_CHAIN = "propose_chain"
+    RECIPE_OFFER = "recipe_offer"
+
+
+class _Option(TypedDict):
+    id: str
+    label: str
+    hint: str | None
+
+
+class _Observed(TypedDict):
+    columns: Sequence[str]
+    samples: Sequence[Mapping[str, Any]]
+    warnings: Sequence[str]
+
+
+class InspectAndConfirmPayload(TypedDict):
+    observed: _Observed
+
+
+class SingleSelectPayload(TypedDict):
+    question: str
+    options: Sequence[_Option]
+    allow_custom: bool
+
+
+class MultiSelectWithCustomPayload(TypedDict):
+    question: str
+    options: Sequence[_Option]
+    default_chosen: Sequence[str]
+    escape_label: str | None
+
+
+class SchemaFormPayload(TypedDict):
+    plugin: str
+    schema_block: Mapping[str, Any]
+    prefilled: Mapping[str, Any]
+
+
+class _ProposedStep(TypedDict):
+    plugin: str
+    options: Mapping[str, Any]
+    rationale: str
+
+
+class ProposeChainPayload(TypedDict):
+    steps: Sequence[_ProposedStep]
+    why: str
+    blockers: Sequence[str]
+
+
+class RecipeOfferPayload(TypedDict):
+    recipe_name: str
+    slots: Mapping[str, Any]
+    alternatives: Sequence[str]

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -182,9 +182,43 @@ _REQUIRED_KEYS: Mapping[TurnType, frozenset[str]] = {
     TurnType.RECIPE_OFFER: frozenset({"recipe_name", "slots", "alternatives", "unsatisfied_slots"}),
 }
 
+# Nested shape spec for recursive payload validation.
+#
+# Each entry maps a TurnType to a list of (field_path_component, field_kind,
+# required_keys) triples that describe nested structures.
+#
+# ``field_kind`` is one of:
+#   "mapping"  — the field value must be a Mapping; validate its required_keys.
+#   "sequence_of_mappings" — the field value must be a Sequence; each element
+#                            must be a Mapping with required_keys.
+#
+# Path-rooted error messages use dot notation: ``"payload.observed.columns"``.
+#
+# Only fields whose nested shapes are meaningful to validate are listed. Scalar
+# and pass-through fields (e.g., ``allow_custom: bool``, ``why: str``) are
+# covered by the top-level required-key check and need no further descend.
+_NestedSpec = tuple[str, str, frozenset[str]]
+_NESTED_SHAPES: Mapping[TurnType, tuple[_NestedSpec, ...]] = {
+    TurnType.INSPECT_AND_CONFIRM: (
+        # "observed" must be a Mapping with these keys
+        ("observed", "mapping", frozenset({"columns", "samples", "warnings"})),
+    ),
+    TurnType.RECIPE_OFFER: (
+        # "unsatisfied_slots" must be a Sequence; each element is a Mapping
+        # with these keys.  "required" is intentionally absent — the
+        # RecipeMatch invariant guarantees every entry is required.
+        ("unsatisfied_slots", "sequence_of_mappings", frozenset({"name", "slot_type", "description"})),
+    ),
+}
+
 
 def validate_payload(turn_type: TurnType, payload: Mapping[str, Any]) -> str | None:
     """Validate that *payload* satisfies the schema for *turn_type*.
+
+    Validates top-level required keys and recursively walks nested TypedDicts
+    listed in ``_NESTED_SHAPES``.  Error messages are path-rooted using dot
+    notation so the caller can locate the offending field:
+    ``"payload.observed.columns missing"`` rather than ``"columns missing"``.
 
     Returns None on success, or a human-readable error string on failure.
     Raises ValueError if turn_type is not a known TurnType.
@@ -195,4 +229,25 @@ def validate_payload(turn_type: TurnType, payload: Mapping[str, Any]) -> str | N
     missing = required - payload.keys()
     if missing:
         return f"payload for {turn_type.value} missing required keys: {sorted(missing)}"
+
+    # Recursive nested-shape validation.
+    for field_name, field_kind, nested_required in _NESTED_SHAPES.get(turn_type, ()):
+        field_value = payload[field_name]
+        prefix = f"payload.{field_name}"
+        if field_kind == "mapping":
+            if not isinstance(field_value, Mapping):
+                return f"{prefix} must be a mapping (got {type(field_value).__name__})"
+            nested_missing = nested_required - field_value.keys()
+            if nested_missing:
+                return f"{prefix} missing required keys: {sorted(nested_missing)}"
+        elif field_kind == "sequence_of_mappings":
+            if not isinstance(field_value, Sequence) or isinstance(field_value, str):
+                return f"{prefix} must be a sequence (got {type(field_value).__name__})"
+            for idx, item in enumerate(field_value):
+                if not isinstance(item, Mapping):
+                    return f"{prefix}[{idx}] must be a mapping (got {type(item).__name__})"
+                item_missing = nested_required - item.keys()
+                if item_missing:
+                    return f"{prefix}[{idx}] missing required keys: {sorted(item_missing)}"
+
     return None

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -72,3 +72,30 @@ class RecipeOfferPayload(TypedDict):
     recipe_name: str
     slots: Mapping[str, Any]
     alternatives: Sequence[str]
+
+
+class ControlSignal(StrEnum):
+    """Out-of-band signals carried in a TurnResponse instead of (or alongside) data."""
+
+    EXIT_TO_FREEFORM = "exit_to_freeform"
+    REQUEST_ADVISOR = "request_advisor"
+    REJECT = "reject"
+
+
+class TurnResponse(TypedDict):
+    """The user's typed response to a turn."""
+
+    chosen: Sequence[str] | None
+    edited_values: Mapping[str, Any] | None
+    custom_inputs: Sequence[str] | None
+    accepted_step_index: int | None
+    edit_step_index: int | None
+    control_signal: str | None  # ControlSignal value, or None
+
+
+class Turn(TypedDict):
+    """A turn emitted to the user (server-emitted or LLM-emitted)."""
+
+    type: str  # TurnType value
+    step_index: int
+    payload: Mapping[str, Any]

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -99,3 +99,74 @@ class Turn(TypedDict):
     type: str  # TurnType value
     step_index: int
     payload: Mapping[str, Any]
+
+
+class GuidedStep(StrEnum):
+    """Wizard step pointer."""
+
+    STEP_1_SOURCE = "step_1_source"
+    STEP_2_SINK = "step_2_sink"
+    STEP_2_5_RECIPE_MATCH = "step_2_5_recipe_match"
+    STEP_3_TRANSFORMS = "step_3_transforms"
+
+
+_LEGAL_TURN_MATRIX: Mapping[GuidedStep, frozenset[TurnType]] = {
+    GuidedStep.STEP_1_SOURCE: frozenset(
+        {
+            TurnType.INSPECT_AND_CONFIRM,
+            TurnType.SINGLE_SELECT,
+            TurnType.SCHEMA_FORM,
+        }
+    ),
+    GuidedStep.STEP_2_SINK: frozenset(
+        {
+            TurnType.SINGLE_SELECT,
+            TurnType.MULTI_SELECT_WITH_CUSTOM,
+            TurnType.SCHEMA_FORM,
+        }
+    ),
+    GuidedStep.STEP_2_5_RECIPE_MATCH: frozenset({TurnType.RECIPE_OFFER}),
+    GuidedStep.STEP_3_TRANSFORMS: frozenset(
+        {
+            TurnType.PROPOSE_CHAIN,
+            TurnType.SINGLE_SELECT,
+        }
+    ),
+}
+
+
+def legal_turn_types_for(step: GuidedStep) -> frozenset[TurnType]:
+    """Return the frozen set of TurnType values legal at the given step."""
+    return _LEGAL_TURN_MATRIX[step]
+
+
+_REQUIRED_KEYS: Mapping[TurnType, frozenset[str]] = {
+    TurnType.INSPECT_AND_CONFIRM: frozenset({"observed"}),
+    TurnType.SINGLE_SELECT: frozenset({"question", "options", "allow_custom"}),
+    TurnType.MULTI_SELECT_WITH_CUSTOM: frozenset(
+        {
+            "question",
+            "options",
+            "default_chosen",
+            "escape_label",
+        }
+    ),
+    TurnType.SCHEMA_FORM: frozenset({"plugin", "schema_block", "prefilled"}),
+    TurnType.PROPOSE_CHAIN: frozenset({"steps", "why", "blockers"}),
+    TurnType.RECIPE_OFFER: frozenset({"recipe_name", "slots", "alternatives"}),
+}
+
+
+def validate_payload(turn_type: TurnType, payload: Mapping[str, Any]) -> str | None:
+    """Validate that *payload* satisfies the schema for *turn_type*.
+
+    Returns None on success, or a human-readable error string on failure.
+    Raises ValueError if turn_type is not a known TurnType.
+    """
+    if not isinstance(turn_type, TurnType):
+        raise ValueError(f"unknown turn type: {turn_type!r}")
+    required = _REQUIRED_KEYS[turn_type]
+    missing = required - payload.keys()
+    if missing:
+        return f"payload for {turn_type.value} missing required keys: {sorted(missing)}"
+    return None

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -9,6 +9,8 @@ from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any, TypedDict
 
+from elspeth.web.composer.recipes import SlotType
+
 
 class TurnType(StrEnum):
     """The closed taxonomy of turn types the protocol allows."""
@@ -71,13 +73,16 @@ class ProposeChainPayload(TypedDict):
 class _RecipeSlotInput(TypedDict):
     """Wire shape for one unsatisfied required slot in a recipe_offer turn.
 
-    ``slot_type`` mirrors :data:`elspeth.web.composer.recipes.SlotType`.
-    The frontend renders an editable input keyed by ``name`` and submits the
-    typed value back as part of ``edited_values.slots``.
+    ``slot_type`` reuses :data:`elspeth.web.composer.recipes.SlotType` directly
+    so the wire schema cannot drift from the source-of-truth Literal: adding a
+    new member to ``SlotType`` immediately fails type-checking here, in the
+    emitter, and (mirrored manually) in ``guided.ts``. The frontend renders an
+    editable input keyed by ``name`` and submits the typed value back as part
+    of ``edited_values.slots``.
     """
 
     name: str
-    slot_type: str  # one of recipes.SlotType: "blob_id"/"str"/"float"/"int"/"str_list"
+    slot_type: SlotType
     description: str
     required: bool
 

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -68,10 +68,25 @@ class ProposeChainPayload(TypedDict):
     blockers: Sequence[str]
 
 
+class _RecipeSlotInput(TypedDict):
+    """Wire shape for one unsatisfied required slot in a recipe_offer turn.
+
+    ``slot_type`` mirrors :data:`elspeth.web.composer.recipes.SlotType`.
+    The frontend renders an editable input keyed by ``name`` and submits the
+    typed value back as part of ``edited_values.slots``.
+    """
+
+    name: str
+    slot_type: str  # one of recipes.SlotType: "blob_id"/"str"/"float"/"int"/"str_list"
+    description: str
+    required: bool
+
+
 class RecipeOfferPayload(TypedDict):
     recipe_name: str
     slots: Mapping[str, Any]
     alternatives: Sequence[str]
+    unsatisfied_slots: Sequence[_RecipeSlotInput]
 
 
 class ControlSignal(StrEnum):
@@ -153,7 +168,7 @@ _REQUIRED_KEYS: Mapping[TurnType, frozenset[str]] = {
     ),
     TurnType.SCHEMA_FORM: frozenset({"plugin", "schema_block", "prefilled"}),
     TurnType.PROPOSE_CHAIN: frozenset({"steps", "why", "blockers"}),
-    TurnType.RECIPE_OFFER: frozenset({"recipe_name", "slots", "alternatives"}),
+    TurnType.RECIPE_OFFER: frozenset({"recipe_name", "slots", "alternatives", "unsatisfied_slots"}),
 }
 
 

--- a/src/elspeth/web/composer/guided/protocol.py
+++ b/src/elspeth/web/composer/guided/protocol.py
@@ -116,7 +116,7 @@ class TurnResponse(TypedDict):
     custom_inputs: Sequence[str] | None
     accepted_step_index: int | None
     edit_step_index: int | None
-    control_signal: str | None  # ControlSignal value, or None
+    control_signal: ControlSignal | None
 
 
 class Turn(TypedDict):

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -40,8 +40,13 @@ by design.
 Recipe coverage in v1
 ~~~~~~~~~~~~~~~~~~~~~
 - ``classify-rows-llm-jsonl``:  CSV → single JSON output with classifier-keyword
-  in required_fields.
-- ``split-by-numeric-threshold``:  CSV → two JSON outputs.
+  in required_fields.  Reachable from the real guided flow.
+- ``split-by-numeric-threshold``:  CSV → two JSON outputs.  Predicate is in
+  the registry but is **currently unreachable from guided-flow Step 2**: the Step 2
+  state machine always produces a single-output sink (``_advance_step_2`` hard-codes
+  ``SinkResolved(outputs=(output,))``).  Enabling this recipe requires a multi-output
+  Step 2 UI and state-machine refactor.  Kept in the registry for forward-compat;
+  tracked at elspeth-obs-74a708e3d7.
 - ``fork-coalesce-truncate-jsonl``:  intentionally omitted in v1.  The recipe
   requires structural intent (truncate one arm, key-based coalesce) that cannot
   be inferred from (source, sink) alone.  Additionally, its topology (CSV →
@@ -271,6 +276,17 @@ def _split_threshold_predicate(source: SourceResolved, sink: SinkResolved) -> bo
     ``blob_ref``, and the slot resolver cannot run without it.  Returning
     False here means "no recipe match" — the flow continues to manual chain
     solving, which is the correct outcome for a non-blob-backed CSV source.
+
+    **Currently unreachable from guided-flow Step 2.**
+
+    ``_advance_step_2`` (state_machine.py) hard-codes
+    ``SinkResolved(outputs=(output,))`` — the state machine always produces a
+    single-output sink. ``_has_two_json_outputs`` therefore never returns True
+    from the real flow.  The predicate is kept in ``_RECIPE_PREDICATES`` for
+    forward-compatibility: when multi-output Step 2 lands (requires multi-output
+    Step 2 UI + ``step_2_sink_intents: tuple[SinkIntent, ...]`` staging field +
+    refactored ``_advance_step_2``), this recipe will auto-wire without restoring
+    deleted code.  Tracked: elspeth-obs-74a708e3d7.
     """
     if not (_is_csv(source) and _has_two_json_outputs(sink)):
         return False

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -94,6 +94,29 @@ class RecipeMatch:
 
     def __post_init__(self) -> None:
         freeze_fields(self, "slots", "unsatisfied_slots")
+        # Offensive invariants: the documented contract on ``unsatisfied_slots``
+        # is enforced by ``match_recipe`` at the construction site, but any
+        # *other* caller (apply-time reconstruction in routes.py, test fixtures,
+        # future code paths) could violate it silently.  Pin the contract here
+        # so violations crash at construction with an informative message
+        # rather than producing audit-trail garbage at apply time.
+        #
+        # Invariant 1: key-disjointness — a slot cannot be both "resolved" and
+        # "unsatisfied".  The two mappings are complementary by definition.
+        overlap = set(self.unsatisfied_slots) & set(self.slots)
+        if overlap:
+            raise ValueError(f"RecipeMatch.unsatisfied_slots must be disjoint from slots; overlap on: {sorted(overlap)}")
+        # Invariant 2: only required slots belong in ``unsatisfied_slots``.
+        # Optional slots with declared defaults are auto-filled by
+        # ``validate_slots`` at apply time and must not be surfaced to the
+        # operator as fields they need to fill.
+        for name, spec in self.unsatisfied_slots.items():
+            if not spec.required:
+                raise ValueError(
+                    f"RecipeMatch.unsatisfied_slots[{name!r}] is optional; "
+                    "only required slots belong in unsatisfied_slots "
+                    "(optional slots are auto-filled by validate_slots)"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -57,6 +57,7 @@ from typing import Any
 
 from elspeth.contracts.freeze import freeze_fields
 from elspeth.web.composer.guided.state_machine import SinkResolved, SourceResolved
+from elspeth.web.composer.recipes import SlotSpec, get_recipe
 
 # ---------------------------------------------------------------------------
 # Type aliases for the predicate registry
@@ -79,13 +80,20 @@ class RecipeMatch:
     state are populated. The route handler emits a ``recipe_offer`` turn
     that asks the operator to fill the remaining required slots before
     ``_execute_apply_pipeline_recipe`` is invoked (see Errata C2).
+
+    ``unsatisfied_slots`` is the schema for the required slots NOT covered by
+    ``slots`` — the emitter projects these to a wire-friendly shape so the
+    frontend can render an editable form for them.  Only *required* slots are
+    included; optional slots with declared defaults are auto-filled by
+    ``validate_slots`` at apply time and are not surfaced to the operator.
     """
 
     recipe_name: str
     slots: Mapping[str, Any]
+    unsatisfied_slots: Mapping[str, SlotSpec]
 
     def __post_init__(self) -> None:
-        freeze_fields(self, "slots")
+        freeze_fields(self, "slots", "unsatisfied_slots")
 
 
 # ---------------------------------------------------------------------------
@@ -236,8 +244,19 @@ def match_recipe(
     """
     for predicate, recipe_name, slot_resolver in _RECIPE_PREDICATES:
         if predicate(source, sink):
+            resolved_slots = slot_resolver(source, sink)
+            # Look up the recipe to derive the unsatisfied required-slot
+            # schema. The predicate registry's recipe_name MUST be registered
+            # — if not, that's an invariant violation, crash loudly.
+            recipe = get_recipe(recipe_name)
+            if recipe is None:
+                raise ValueError(f"Recipe '{recipe_name}' is in _RECIPE_PREDICATES but not registered in recipes.py — invariant violation.")
+            unsatisfied: dict[str, SlotSpec] = {
+                name: spec for name, spec in recipe.slots.items() if spec.required and name not in resolved_slots
+            }
             return RecipeMatch(
                 recipe_name=recipe_name,
-                slots=slot_resolver(source, sink),
+                slots=resolved_slots,
+                unsatisfied_slots=unsatisfied,
             )
     return None

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -16,9 +16,15 @@ Two kinds of values are read from ``source.options`` and
     ``_execute_set_source_from_blob`` (tools.py) **and** by
     ``handle_step_1_source`` (steps.py) when the submitted path resolves to
     a known uploaded blob.  This is Tier-2 data (already validated by our
-    own code) — direct subscript access is mandatory, no ``.get()``.  A
-    missing ``blob_ref`` crashes with an informative ``InvariantError`` (the
-    resolver must only be called after blob-backed source commit).
+    own code) — direct subscript access is mandatory, no ``.get()``.
+
+    **Both predicates gate on ``"blob_ref" in source.options`` before returning
+    True**, so a CSV source without a blob upload will produce no recipe match
+    (returning ``None``) rather than crashing in the resolver.  CSV-without-blob
+    is a legitimate user configuration; the correct outcome is that the flow
+    continues to manual chain solving via Step 3.  Slot resolvers retain their
+    ``InvariantError`` guard as defence-in-depth for any future caller that
+    bypasses the predicate registry.
 
 Output paths (``sink.outputs[i].options.get("path", default)``)
     User/LLM-supplied via the SchemaForm, so genuinely Tier-3.  A default
@@ -145,13 +151,20 @@ _CLASSIFY_KEYWORDS: frozenset[str] = frozenset({"category", "label", "tag", "cla
 
 
 def _classify_predicate(source: SourceResolved, sink: SinkResolved) -> bool:
-    """Return True for CSV → single-JSON with a classifier-keyword required field.
+    """Return True for blob-backed CSV → single-JSON with a classifier-keyword required field.
+
+    Requires ``blob_ref`` in ``source.options``: a CSV source configured via
+    SchemaForm with a direct file path (no blob upload) has no ``blob_ref`` and
+    must NOT match — the slot resolver cannot run without it, and "no recipe match"
+    is the correct outcome (the flow continues to manual chain solving).
 
     The required_fields check is the only topology signal that separates
     classify from fork-coalesce-truncate (which also produces single JSON
     output from CSV). Without it, recipe selection would be ambiguous.
     """
     if not (_is_csv(source) and _has_single_json_output(sink)):
+        return False
+    if "blob_ref" not in source.options:
         return False
     return any(name in _CLASSIFY_KEYWORDS for name in sink.outputs[0].required_fields)
 
@@ -172,9 +185,14 @@ def _classify_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mappi
     ``source.options["blob_ref"]`` is the composer-canonical blob UUID.
     It is written by ``_execute_set_source_from_blob`` for blob-upload flows
     and by ``handle_step_1_source`` (steps.py) for SchemaForm flows where
-    the submitted path resolves to an uploaded blob.  A missing ``blob_ref``
-    is a state-machine invariant violation — this resolver must only be
-    reached for blob-backed sources.
+    the submitted path resolves to an uploaded blob.
+
+    The ``_classify_predicate`` gate now requires ``blob_ref in source.options``
+    before returning True, so this InvariantError is structurally unreachable from
+    any call path through ``match_recipe``.  It is kept as defence-in-depth: any
+    future caller that bypasses the predicate registry and invokes this resolver
+    directly will get a clear, immediately-informative crash rather than a silent
+    ``KeyError`` or opaque downstream failure.
     """
     if "blob_ref" not in source.options:
         raise InvariantError(
@@ -200,8 +218,17 @@ def _classify_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mappi
 
 
 def _split_threshold_predicate(source: SourceResolved, sink: SinkResolved) -> bool:
-    """Return True for CSV → two JSON outputs (regardless of required_fields)."""
-    return _is_csv(source) and _has_two_json_outputs(sink)
+    """Return True for blob-backed CSV → two JSON outputs (regardless of required_fields).
+
+    Requires ``blob_ref`` in ``source.options`` for the same reason as
+    ``_classify_predicate``: a CSV source without a blob upload has no
+    ``blob_ref``, and the slot resolver cannot run without it.  Returning
+    False here means "no recipe match" — the flow continues to manual chain
+    solving, which is the correct outcome for a non-blob-backed CSV source.
+    """
+    if not (_is_csv(source) and _has_two_json_outputs(sink)):
+        return False
+    return "blob_ref" in source.options
 
 
 def _split_threshold_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mapping[str, Any]:
@@ -214,6 +241,12 @@ def _split_threshold_slot_resolver(source: SourceResolved, sink: SinkResolved) -
     same contract as ``_classify_slot_resolver`` — must be present.
     ``sink.outputs[i].options.get("path", default)`` is Tier-3 with a
     rubber-stampable suggested default.
+
+    The ``_split_threshold_predicate`` gate now requires ``blob_ref in source.options``
+    before returning True, so this InvariantError is structurally unreachable from
+    any call path through ``match_recipe``.  It is kept as defence-in-depth: any
+    future caller that bypasses the predicate registry will get a clear crash
+    rather than a silent ``KeyError`` or opaque downstream failure.
     """
     if "blob_ref" not in source.options:
         raise InvariantError(

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -1,0 +1,214 @@
+"""Deterministic recipe matcher: topology-only, pure function, no I/O.
+
+``match_recipe(source, sink)`` runs at Step 2.5 to detect if an existing
+registered recipe fits the operator's (source, sink) shape. On a match, it
+returns a :class:`RecipeMatch` with a **partial** slot map — only the slots
+derivable from observed (source, sink) state are populated. The operator fills
+the remaining required slots via a ``recipe_offer`` turn at Step 2.5.
+
+Boundary contract for ``.get()`` usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``source.options`` and ``sink.outputs[0].options`` are Tier-3 inputs
+(user/LLM-supplied via the source/sink spec). The ``.get(key, default)``
+calls in the slot resolvers are the documented coercion at this boundary:
+an empty-string sentinel (for blob ids) or a default path (for output paths)
+signals "operator must supply or confirm via the ``recipe_offer`` turn".
+
+Predicates match on **topology only** (source plugin + sink output count and
+plugin). They do NOT return False just because some required slots cannot be
+derived — that would make Step 2.5 a dead letter. Slot resolvers are partial
+by design.
+
+Recipe coverage in v1
+~~~~~~~~~~~~~~~~~~~~~
+- ``classify-rows-llm-jsonl``:  CSV → single JSON output with classifier-keyword
+  in required_fields.
+- ``split-by-numeric-threshold``:  CSV → two JSON outputs.
+- ``fork-coalesce-truncate-jsonl``:  intentionally omitted in v1.  The recipe
+  requires structural intent (truncate one arm, key-based coalesce) that cannot
+  be inferred from (source, sink) alone.  Additionally, its topology (CSV →
+  single JSON output) overlaps with classify — ordering alone cannot
+  disambiguate; only the classifier-keyword check separates them.  Adding an
+  R3 predicate without a clear distinguishing signal would produce ambiguous
+  matches.  Users who want this recipe must hand-build via Step 3 or
+  pre-select via ``list_recipes``.
+
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §6.4
+and Errata C8.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from elspeth.contracts.freeze import freeze_fields
+from elspeth.web.composer.guided.state_machine import SinkResolved, SourceResolved
+
+# ---------------------------------------------------------------------------
+# Type aliases for the predicate registry
+# ---------------------------------------------------------------------------
+
+_Predicate = Callable[[SourceResolved, SinkResolved], bool]
+_SlotResolver = Callable[[SourceResolved, SinkResolved], Mapping[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeMatch:
+    """Result of matching a recipe to a (source, sink) tuple.
+
+    ``slots`` is a *partial* map: only the slots derivable from observed
+    state are populated. The route handler emits a ``recipe_offer`` turn
+    that asks the operator to fill the remaining required slots before
+    ``_execute_apply_pipeline_recipe`` is invoked (see Errata C2).
+    """
+
+    recipe_name: str
+    slots: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "slots")
+
+
+# ---------------------------------------------------------------------------
+# Topology helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_csv(source: SourceResolved) -> bool:
+    return source.plugin == "csv"
+
+
+def _has_single_json_output(sink: SinkResolved) -> bool:
+    return len(sink.outputs) == 1 and sink.outputs[0].plugin == "json"
+
+
+def _has_two_json_outputs(sink: SinkResolved) -> bool:
+    return len(sink.outputs) == 2 and all(o.plugin == "json" for o in sink.outputs)
+
+
+# ---------------------------------------------------------------------------
+# Classify-rows-llm-jsonl predicate and slot resolver
+# ---------------------------------------------------------------------------
+
+_CLASSIFY_KEYWORDS: frozenset[str] = frozenset({"category", "label", "tag", "classification"})
+
+
+def _classify_predicate(source: SourceResolved, sink: SinkResolved) -> bool:
+    """Return True for CSV → single-JSON with a classifier-keyword required field.
+
+    The required_fields check is the only topology signal that separates
+    classify from fork-coalesce-truncate (which also produces single JSON
+    output from CSV). Without it, recipe selection would be ambiguous.
+    """
+    if not (_is_csv(source) and _has_single_json_output(sink)):
+        return False
+    return any(name in _CLASSIFY_KEYWORDS for name in sink.outputs[0].required_fields)
+
+
+def _classify_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mapping[str, Any]:
+    """Partial slot map for the classify-rows-llm-jsonl recipe.
+
+    Provides: ``source_blob_id``, ``output_path``, ``label_field``.
+    User-fillable: ``classifier_template``, ``model``, ``api_key_secret``,
+    ``provider``, ``required_input_fields``.
+
+    ``label_field`` is the first required_field name that belongs to
+    ``_CLASSIFY_KEYWORDS``.  Using the keyword-matching field rather than
+    ``required_fields[0]`` produces an honest pre-fill — the operator may
+    rubber-stamp the default via the ``recipe_offer`` turn, so it should be
+    the most likely correct value.
+
+    ``source.options`` is a Tier-3 input; ``.get("blob_id", "")`` is the
+    documented coercion at this boundary — an empty string means "operator
+    must supply via the recipe_offer turn".
+    """
+    # source.options is Tier-3 (user/LLM-supplied); .get is boundary coercion.
+    blob_id = source.options.get("blob_id", "")
+    output_path = sink.outputs[0].options.get("path", "outputs/classified.jsonl")
+    # Pick the first keyword-matching required_field; predicate guarantees one exists.
+    label_field = next(n for n in sink.outputs[0].required_fields if n in _CLASSIFY_KEYWORDS)
+    return {
+        "source_blob_id": blob_id,
+        "output_path": output_path,
+        "label_field": label_field,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Split-by-numeric-threshold predicate and slot resolver
+# ---------------------------------------------------------------------------
+
+
+def _split_threshold_predicate(source: SourceResolved, sink: SinkResolved) -> bool:
+    """Return True for CSV → two JSON outputs (regardless of required_fields)."""
+    return _is_csv(source) and _has_two_json_outputs(sink)
+
+
+def _split_threshold_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mapping[str, Any]:
+    """Partial slot map for the split-by-numeric-threshold recipe.
+
+    Provides: ``source_blob_id``, ``above_output_path``, ``below_output_path``.
+    User-fillable: ``field``, ``threshold``.
+
+    ``source.options`` and ``sink.outputs[i].options`` are Tier-3 inputs;
+    ``.get(key, default)`` is the documented coercion at this boundary.
+    """
+    # source.options is Tier-3 (user/LLM-supplied); .get is boundary coercion.
+    blob_id = source.options.get("blob_id", "")
+    above_path = sink.outputs[0].options.get("path", "outputs/above.jsonl")
+    below_path = sink.outputs[1].options.get("path", "outputs/below.jsonl")
+    return {
+        "source_blob_id": blob_id,
+        "above_output_path": above_path,
+        "below_output_path": below_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Predicate registry — most-specific first, first match wins
+# ---------------------------------------------------------------------------
+
+_RECIPE_PREDICATES: Sequence[tuple[_Predicate, str, _SlotResolver]] = (
+    (_classify_predicate, "classify-rows-llm-jsonl", _classify_slot_resolver),
+    (_split_threshold_predicate, "split-by-numeric-threshold", _split_threshold_slot_resolver),
+    # fork-coalesce-truncate-jsonl predicate intentionally omitted in v1; that
+    # recipe requires structural intent (truncate one arm, key-based coalesce)
+    # that the matcher cannot infer from (source, sink) alone.  Even if a
+    # predicate were added later, topology cannot disambiguate classify vs R3
+    # (both are CSV → single JSON) — only the classifier-keyword check separates
+    # them.  Users who want fork-coalesce must hand-build via Step 3 or
+    # pre-select via list_recipes.
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def match_recipe(
+    source: SourceResolved,
+    sink: SinkResolved,
+) -> RecipeMatch | None:
+    """Return the most-specific recipe matching the tuple, or None.
+
+    Topology-only. Predicates examine source plugin + sink output count
+    and plugin. Slot resolvers derive what they can; operator fills the
+    rest via the ``recipe_offer`` turn at Step 2.5.
+
+    First match in ``_RECIPE_PREDICATES`` wins; order is most-specific first.
+    """
+    for predicate, recipe_name, slot_resolver in _RECIPE_PREDICATES:
+        if predicate(source, sink):
+            return RecipeMatch(
+                recipe_name=recipe_name,
+                slots=slot_resolver(source, sink),
+            )
+    return None

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -17,7 +17,7 @@ Two kinds of values are read from ``source.options`` and
     ``handle_step_1_source`` (steps.py) when the submitted path resolves to
     a known uploaded blob.  This is Tier-2 data (already validated by our
     own code) — direct subscript access is mandatory, no ``.get()``.  A
-    missing ``blob_ref`` crashes with an informative ``ValueError`` (the
+    missing ``blob_ref`` crashes with an informative ``InvariantError`` (the
     resolver must only be called after blob-backed source commit).
 
 Output paths (``sink.outputs[i].options.get("path", default)``)

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -59,12 +59,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
-from elspeth.contracts.freeze import freeze_fields
+from elspeth.contracts.freeze import deep_thaw, freeze_fields
 from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.state_machine import SinkResolved, SourceResolved
-from elspeth.web.composer.recipes import SlotSpec, get_recipe
+from elspeth.web.composer.recipes import SlotSpec, SlotType, get_recipe
 
 # ---------------------------------------------------------------------------
 # Type aliases for the predicate registry
@@ -124,6 +124,52 @@ class RecipeMatch:
                     "only required slots belong in unsatisfied_slots "
                     "(optional slots are auto-filled by validate_slots)"
                 )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict.
+
+        ``slots`` values are arbitrary (Tier-2, already validated). ``unsatisfied_slots``
+        values are ``SlotSpec`` instances — serialised as plain dicts with scalar fields.
+        """
+        unsatisfied: dict[str, dict[str, Any]] = {
+            name: {
+                "slot_type": spec.slot_type,
+                "required": spec.required,
+                "description": spec.description,
+                "default": spec.default,
+            }
+            for name, spec in self.unsatisfied_slots.items()
+        }
+        return {
+            "recipe_name": self.recipe_name,
+            "slots": dict(deep_thaw(self.slots)),
+            "unsatisfied_slots": unsatisfied,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RecipeMatch:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data.
+
+        Used when restoring ``step_2_5_recipe_offer`` from ``GuidedSession.from_dict``.
+        The dict must have been produced by ``to_dict()``.
+        """
+        try:
+            unsatisfied: dict[str, SlotSpec] = {
+                name: SlotSpec(
+                    slot_type=cast(SlotType, spec_d["slot_type"]),
+                    required=spec_d["required"],
+                    description=spec_d["description"],
+                    default=spec_d["default"],
+                )
+                for name, spec_d in d["unsatisfied_slots"].items()
+            }
+            return cls(
+                recipe_name=d["recipe_name"],
+                slots=d["slots"],
+                unsatisfied_slots=unsatisfied,
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise InvariantError(f"RecipeMatch.from_dict: malformed record {d!r}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -56,6 +56,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from elspeth.contracts.freeze import freeze_fields
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.state_machine import SinkResolved, SourceResolved
 from elspeth.web.composer.recipes import SlotSpec, get_recipe
 
@@ -105,14 +106,14 @@ class RecipeMatch:
         # "unsatisfied".  The two mappings are complementary by definition.
         overlap = set(self.unsatisfied_slots) & set(self.slots)
         if overlap:
-            raise ValueError(f"RecipeMatch.unsatisfied_slots must be disjoint from slots; overlap on: {sorted(overlap)}")
+            raise InvariantError(f"RecipeMatch.unsatisfied_slots must be disjoint from slots; overlap on: {sorted(overlap)}")
         # Invariant 2: only required slots belong in ``unsatisfied_slots``.
         # Optional slots with declared defaults are auto-filled by
         # ``validate_slots`` at apply time and must not be surfaced to the
         # operator as fields they need to fill.
         for name, spec in self.unsatisfied_slots.items():
             if not spec.required:
-                raise ValueError(
+                raise InvariantError(
                     f"RecipeMatch.unsatisfied_slots[{name!r}] is optional; "
                     "only required slots belong in unsatisfied_slots "
                     "(optional slots are auto-filled by validate_slots)"
@@ -176,7 +177,7 @@ def _classify_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mappi
     reached for blob-backed sources.
     """
     if "blob_ref" not in source.options:
-        raise ValueError(
+        raise InvariantError(
             "Recipe slot resolver requires source.options['blob_ref'] "
             "(set by _execute_set_source_from_blob or handle_step_1_source "
             "blob enrichment path); source options present: "
@@ -215,7 +216,7 @@ def _split_threshold_slot_resolver(source: SourceResolved, sink: SinkResolved) -
     rubber-stampable suggested default.
     """
     if "blob_ref" not in source.options:
-        raise ValueError(
+        raise InvariantError(
             "Recipe slot resolver requires source.options['blob_ref'] "
             "(set by _execute_set_source_from_blob or handle_step_1_source "
             "blob enrichment path); source options present: "
@@ -273,7 +274,9 @@ def match_recipe(
             # — if not, that's an invariant violation, crash loudly.
             recipe = get_recipe(recipe_name)
             if recipe is None:
-                raise ValueError(f"Recipe '{recipe_name}' is in _RECIPE_PREDICATES but not registered in recipes.py — invariant violation.")
+                raise InvariantError(
+                    f"Recipe '{recipe_name}' is in _RECIPE_PREDICATES but not registered in recipes.py — invariant violation."
+                )
             unsatisfied: dict[str, SlotSpec] = {
                 name: spec for name, spec in recipe.slots.items() if spec.required and name not in resolved_slots
             }

--- a/src/elspeth/web/composer/guided/recipe_match.py
+++ b/src/elspeth/web/composer/guided/recipe_match.py
@@ -6,13 +6,25 @@ returns a :class:`RecipeMatch` with a **partial** slot map — only the slots
 derivable from observed (source, sink) state are populated. The operator fills
 the remaining required slots via a ``recipe_offer`` turn at Step 2.5.
 
-Boundary contract for ``.get()`` usage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``source.options`` and ``sink.outputs[0].options`` are Tier-3 inputs
-(user/LLM-supplied via the source/sink spec). The ``.get(key, default)``
-calls in the slot resolvers are the documented coercion at this boundary:
-an empty-string sentinel (for blob ids) or a default path (for output paths)
-signals "operator must supply or confirm via the ``recipe_offer`` turn".
+Boundary contract for slot resolvers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Two kinds of values are read from ``source.options`` and
+``sink.outputs[i].options``:
+
+``blob_ref`` (``source.options["blob_ref"]``)
+    The composer-canonical blob UUID, written by
+    ``_execute_set_source_from_blob`` (tools.py) **and** by
+    ``handle_step_1_source`` (steps.py) when the submitted path resolves to
+    a known uploaded blob.  This is Tier-2 data (already validated by our
+    own code) — direct subscript access is mandatory, no ``.get()``.  A
+    missing ``blob_ref`` crashes with an informative ``ValueError`` (the
+    resolver must only be called after blob-backed source commit).
+
+Output paths (``sink.outputs[i].options.get("path", default)``)
+    User/LLM-supplied via the SchemaForm, so genuinely Tier-3.  A default
+    is the documented coercion: an absent path produces a rubber-stampable
+    suggested value that the operator can confirm or change via the
+    ``recipe_offer`` turn.
 
 Predicates match on **topology only** (source plugin + sink output count and
 plugin). They do NOT return False just because some required slots cannot be
@@ -125,17 +137,26 @@ def _classify_slot_resolver(source: SourceResolved, sink: SinkResolved) -> Mappi
     rubber-stamp the default via the ``recipe_offer`` turn, so it should be
     the most likely correct value.
 
-    ``source.options`` is a Tier-3 input; ``.get("blob_id", "")`` is the
-    documented coercion at this boundary — an empty string means "operator
-    must supply via the recipe_offer turn".
+    ``source.options["blob_ref"]`` is the composer-canonical blob UUID.
+    It is written by ``_execute_set_source_from_blob`` for blob-upload flows
+    and by ``handle_step_1_source`` (steps.py) for SchemaForm flows where
+    the submitted path resolves to an uploaded blob.  A missing ``blob_ref``
+    is a state-machine invariant violation — this resolver must only be
+    reached for blob-backed sources.
     """
-    # source.options is Tier-3 (user/LLM-supplied); .get is boundary coercion.
-    blob_id = source.options.get("blob_id", "")
+    if "blob_ref" not in source.options:
+        raise ValueError(
+            "Recipe slot resolver requires source.options['blob_ref'] "
+            "(set by _execute_set_source_from_blob or handle_step_1_source "
+            "blob enrichment path); source options present: "
+            f"{sorted(source.options.keys())}"
+        )
+    blob_ref = source.options["blob_ref"]
     output_path = sink.outputs[0].options.get("path", "outputs/classified.jsonl")
     # Pick the first keyword-matching required_field; predicate guarantees one exists.
     label_field = next(n for n in sink.outputs[0].required_fields if n in _CLASSIFY_KEYWORDS)
     return {
-        "source_blob_id": blob_id,
+        "source_blob_id": blob_ref,
         "output_path": output_path,
         "label_field": label_field,
     }
@@ -157,15 +178,23 @@ def _split_threshold_slot_resolver(source: SourceResolved, sink: SinkResolved) -
     Provides: ``source_blob_id``, ``above_output_path``, ``below_output_path``.
     User-fillable: ``field``, ``threshold``.
 
-    ``source.options`` and ``sink.outputs[i].options`` are Tier-3 inputs;
-    ``.get(key, default)`` is the documented coercion at this boundary.
+    ``source.options["blob_ref"]`` is the composer-canonical blob UUID;
+    same contract as ``_classify_slot_resolver`` — must be present.
+    ``sink.outputs[i].options.get("path", default)`` is Tier-3 with a
+    rubber-stampable suggested default.
     """
-    # source.options is Tier-3 (user/LLM-supplied); .get is boundary coercion.
-    blob_id = source.options.get("blob_id", "")
+    if "blob_ref" not in source.options:
+        raise ValueError(
+            "Recipe slot resolver requires source.options['blob_ref'] "
+            "(set by _execute_set_source_from_blob or handle_step_1_source "
+            "blob enrichment path); source options present: "
+            f"{sorted(source.options.keys())}"
+        )
+    blob_ref = source.options["blob_ref"]
     above_path = sink.outputs[0].options.get("path", "outputs/above.jsonl")
     below_path = sink.outputs[1].options.get("path", "outputs/below.jsonl")
     return {
-        "source_blob_id": blob_id,
+        "source_blob_id": blob_ref,
         "above_output_path": above_path,
         "below_output_path": below_path,
     }

--- a/src/elspeth/web/composer/guided/skills/guided_pipeline.md
+++ b/src/elspeth/web/composer/guided/skills/guided_pipeline.md
@@ -1,0 +1,80 @@
+# Guided-Mode Pipeline Composer Skill
+
+You are operating the ELSPETH composer in **guided mode**. This is a structured
+turn protocol — both you and the user operate inside fixed constraints:
+
+- You may emit **exactly one** turn per turn, of one of these six types:
+  `inspect_and_confirm`, `single_select`, `multi_select_with_custom`,
+  `schema_form`, `propose_chain`, `recipe_offer`. Anything else is rejected.
+- The user can only answer using the chips, forms, or accept/reject controls
+  the turn defines. There is no freeform text input.
+- You **cannot** mutate pipeline state. Server-side step handlers commit
+  state in response to the user's typed answers. Your only job is to choose
+  the right turn for the current step.
+
+## Per-step playbook
+
+### Step 1 — Source
+
+Legal turn types: `inspect_and_confirm`, `single_select`, `schema_form`.
+Default: emit `inspect_and_confirm` after a blob is attached. Emit
+`schema_form` if the user needs to set non-default options. Emit
+`single_select` only if no source plugin has been chosen yet.
+
+### Step 2 — Sink + required fields
+
+Legal turn types: `single_select`, `multi_select_with_custom`, `schema_form`.
+Default: `single_select` for the sink plugin, then `schema_form` for
+options, then `multi_select_with_custom` for required output fields with
+chips pre-populated from Step 1's observed columns.
+
+### Step 2.5 — Recipe match
+
+The server emits `recipe_offer` automatically when a recipe matches; you do
+**not** emit this turn yourself. If the user picks "build manually," you
+proceed to Step 3.
+
+### Step 3 — Transform chain proposal
+
+Legal turn types: `propose_chain`, `single_select`. The server gives you a
+context block:
+
+```
+GUIDED CONTEXT (server-resolved):
+source: {plugin: ..., columns: [...], sample: [...]}
+sink: {outputs: [{plugin: ..., required_fields: [...]}, ...]}
+recipe_match: null
+```
+
+Propose a transform chain that satisfies the contract from `source.columns`
+to each sink's `required_fields`. Every step in the chain must include a
+`rationale` string that names what it does and why it is required.
+
+If you cannot find a chain that satisfies the contract:
+
+1. Emit `single_select` with a clarifying question and chip answers — only
+   when the user can resolve the ambiguity in one click.
+2. Or escalate via `request_advisor_hint` if the question is structural.
+
+**Do not emit a `propose_chain` whose preview will fail.** A degraded
+proposal that the server then rejects costs the user a turn.
+
+## Hard rules that survive from freeform mode
+
+- **Anti-fabrication.** Do not invent plugins, options, model names, or
+  capabilities. If a name does not appear in `list_sources`/`list_sinks`/
+  `list_transforms`/`list_models`, it does not exist.
+- **Shape preservation.** If the user described a shape (fork-and-merge,
+  multi-stage cascade) that you cannot build, refuse with a named gap via
+  `single_select`. Do not silently downgrade.
+- **Audit boundary.** Audit logging is operator-managed and not
+  composer-configurable. Do not propose audit sinks; refer the user to
+  the operator if they ask.
+
+## Sample-value eyeballing (Step 3 only)
+
+When wiring a column into a value-shape-sensitive transform field
+(`web_scrape.url_field`, `database.url`, `value_transform` arithmetic), check
+that the sample values in the GUIDED CONTEXT block actually look like the
+required shape. If not, propose an upstream `value_transform` or `type_coerce`
+to normalise — do not assume the strings will be valid at run time.

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -23,6 +23,7 @@ from enum import StrEnum
 from typing import Any
 
 from elspeth.contracts.freeze import deep_thaw, freeze_fields
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse, TurnType
 
 
@@ -68,7 +69,7 @@ class TerminalState:
                 pipeline_yaml=d["pipeline_yaml"],
             )
         except (KeyError, ValueError) as exc:
-            raise ValueError(f"TerminalState.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"TerminalState.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,7 +104,7 @@ class TurnRecord:
                 emitter=d["emitter"],
             )
         except (KeyError, ValueError) as exc:
-            raise ValueError(f"TurnRecord.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"TurnRecord.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,7 +142,7 @@ class SourceResolved:
                 sample_rows=tuple(dict(r) for r in d["sample_rows"]),
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"SourceResolved.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"SourceResolved.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,7 +180,7 @@ class SinkOutputResolved:
                 schema_mode=d["schema_mode"],
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"SinkOutputResolved.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"SinkOutputResolved.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -204,7 +205,7 @@ class SinkResolved:
         try:
             return cls(outputs=tuple(SinkOutputResolved.from_dict(o) for o in d["outputs"]))
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"SinkResolved.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"SinkResolved.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -252,7 +253,7 @@ class SourceIntent:
                 sample_rows=tuple(dict(r) for r in d["sample_rows"]),
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"SourceIntent.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"SourceIntent.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -294,7 +295,7 @@ class SinkIntent:
                 options=d["options"],
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"SinkIntent.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"SinkIntent.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -326,7 +327,7 @@ class ChainProposal:
                 why=d["why"],
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"ChainProposal.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"ChainProposal.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -419,7 +420,7 @@ class GuidedSession:
                 step_2_sink_intent=SinkIntent.from_dict(sink_intent_raw) if sink_intent_raw is not None else None,
             )
         except (KeyError, ValueError, TypeError) as exc:
-            raise ValueError(f"GuidedSession.from_dict: malformed record {d!r}") from exc
+            raise InvariantError(f"GuidedSession.from_dict: malformed record {d!r}") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -547,7 +548,7 @@ def _advance_step_1(
 
     intent = session.step_1_source_intent
     if intent is None:
-        raise ValueError(
+        raise InvariantError(
             "_advance_step_1: step_1_source_intent is None when INSPECT_AND_CONFIRM "
             "was received — the INSPECT_AND_CONFIRM emit site must set it before "
             "emitting the turn. This is a state-machine invariant violation."
@@ -615,7 +616,7 @@ def _advance_step_2(
 
     intent = session.step_2_sink_intent
     if intent is None:
-        raise ValueError(
+        raise InvariantError(
             "_advance_step_2: step_2_sink_intent is None when MULTI_SELECT_WITH_CUSTOM "
             "was received — the SCHEMA_FORM dispatcher must set it before emitting "
             "the MULTI_SELECT_WITH_CUSTOM turn. This is a state-machine invariant "

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -208,6 +208,48 @@ class SinkResolved:
 
 
 @dataclass(frozen=True, slots=True)
+class SinkIntent:
+    """Sink plugin name and options captured during the Step-2 SCHEMA_FORM turn.
+
+    Persisted in GuidedSession.step_2_sink_intent as a mid-Step-2 staging
+    field.  The SCHEMA_FORM dispatcher writes it; _advance_step_2 reads it
+    when processing the subsequent MULTI_SELECT_WITH_CUSTOM response to
+    construct the full SinkOutputResolved entry.
+
+    It is cleared (set to None) as part of the same atomic replace() that
+    consumes it, so it cannot be misread by a later step.
+
+    Frozen, audit-tier: same freeze contract as SourceResolved and
+    SinkOutputResolved.  options is a Mapping because the sink schema can
+    contain arbitrary types; freeze_fields enforces deep immutability.
+    """
+
+    plugin: str
+    options: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "options")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "plugin": self.plugin,
+            "options": deep_thaw(self.options),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SinkIntent:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                plugin=d["plugin"],
+                options=d["options"],
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"SinkIntent.from_dict: malformed record {d!r}") from exc
+
+
+@dataclass(frozen=True, slots=True)
 class ChainProposal:
     """A transform chain proposed by Step 3 LLM.
 
@@ -250,6 +292,12 @@ class GuidedSession:
     Serialisation: use ``to_dict()`` / ``from_dict()`` for persistence via
     ``composer_meta["guided_session"]`` (see Task 3.5a implementation notes).
     The frozen dataclass equality check is the round-trip invariant test.
+
+    ``step_2_sink_intent`` is a mid-Step-2 staging field.  The SCHEMA_FORM
+    dispatcher writes the chosen sink plugin + options into it before emitting
+    the MULTI_SELECT_WITH_CUSTOM turn.  ``_advance_step_2`` reads it to
+    reconstruct the full SinkOutputResolved and clears it in the same atomic
+    replace(); it is always None after Step 2 completes.
     """
 
     step: GuidedStep
@@ -259,6 +307,7 @@ class GuidedSession:
     step_3_proposal: ChainProposal | None
     terminal: TerminalState | None
     transition_consumed: bool = False
+    step_2_sink_intent: SinkIntent | None = None
 
     @classmethod
     def initial(cls) -> GuidedSession:
@@ -285,6 +334,7 @@ class GuidedSession:
             "step_3_proposal": self.step_3_proposal.to_dict() if self.step_3_proposal is not None else None,
             "terminal": self.terminal.to_dict() if self.terminal is not None else None,
             "transition_consumed": self.transition_consumed,
+            "step_2_sink_intent": self.step_2_sink_intent.to_dict() if self.step_2_sink_intent is not None else None,
         }
 
     @classmethod
@@ -299,6 +349,7 @@ class GuidedSession:
             step_2_raw = d["step_2_result"]
             step_3_raw = d["step_3_proposal"]
             terminal_raw = d["terminal"]
+            sink_intent_raw = d["step_2_sink_intent"]
             return cls(
                 step=GuidedStep(d["step"]),
                 history=tuple(TurnRecord.from_dict(r) for r in d["history"]),
@@ -307,6 +358,7 @@ class GuidedSession:
                 step_3_proposal=ChainProposal.from_dict(step_3_raw) if step_3_raw is not None else None,
                 terminal=TerminalState.from_dict(terminal_raw) if terminal_raw is not None else None,
                 transition_consumed=d["transition_consumed"],
+                step_2_sink_intent=SinkIntent.from_dict(sink_intent_raw) if sink_intent_raw is not None else None,
             )
         except (KeyError, ValueError, TypeError) as exc:
             raise ValueError(f"GuidedSession.from_dict: malformed record {d!r}") from exc
@@ -463,27 +515,44 @@ def _advance_step_2(
     Only ``MULTI_SELECT_WITH_CUSTOM`` causes a step transition; all other Step 2
     turn types are intra-step turns that do not advance the wizard.
 
-    The ``edited_values["outputs"]`` list is Tier-3 external data: each field
-    is coerced at this boundary (``str``, ``dict``, ``tuple``, ``str``) before
-    being stored in the audit-tier ``SinkOutputResolved`` dataclass.
+    The MULTI_SELECT_WITH_CUSTOM response carries:
+    - ``chosen``: the list of required field names the user selected
+    - ``custom_inputs``: any additional field names the user typed in
+
+    The sink plugin name and options were persisted in
+    ``session.step_2_sink_intent`` by the preceding SCHEMA_FORM dispatcher.
+    ``_advance_step_2`` reads them here, combines with ``chosen`` +
+    ``custom_inputs`` to construct a single ``SinkOutputResolved``, and
+    clears ``step_2_sink_intent`` in the same atomic replace() so it cannot
+    be misread by a later step.
+
+    All values from the response are Tier-3 external data and are coerced
+    (str, tuple) before being stored in the audit-tier ``SinkOutputResolved``.
     """
     if turn_type is not TurnType.MULTI_SELECT_WITH_CUSTOM:
         return (session, None, None, [])
 
-    edited = response["edited_values"]
-    if edited is None:
-        raise ValueError("multi_select_with_custom response must carry edited_values")
-    raw_outputs = edited["outputs"]
-    outputs = tuple(
-        SinkOutputResolved(
-            plugin=str(o["plugin"]),
-            options=dict(o["options"]),
-            required_fields=tuple(o["required_fields"]),
-            schema_mode=str(o["schema_mode"]),
+    intent = session.step_2_sink_intent
+    if intent is None:
+        raise ValueError(
+            "_advance_step_2: step_2_sink_intent is None when MULTI_SELECT_WITH_CUSTOM "
+            "was received — the SCHEMA_FORM dispatcher must set it before emitting "
+            "the MULTI_SELECT_WITH_CUSTOM turn. This is a state-machine invariant "
+            "violation."
         )
-        for o in raw_outputs
+
+    # chosen and custom_inputs are Tier-3: coerce to tuple[str, ...].
+    chosen_raw = response["chosen"] or []
+    custom_inputs_raw = response["custom_inputs"] or []
+    required_fields = tuple(str(f) for f in chosen_raw) + tuple(str(f) for f in custom_inputs_raw)
+
+    output = SinkOutputResolved(
+        plugin=intent.plugin,
+        options=dict(deep_thaw(intent.options)),
+        required_fields=required_fields,
+        schema_mode="observed",
     )
-    sink = SinkResolved(outputs=outputs)
+    sink = SinkResolved(outputs=(output,))
     directives = [
         GuidedAuditDirective(
             tool_name="guided_step_advanced",
@@ -498,6 +567,7 @@ def _advance_step_2(
         session,
         step=GuidedStep.STEP_2_5_RECIPE_MATCH,
         step_2_result=sink,
+        step_2_sink_intent=None,  # consumed; clear to prevent misread by later steps
     )
     return (new_sess, None, None, directives)
 

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -208,6 +208,54 @@ class SinkResolved:
 
 
 @dataclass(frozen=True, slots=True)
+class SourceIntent:
+    """Source plugin name, options, and observed inspection facts captured during Step 1.
+
+    Persisted in GuidedSession.step_1_source_intent as a mid-Step-1 staging
+    field.  The INSPECT_AND_CONFIRM emit site writes it; _advance_step_1 reads it
+    when processing the INSPECT_AND_CONFIRM response to construct SourceResolved.
+
+    It is cleared (set to None) as part of the same atomic replace() that
+    consumes it, so it cannot be misread by a later step.
+
+    Frozen, audit-tier: same freeze contract as SourceResolved and SinkIntent.
+    options is a Mapping because the source schema can contain arbitrary types;
+    observed_columns and sample_rows are Sequences for the same reason;
+    freeze_fields enforces deep immutability on all container fields.
+    """
+
+    plugin: str
+    options: Mapping[str, Any]
+    observed_columns: Sequence[str]
+    sample_rows: Sequence[Mapping[str, Any]]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "options", "observed_columns", "sample_rows")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "plugin": self.plugin,
+            "options": deep_thaw(self.options),
+            "observed_columns": list(deep_thaw(self.observed_columns)),
+            "sample_rows": [dict(deep_thaw(r)) for r in self.sample_rows],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SourceIntent:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                plugin=d["plugin"],
+                options=d["options"],
+                observed_columns=tuple(d["observed_columns"]),
+                sample_rows=tuple(dict(r) for r in d["sample_rows"]),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"SourceIntent.from_dict: malformed record {d!r}") from exc
+
+
+@dataclass(frozen=True, slots=True)
 class SinkIntent:
     """Sink plugin name and options captured during the Step-2 SCHEMA_FORM turn.
 
@@ -293,6 +341,12 @@ class GuidedSession:
     ``composer_meta["guided_session"]`` (see Task 3.5a implementation notes).
     The frozen dataclass equality check is the round-trip invariant test.
 
+    ``step_1_source_intent`` is a mid-Step-1 staging field.  The INSPECT_AND_CONFIRM
+    emit site writes the chosen source plugin + options + observed inspection facts
+    into it before emitting the INSPECT_AND_CONFIRM turn.  ``_advance_step_1`` reads
+    it to reconstruct the full SourceResolved and clears it in the same atomic
+    replace(); it is always None after Step 1 completes.
+
     ``step_2_sink_intent`` is a mid-Step-2 staging field.  The SCHEMA_FORM
     dispatcher writes the chosen sink plugin + options into it before emitting
     the MULTI_SELECT_WITH_CUSTOM turn.  ``_advance_step_2`` reads it to
@@ -307,6 +361,7 @@ class GuidedSession:
     step_3_proposal: ChainProposal | None
     terminal: TerminalState | None
     transition_consumed: bool = False
+    step_1_source_intent: SourceIntent | None = None
     step_2_sink_intent: SinkIntent | None = None
 
     @classmethod
@@ -334,6 +389,7 @@ class GuidedSession:
             "step_3_proposal": self.step_3_proposal.to_dict() if self.step_3_proposal is not None else None,
             "terminal": self.terminal.to_dict() if self.terminal is not None else None,
             "transition_consumed": self.transition_consumed,
+            "step_1_source_intent": self.step_1_source_intent.to_dict() if self.step_1_source_intent is not None else None,
             "step_2_sink_intent": self.step_2_sink_intent.to_dict() if self.step_2_sink_intent is not None else None,
         }
 
@@ -349,6 +405,7 @@ class GuidedSession:
             step_2_raw = d["step_2_result"]
             step_3_raw = d["step_3_proposal"]
             terminal_raw = d["terminal"]
+            source_intent_raw = d["step_1_source_intent"]
             sink_intent_raw = d["step_2_sink_intent"]
             return cls(
                 step=GuidedStep(d["step"]),
@@ -358,6 +415,7 @@ class GuidedSession:
                 step_3_proposal=ChainProposal.from_dict(step_3_raw) if step_3_raw is not None else None,
                 terminal=TerminalState.from_dict(terminal_raw) if terminal_raw is not None else None,
                 transition_consumed=d["transition_consumed"],
+                step_1_source_intent=SourceIntent.from_dict(source_intent_raw) if source_intent_raw is not None else None,
                 step_2_sink_intent=SinkIntent.from_dict(sink_intent_raw) if sink_intent_raw is not None else None,
             )
         except (KeyError, ValueError, TypeError) as exc:
@@ -471,21 +529,43 @@ def _advance_step_1(
     turn types (``SINGLE_SELECT`` for plugin selection, ``SCHEMA_FORM`` for
     options) are intra-step turns that do not advance the wizard. Those
     branches emit the next intra-step turn and are out of scope here.
+
+    The inspection state (plugin, options, samples, warnings) is held in
+    ``session.step_1_source_intent`` — set by the INSPECT_AND_CONFIRM emit site
+    before the turn is returned to the client.  The wire response carries only
+    ``edited_values = {"columns": list[str]}``, since that is the only field
+    the widget can authoritatively edit.  plugin/options/samples are recovered
+    from intent; columns come from the response.
+
+    All values from the response are Tier-3 external data and are coerced
+    (str, tuple) before being stored in the audit-tier ``SourceResolved``.
     """
     if turn_type is not TurnType.INSPECT_AND_CONFIRM:
         # Intra-step turns (plugin select, options form) — do not advance.
         # Tasks 2.2+ wire these when the full intra-step flow is added.
         return (session, None, None, [])
 
+    intent = session.step_1_source_intent
+    if intent is None:
+        raise ValueError(
+            "_advance_step_1: step_1_source_intent is None when INSPECT_AND_CONFIRM "
+            "was received — the INSPECT_AND_CONFIRM emit site must set it before "
+            "emitting the turn. This is a state-machine invariant violation."
+        )
+
     edited = response["edited_values"]
     if edited is None:
         raise ValueError("inspect_and_confirm response must carry edited_values; got None")
 
+    # columns is the only field the widget edits; it is Tier-3: coerce to tuple[str, ...].
+    columns_raw = edited["columns"]  # KeyError propagates as protocol violation
+    columns = tuple(str(c) for c in columns_raw)
+
     source = SourceResolved(
-        plugin=str(edited["plugin"]),
-        options=dict(edited["options"]),
-        observed_columns=tuple(edited["observed_columns"]),
-        sample_rows=tuple(dict(r) for r in edited["sample_rows"]),
+        plugin=intent.plugin,
+        options=dict(intent.options),
+        observed_columns=columns,
+        sample_rows=tuple(dict(r) for r in intent.sample_rows),
     )
     directives: list[GuidedAuditDirective] = [
         GuidedAuditDirective(
@@ -501,6 +581,7 @@ def _advance_step_1(
         session,
         step=GuidedStep.STEP_2_SINK,
         step_1_result=source,
+        step_1_source_intent=None,  # consumed; clear to prevent misread by later steps
     )
     return (new_sess, None, None, directives)
 

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -382,4 +382,99 @@ def _advance_step_3(
     response: TurnResponse,
     turn_type: TurnType,
 ) -> _StepAdvanceResult:
-    raise NotImplementedError("step 3 advance — implemented in Task 2.5")
+    """Handle a Step 3 (transform chain) response.
+
+    Acceptance/rejection of a chain proposal is interpreted by the endpoint
+    handler (Task 4.4), which runs preview_pipeline and commits via tools.py.
+    step_advance is pure and does not mutate state on accept; the handler does.
+
+    Two legal turn types at Step 3:
+    - PROPOSE_CHAIN: The LLM has proposed a chain. Accept/reject is decided
+      by the endpoint handler after running preview_pipeline. step_advance
+      passes through unchanged.
+    - SINGLE_SELECT: A clarifying question was answered — no step change.
+      The handler interprets the response and either re-emits propose_chain
+      or asks another question.
+
+    Any other turn type is a protocol violation — raises ValueError.
+    """
+    if turn_type is TurnType.PROPOSE_CHAIN:
+        return (session, None, None, [])
+    if turn_type is TurnType.SINGLE_SELECT:
+        # Clarifying question answered — no step change. The handler interprets
+        # the response and either re-emits propose_chain or asks another question.
+        return (session, None, None, [])
+    raise ValueError(f"unexpected turn_type at step 3: {turn_type}")
+
+
+# ---------------------------------------------------------------------------
+# Terminal-failure helpers — standalone endpoint helpers for spec §5.4
+# ---------------------------------------------------------------------------
+
+
+def mark_solver_exhausted(
+    session: GuidedSession,
+    *,
+    validation_result: Mapping[str, Any] | None,
+) -> tuple[GuidedSession, TerminalState, list[GuidedAuditDirective]]:
+    """Endpoint helper: stamp the session as solver-exhausted and emit a directive.
+
+    Called by the Step 3 endpoint handler after repair attempt + advisor
+    consultation both fail (spec §5.4). Pure function; the route handler
+    fans the directive out to emit_dropped_to_freeform.
+
+    Returns ``(new_session, terminal, directives)`` where ``directives`` is
+    a ``list[GuidedAuditDirective]`` carrying the ``guided_dropped_to_freeform``
+    event (Errata C4). The route handler maps each directive to the matching
+    ``emit_*`` helper in ``composer/guided/audit.py``.
+    """
+    directives: list[GuidedAuditDirective] = [
+        GuidedAuditDirective(
+            tool_name="guided_dropped_to_freeform",
+            arguments={
+                "prev_step": session.step.value,
+                "drop_reason": TerminalReason.SOLVER_EXHAUSTED.value,
+                "validation_result": (dict(validation_result) if validation_result is not None else None),
+            },
+        ),
+    ]
+    terminal = TerminalState(
+        kind=TerminalKind.EXITED_TO_FREEFORM,
+        reason=TerminalReason.SOLVER_EXHAUSTED,
+        pipeline_yaml=None,
+    )
+    new_sess = replace(session, terminal=terminal)
+    return (new_sess, terminal, directives)
+
+
+def mark_protocol_violation(
+    session: GuidedSession,
+) -> tuple[GuidedSession, TerminalState, list[GuidedAuditDirective]]:
+    """Endpoint helper: stamp the session as protocol-violated and emit a directive.
+
+    Called by the route handler after the LLM emits an illegal turn type
+    twice in a row (spec §5.4). ``validation_result`` is ``None`` — the
+    violation is at the turn-type level, not the schema level.
+
+    Returns ``(new_session, terminal, directives)`` where ``directives`` is
+    a ``list[GuidedAuditDirective]`` carrying the ``guided_dropped_to_freeform``
+    event (Errata C4). The route handler maps each directive to the matching
+    ``emit_*`` helper in ``composer/guided/audit.py``.
+    """
+    directives: list[GuidedAuditDirective] = [
+        GuidedAuditDirective(
+            tool_name="guided_dropped_to_freeform",
+            arguments={
+                "prev_step": session.step.value,
+                "drop_reason": TerminalReason.PROTOCOL_VIOLATION.value,
+                "validation_result": None,
+            },
+        ),
+    ]
+    terminal = TerminalState(
+        kind=TerminalKind.EXITED_TO_FREEFORM,
+        reason=TerminalReason.PROTOCOL_VIOLATION,
+        pipeline_yaml=None,
+    )
+    new_sess = replace(session, terminal=terminal)
+    return (new_sess, terminal, directives)

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -1,9 +1,10 @@
-"""Guided-mode state machine: audit-tier (Tier 1) dataclasses.
+"""Guided-mode state-machine data: GuidedSession, TerminalState, TurnRecord.
 
-Frozen dataclasses representing session state at the SDA wizard boundary.
-Every field is immutable. Container fields undergo deep-freeze in __post_init__.
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §5.
 
-See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §3.
+Trust tier: Tier 1 (audit). Coercion forbidden — every field crashes on
+malformed input. The freeze_fields contract applies because these structures
+are persisted and re-read across the audit trail.
 """
 
 from __future__ import annotations
@@ -14,48 +15,43 @@ from enum import StrEnum
 from typing import Any
 
 from elspeth.contracts.freeze import freeze_fields
-from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
 
 
 class TerminalKind(StrEnum):
-    """The outcome classification when a guided session ends."""
-
     COMPLETED = "completed"
     EXITED_TO_FREEFORM = "exited_to_freeform"
-    FAILED = "failed"
 
 
 class TerminalReason(StrEnum):
-    """The reason a guided session ended."""
-
-    USER_CHOSE_FREEFORM = "user_chose_freeform"
-    USER_REJECTED_PROPOSAL = "user_rejected_proposal"
-    RECIPE_NOT_FOUND = "recipe_not_found"
-    SOLVER_ERROR = "solver_error"
-    STEP_HANDLER_ERROR = "step_handler_error"
+    USER_PRESSED_EXIT = "user_pressed_exit"
+    PROTOCOL_VIOLATION = "protocol_violation"
+    SOLVER_EXHAUSTED = "solver_exhausted"
 
 
 @dataclass(frozen=True, slots=True)
 class TerminalState:
-    """Marks the end of a guided session.
+    """Outcome of a guided session.
 
-    Frozen, audit-tier. Persisted in GuidedSession.terminal.
+    `reason` is None when `kind == COMPLETED`; required when
+    `kind == EXITED_TO_FREEFORM`. `pipeline_yaml` is set only on COMPLETED.
+    Callers must construct consistently — invariants enforced by step_advance().
     """
 
     kind: TerminalKind
     reason: TerminalReason | None
+    pipeline_yaml: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class TurnRecord:
-    """A single turn in the guided-mode dialog.
+    """One emitted turn + its (optional) user response, recorded for audit."""
 
-    Frozen, audit-tier. Appended to GuidedSession.history.
-    Carries both the wizard turn (what was emitted) and the user's response.
-    """
-
-    turn: Turn
-    response: TurnResponse
+    step: GuidedStep
+    turn_type: TurnType
+    payload_hash: str
+    response_hash: str | None
+    emitter: str  # "server" | "llm"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -531,11 +531,11 @@ def _advance_step_1(
     options) are intra-step turns that do not advance the wizard. Those
     branches emit the next intra-step turn and are out of scope here.
 
-    The inspection state (plugin, options, samples, warnings) is held in
+    The inspection state (plugin, options, sample_rows) is held in
     ``session.step_1_source_intent`` — set by the INSPECT_AND_CONFIRM emit site
     before the turn is returned to the client.  The wire response carries only
     ``edited_values = {"columns": list[str]}``, since that is the only field
-    the widget can authoritatively edit.  plugin/options/samples are recovered
+    the widget can authoritatively edit.  plugin/options/sample_rows are recovered
     from intent; columns come from the response.
 
     All values from the response are Tier-3 external data and are coerced

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -5,6 +5,14 @@ See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §5.
 Trust tier: Tier 1 (audit). Coercion forbidden — every field crashes on
 malformed input. The freeze_fields contract applies because these structures
 are persisted and re-read across the audit trail.
+
+Serialisation:
+  Each type exposes ``to_dict()`` → plain JSON-serialisable dict and a
+  corresponding ``from_dict(d)`` classmethod.  ``from_dict`` is Tier 1
+  strict: it uses direct key access (never ``.get()``), constructs enums
+  directly (ValueError on unknown value), and chains exceptions via
+  ``from exc``.  The round-trip invariant holds for all types:
+      obj == type.from_dict(obj.to_dict())
 """
 
 from __future__ import annotations
@@ -14,7 +22,7 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
 
-from elspeth.contracts.freeze import freeze_fields
+from elspeth.contracts.freeze import deep_thaw, freeze_fields
 from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse, TurnType
 
 
@@ -42,6 +50,26 @@ class TerminalState:
     reason: TerminalReason | None
     pipeline_yaml: str | None
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "kind": self.kind.value,
+            "reason": self.reason.value if self.reason is not None else None,
+            "pipeline_yaml": self.pipeline_yaml,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TerminalState:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                kind=TerminalKind(d["kind"]),
+                reason=TerminalReason(d["reason"]) if d["reason"] is not None else None,
+                pipeline_yaml=d["pipeline_yaml"],
+            )
+        except (KeyError, ValueError) as exc:
+            raise ValueError(f"TerminalState.from_dict: malformed record {d!r}") from exc
+
 
 @dataclass(frozen=True, slots=True)
 class TurnRecord:
@@ -52,6 +80,30 @@ class TurnRecord:
     payload_hash: str
     response_hash: str | None
     emitter: str  # "server" | "llm"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "step": self.step.value,
+            "turn_type": self.turn_type.value,
+            "payload_hash": self.payload_hash,
+            "response_hash": self.response_hash,
+            "emitter": self.emitter,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TurnRecord:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                step=GuidedStep(d["step"]),
+                turn_type=TurnType(d["turn_type"]),
+                payload_hash=d["payload_hash"],
+                response_hash=d["response_hash"],
+                emitter=d["emitter"],
+            )
+        except (KeyError, ValueError) as exc:
+            raise ValueError(f"TurnRecord.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +121,28 @@ class SourceResolved:
     def __post_init__(self) -> None:
         freeze_fields(self, "options", "observed_columns", "sample_rows")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "plugin": self.plugin,
+            "options": deep_thaw(self.options),
+            "observed_columns": list(deep_thaw(self.observed_columns)),
+            "sample_rows": [dict(deep_thaw(r)) for r in self.sample_rows],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SourceResolved:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                plugin=d["plugin"],
+                options=d["options"],
+                observed_columns=tuple(d["observed_columns"]),
+                sample_rows=tuple(dict(r) for r in d["sample_rows"]),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"SourceResolved.from_dict: malformed record {d!r}") from exc
+
 
 @dataclass(frozen=True, slots=True)
 class SinkOutputResolved:
@@ -85,6 +159,28 @@ class SinkOutputResolved:
     def __post_init__(self) -> None:
         freeze_fields(self, "options", "required_fields")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "plugin": self.plugin,
+            "options": deep_thaw(self.options),
+            "required_fields": list(deep_thaw(self.required_fields)),
+            "schema_mode": self.schema_mode,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SinkOutputResolved:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                plugin=d["plugin"],
+                options=d["options"],
+                required_fields=tuple(d["required_fields"]),
+                schema_mode=d["schema_mode"],
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"SinkOutputResolved.from_dict: malformed record {d!r}") from exc
+
 
 @dataclass(frozen=True, slots=True)
 class SinkResolved:
@@ -97,6 +193,18 @@ class SinkResolved:
 
     def __post_init__(self) -> None:
         freeze_fields(self, "outputs")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {"outputs": [o.to_dict() for o in self.outputs]}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SinkResolved:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(outputs=tuple(SinkOutputResolved.from_dict(o) for o in d["outputs"]))
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"SinkResolved.from_dict: malformed record {d!r}") from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,6 +220,24 @@ class ChainProposal:
     def __post_init__(self) -> None:
         freeze_fields(self, "steps")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict."""
+        return {
+            "steps": [dict(deep_thaw(s)) for s in self.steps],
+            "why": self.why,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ChainProposal:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data."""
+        try:
+            return cls(
+                steps=tuple(dict(s) for s in d["steps"]),
+                why=d["why"],
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"ChainProposal.from_dict: malformed record {d!r}") from exc
+
 
 @dataclass(frozen=True, slots=True)
 class GuidedSession:
@@ -120,6 +246,10 @@ class GuidedSession:
     Persisted in CompositionState.guided_session. `terminal` becomes non-None
     when the wizard ends; subsequent freeform turns honour progressive
     disclosure (see §8.2 of the spec).
+
+    Serialisation: use ``to_dict()`` / ``from_dict()`` for persistence via
+    ``composer_meta["guided_session"]`` (see Task 3.5a implementation notes).
+    The frozen dataclass equality check is the round-trip invariant test.
     """
 
     step: GuidedStep
@@ -139,6 +269,44 @@ class GuidedSession:
             step_3_proposal=None,
             terminal=None,
         )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-serialisable dict.
+
+        All nested optional types serialise their presence — ``None`` round-
+        trips as ``None`` (never fabricated).
+        """
+        return {
+            "step": self.step.value,
+            "history": [r.to_dict() for r in self.history],
+            "step_1_result": self.step_1_result.to_dict() if self.step_1_result is not None else None,
+            "step_2_result": self.step_2_result.to_dict() if self.step_2_result is not None else None,
+            "step_3_proposal": self.step_3_proposal.to_dict() if self.step_3_proposal is not None else None,
+            "terminal": self.terminal.to_dict() if self.terminal is not None else None,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> GuidedSession:
+        """Reconstruct from a plain dict.  Tier 1 strict — crashes on bad data.
+
+        Used when restoring state from ``composer_meta["guided_session"]``.
+        KeyError, ValueError, and TypeError all indicate Tier 1 corruption.
+        """
+        try:
+            step_1_raw = d["step_1_result"]
+            step_2_raw = d["step_2_result"]
+            step_3_raw = d["step_3_proposal"]
+            terminal_raw = d["terminal"]
+            return cls(
+                step=GuidedStep(d["step"]),
+                history=tuple(TurnRecord.from_dict(r) for r in d["history"]),
+                step_1_result=SourceResolved.from_dict(step_1_raw) if step_1_raw is not None else None,
+                step_2_result=SinkResolved.from_dict(step_2_raw) if step_2_raw is not None else None,
+                step_3_proposal=ChainProposal.from_dict(step_3_raw) if step_3_raw is not None else None,
+                terminal=TerminalState.from_dict(terminal_raw) if terminal_raw is not None else None,
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"GuidedSession.from_dict: malformed record {d!r}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -20,11 +20,19 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from elspeth.contracts.freeze import deep_thaw, freeze_fields
 from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse, TurnType
+
+if TYPE_CHECKING:
+    # Imported for type annotations only — avoids a circular dependency.
+    # recipe_match.py imports state_machine.py (SourceResolved, SinkResolved);
+    # a runtime import of RecipeMatch here would create a cycle.
+    # RecipeMatch is a frozen dataclass; no freeze_fields needed on GuidedSession
+    # for this field — frozen dataclass instances are already immutable.
+    from elspeth.web.composer.guided.recipe_match import RecipeMatch
 
 
 class TerminalKind(StrEnum):
@@ -353,6 +361,16 @@ class GuidedSession:
     the MULTI_SELECT_WITH_CUSTOM turn.  ``_advance_step_2`` reads it to
     reconstruct the full SinkOutputResolved and clears it in the same atomic
     replace(); it is always None after Step 2 completes.
+
+    ``step_2_5_recipe_offer`` is a mid-Step-2.5 staging field.  The Step 2.5
+    dispatcher writes the emitted ``RecipeMatch`` into it immediately before
+    emitting the RECIPE_OFFER turn.  The recipe-accept branch in the dispatcher
+    reads it to verify that the client-supplied ``recipe_name`` matches the
+    recipe that was actually offered — binding the acceptance to the server-emitted
+    offer and preventing a crafted client from accepting a different recipe.  The
+    field is cleared (set to None) in the same atomic replace() that consumes it
+    (the terminal=COMPLETED path).  It is always None when the session is not at
+    STEP_2_5_RECIPE_MATCH.
     """
 
     step: GuidedStep
@@ -364,6 +382,7 @@ class GuidedSession:
     transition_consumed: bool = False
     step_1_source_intent: SourceIntent | None = None
     step_2_sink_intent: SinkIntent | None = None
+    step_2_5_recipe_offer: RecipeMatch | None = None
 
     @classmethod
     def initial(cls) -> GuidedSession:
@@ -392,6 +411,7 @@ class GuidedSession:
             "transition_consumed": self.transition_consumed,
             "step_1_source_intent": self.step_1_source_intent.to_dict() if self.step_1_source_intent is not None else None,
             "step_2_sink_intent": self.step_2_sink_intent.to_dict() if self.step_2_sink_intent is not None else None,
+            "step_2_5_recipe_offer": self.step_2_5_recipe_offer.to_dict() if self.step_2_5_recipe_offer is not None else None,
         }
 
     @classmethod
@@ -408,6 +428,12 @@ class GuidedSession:
             terminal_raw = d["terminal"]
             source_intent_raw = d["step_1_source_intent"]
             sink_intent_raw = d["step_2_sink_intent"]
+            recipe_offer_raw = d["step_2_5_recipe_offer"]
+            # Deferred import to avoid a circular dependency at module level.
+            # recipe_match.py imports from state_machine.py; importing RecipeMatch
+            # at module level here would create a cycle.
+            from elspeth.web.composer.guided.recipe_match import RecipeMatch as _RecipeMatch
+
             return cls(
                 step=GuidedStep(d["step"]),
                 history=tuple(TurnRecord.from_dict(r) for r in d["history"]),
@@ -418,6 +444,7 @@ class GuidedSession:
                 transition_consumed=d["transition_consumed"],
                 step_1_source_intent=SourceIntent.from_dict(source_intent_raw) if source_intent_raw is not None else None,
                 step_2_sink_intent=SinkIntent.from_dict(sink_intent_raw) if sink_intent_raw is not None else None,
+                step_2_5_recipe_offer=_RecipeMatch.from_dict(recipe_offer_raw) if recipe_offer_raw is not None else None,
             )
         except (KeyError, ValueError, TypeError) as exc:
             raise InvariantError(f"GuidedSession.from_dict: malformed record {d!r}") from exc

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -287,7 +287,48 @@ def _advance_step_2(
     response: TurnResponse,
     turn_type: TurnType,
 ) -> _StepAdvanceResult:
-    raise NotImplementedError("step 2 advance — implemented in Task 2.2")
+    """Handle a Step 2 (sink) response.
+
+    Only ``MULTI_SELECT_WITH_CUSTOM`` causes a step transition; all other Step 2
+    turn types are intra-step turns that do not advance the wizard.
+
+    The ``edited_values["outputs"]`` list is Tier-3 external data: each field
+    is coerced at this boundary (``str``, ``dict``, ``tuple``, ``str``) before
+    being stored in the audit-tier ``SinkOutputResolved`` dataclass.
+    """
+    if turn_type is not TurnType.MULTI_SELECT_WITH_CUSTOM:
+        return (session, None, None, [])
+
+    edited = response["edited_values"]
+    if edited is None:
+        raise ValueError("multi_select_with_custom response must carry edited_values")
+    raw_outputs = edited["outputs"]
+    outputs = tuple(
+        SinkOutputResolved(
+            plugin=str(o["plugin"]),
+            options=dict(o["options"]),
+            required_fields=tuple(o["required_fields"]),
+            schema_mode=str(o["schema_mode"]),
+        )
+        for o in raw_outputs
+    )
+    sink = SinkResolved(outputs=outputs)
+    directives = [
+        GuidedAuditDirective(
+            tool_name="guided_step_advanced",
+            arguments={
+                "prev_step": GuidedStep.STEP_2_SINK.value,
+                "next_step": GuidedStep.STEP_2_5_RECIPE_MATCH.value,
+                "reason": "user_advanced",
+            },
+        ),
+    ]
+    new_sess = replace(
+        session,
+        step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+        step_2_result=sink,
+    )
+    return (new_sess, None, None, directives)
 
 
 def _advance_step_2_5(

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -258,6 +258,7 @@ class GuidedSession:
     step_2_result: SinkResolved | None
     step_3_proposal: ChainProposal | None
     terminal: TerminalState | None
+    transition_consumed: bool = False
 
     @classmethod
     def initial(cls) -> GuidedSession:
@@ -283,6 +284,7 @@ class GuidedSession:
             "step_2_result": self.step_2_result.to_dict() if self.step_2_result is not None else None,
             "step_3_proposal": self.step_3_proposal.to_dict() if self.step_3_proposal is not None else None,
             "terminal": self.terminal.to_dict() if self.terminal is not None else None,
+            "transition_consumed": self.transition_consumed,
         }
 
     @classmethod
@@ -304,6 +306,7 @@ class GuidedSession:
                 step_2_result=SinkResolved.from_dict(step_2_raw) if step_2_raw is not None else None,
                 step_3_proposal=ChainProposal.from_dict(step_3_raw) if step_3_raw is not None else None,
                 terminal=TerminalState.from_dict(terminal_raw) if terminal_raw is not None else None,
+                transition_consumed=d["transition_consumed"],
             )
         except (KeyError, ValueError, TypeError) as exc:
             raise ValueError(f"GuidedSession.from_dict: malformed record {d!r}") from exc

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -371,6 +371,18 @@ class GuidedSession:
     field is cleared (set to None) in the same atomic replace() that consumes it
     (the terminal=COMPLETED path).  It is always None when the session is not at
     STEP_2_5_RECIPE_MATCH.
+
+    ``step_2_chosen_plugin`` is a mid-Step-2 staging field.  The Step-2
+    SINGLE_SELECT dispatcher writes the chosen sink plugin name into it
+    immediately before emitting the SCHEMA_FORM turn.  The SCHEMA_FORM
+    dispatcher reads it when rebuilding the SCHEMA_FORM on GET /guided —
+    the chosen plugin is needed to retrieve the correct schema from the
+    catalog.  It is cleared (set to None) in the same atomic replace()
+    that sets ``step_2_sink_intent`` (i.e. when the SCHEMA_FORM response
+    arrives and the MULTI_SELECT_WITH_CUSTOM turn is about to be emitted);
+    it cannot be non-None at the same time as ``step_2_sink_intent``.
+    It is always None outside the SINGLE_SELECT→SCHEMA_FORM intra-step
+    window at STEP_2_SINK.
     """
 
     step: GuidedStep
@@ -383,6 +395,7 @@ class GuidedSession:
     step_1_source_intent: SourceIntent | None = None
     step_2_sink_intent: SinkIntent | None = None
     step_2_5_recipe_offer: RecipeMatch | None = None
+    step_2_chosen_plugin: str | None = None
 
     @classmethod
     def initial(cls) -> GuidedSession:
@@ -412,6 +425,7 @@ class GuidedSession:
             "step_1_source_intent": self.step_1_source_intent.to_dict() if self.step_1_source_intent is not None else None,
             "step_2_sink_intent": self.step_2_sink_intent.to_dict() if self.step_2_sink_intent is not None else None,
             "step_2_5_recipe_offer": self.step_2_5_recipe_offer.to_dict() if self.step_2_5_recipe_offer is not None else None,
+            "step_2_chosen_plugin": self.step_2_chosen_plugin,
         }
 
     @classmethod
@@ -429,6 +443,7 @@ class GuidedSession:
             source_intent_raw = d["step_1_source_intent"]
             sink_intent_raw = d["step_2_sink_intent"]
             recipe_offer_raw = d["step_2_5_recipe_offer"]
+            step_2_chosen_plugin_raw = d["step_2_chosen_plugin"]
             # Deferred import to avoid a circular dependency at module level.
             # recipe_match.py imports from state_machine.py; importing RecipeMatch
             # at module level here would create a cycle.
@@ -445,6 +460,7 @@ class GuidedSession:
                 step_1_source_intent=SourceIntent.from_dict(source_intent_raw) if source_intent_raw is not None else None,
                 step_2_sink_intent=SinkIntent.from_dict(sink_intent_raw) if sink_intent_raw is not None else None,
                 step_2_5_recipe_offer=_RecipeMatch.from_dict(recipe_offer_raw) if recipe_offer_raw is not None else None,
+                step_2_chosen_plugin=str(step_2_chosen_plugin_raw) if step_2_chosen_plugin_raw is not None else None,
             )
         except (KeyError, ValueError, TypeError) as exc:
             raise InvariantError(f"GuidedSession.from_dict: malformed record {d!r}") from exc

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -10,12 +10,12 @@ are persisted and re-read across the audit trail.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
 
 from elspeth.contracts.freeze import freeze_fields
-from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
+from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse, TurnType
 
 
 class TerminalKind(StrEnum):
@@ -139,3 +139,168 @@ class GuidedSession:
             step_3_proposal=None,
             terminal=None,
         )
+
+
+# ---------------------------------------------------------------------------
+# GuidedAuditDirective — L3-internal coordination type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GuidedAuditDirective:
+    """Pure-function directive: "fire this guided audit event."
+
+    ``step_advance()`` is pure (no uuid, no clock, no recorder), so it
+    cannot construct ``ComposerToolInvocation`` records directly — those
+    need a tool_call_id, timestamps, version snapshot, and operator
+    actor that only the route handler has. Instead, step_advance returns
+    a list of directives; the route handler (Phase 3) maps each
+    directive's ``tool_name`` to the corresponding ``emit_*`` helper in
+    ``composer/guided/audit.py`` and calls it with the live recorder,
+    composition version, and actor.
+
+    Per Errata C4: no new audit primitive at L0. ``GuidedAuditDirective``
+    is L3-internal coordination only. The on-the-wire record is still
+    ``ComposerToolInvocation``.
+
+    Allowed ``tool_name`` values (closed list):
+    - ``guided_turn_emitted``
+    - ``guided_turn_answered``
+    - ``guided_step_advanced``
+    - ``guided_dropped_to_freeform``
+
+    ``arguments`` is a payload dict; the Phase 3 route handler will
+    translate it into the matching ``emit_*`` keyword arguments.
+    """
+
+    tool_name: str  # one of: guided_turn_emitted, guided_turn_answered,
+    #                          guided_step_advanced, guided_dropped_to_freeform
+    arguments: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "arguments")
+
+
+# ---------------------------------------------------------------------------
+# step_advance — pure function, no I/O, no clock, no uuid
+# ---------------------------------------------------------------------------
+
+_StepAdvanceResult = tuple[GuidedSession, Turn | None, TerminalState | None, list[GuidedAuditDirective]]
+
+
+def step_advance(
+    session: GuidedSession,
+    response: TurnResponse,
+    *,
+    current_turn_type: TurnType,
+) -> _StepAdvanceResult:
+    """Apply *response* to *session*. Pure function (no I/O, no clock, no uuid).
+
+    Returns ``(new_session, next_turn_or_None, terminal_or_None, directives)``.
+    The caller (route handler) emits each directive via the matching
+    ``emit_*`` helper in ``composer.guided.audit``.
+
+    Per spec §5.3:
+    - A ``control_signal`` of ``"exit_to_freeform"`` terminates the wizard with
+      ``TerminalKind.EXITED_TO_FREEFORM / TerminalReason.USER_PRESSED_EXIT``
+      and produces a ``guided_dropped_to_freeform`` directive.
+    - Otherwise, the current ``session.step`` selects the branch handler.
+    """
+    directives: list[GuidedAuditDirective] = []
+
+    if response["control_signal"] == "exit_to_freeform":
+        directives.append(
+            GuidedAuditDirective(
+                tool_name="guided_dropped_to_freeform",
+                arguments={
+                    "prev_step": session.step.value,
+                    "drop_reason": TerminalReason.USER_PRESSED_EXIT.value,
+                    "validation_result": None,
+                },
+            )
+        )
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
+        )
+        return (replace(session, terminal=terminal), None, terminal, directives)
+
+    if session.step is GuidedStep.STEP_1_SOURCE:
+        return _advance_step_1(session, response, current_turn_type)
+    if session.step is GuidedStep.STEP_2_SINK:
+        return _advance_step_2(session, response, current_turn_type)
+    if session.step is GuidedStep.STEP_2_5_RECIPE_MATCH:
+        return _advance_step_2_5(session, response, current_turn_type)
+    if session.step is GuidedStep.STEP_3_TRANSFORMS:
+        return _advance_step_3(session, response, current_turn_type)
+    raise AssertionError(f"unhandled step: {session.step}")
+
+
+def _advance_step_1(
+    session: GuidedSession,
+    response: TurnResponse,
+    turn_type: TurnType,
+) -> _StepAdvanceResult:
+    """Handle a Step 1 (source) response.
+
+    Only ``INSPECT_AND_CONFIRM`` causes a step transition; all other Step 1
+    turn types (``SINGLE_SELECT`` for plugin selection, ``SCHEMA_FORM`` for
+    options) are intra-step turns that do not advance the wizard. Those
+    branches emit the next intra-step turn and are out of scope here.
+    """
+    if turn_type is not TurnType.INSPECT_AND_CONFIRM:
+        # Intra-step turns (plugin select, options form) — do not advance.
+        # Tasks 2.2+ wire these when the full intra-step flow is added.
+        return (session, None, None, [])
+
+    edited = response["edited_values"]
+    if edited is None:
+        raise ValueError("inspect_and_confirm response must carry edited_values; got None")
+
+    source = SourceResolved(
+        plugin=str(edited["plugin"]),
+        options=dict(edited["options"]),
+        observed_columns=tuple(edited["observed_columns"]),
+        sample_rows=tuple(dict(r) for r in edited["sample_rows"]),
+    )
+    directives: list[GuidedAuditDirective] = [
+        GuidedAuditDirective(
+            tool_name="guided_step_advanced",
+            arguments={
+                "prev_step": GuidedStep.STEP_1_SOURCE.value,
+                "next_step": GuidedStep.STEP_2_SINK.value,
+                "reason": "user_advanced",
+            },
+        ),
+    ]
+    new_sess = replace(
+        session,
+        step=GuidedStep.STEP_2_SINK,
+        step_1_result=source,
+    )
+    return (new_sess, None, None, directives)
+
+
+def _advance_step_2(
+    session: GuidedSession,
+    response: TurnResponse,
+    turn_type: TurnType,
+) -> _StepAdvanceResult:
+    raise NotImplementedError("step 2 advance — implemented in Task 2.2")
+
+
+def _advance_step_2_5(
+    session: GuidedSession,
+    response: TurnResponse,
+    turn_type: TurnType,
+) -> _StepAdvanceResult:
+    raise NotImplementedError("step 2.5 advance — implemented in Task 2.4")
+
+
+def _advance_step_3(
+    session: GuidedSession,
+    response: TurnResponse,
+    turn_type: TurnType,
+) -> _StepAdvanceResult:
+    raise NotImplementedError("step 3 advance — implemented in Task 2.5")

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -719,7 +719,10 @@ def _advance_step_3(
       The handler interprets the response and either re-emits propose_chain
       or asks another question.
 
-    Any other turn type is a protocol violation — raises ValueError.
+    Any other turn type is a server-side invariant violation: Step 3 only ever
+    emits PROPOSE_CHAIN or SINGLE_SELECT turns, so a different turn type in
+    ``current_turn_type`` means the emitter stamped an invalid type on the
+    history record — raises InvariantError (server bug, not client fault).
     """
     if turn_type is TurnType.PROPOSE_CHAIN:
         return (session, None, None, [])
@@ -727,7 +730,11 @@ def _advance_step_3(
         # Clarifying question answered — no step change. The handler interprets
         # the response and either re-emits propose_chain or asks another question.
         return (session, None, None, [])
-    raise ValueError(f"unexpected turn_type at step 3: {turn_type}")
+    raise InvariantError(
+        f"_advance_step_3: unexpected turn_type {turn_type!r} — Step 3 only "
+        "emits PROPOSE_CHAIN and SINGLE_SELECT turns; any other type in the "
+        "history record indicates a server-side emitter bug."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -559,7 +559,7 @@ def step_advance(
         return _advance_step_2_5(session, response, current_turn_type)
     if session.step is GuidedStep.STEP_3_TRANSFORMS:
         return _advance_step_3(session, response, current_turn_type)
-    raise AssertionError(f"unhandled step: {session.step}")
+    raise InvariantError(f"unhandled step: {session.step}")
 
 
 def _advance_step_1(

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -336,7 +336,45 @@ def _advance_step_2_5(
     response: TurnResponse,
     turn_type: TurnType,
 ) -> _StepAdvanceResult:
-    raise NotImplementedError("step 2.5 advance — implemented in Task 2.4")
+    """Handle a Step 2.5 (recipe match) response.
+
+    Two valid paths:
+    - chosen == ["accept"]: the session stays at STEP_2_5 with no directive.
+      The endpoint handler (Task 3.3 / Errata C2) detects response["chosen"] ==
+      ["accept"] and invokes ``_execute_apply_pipeline_recipe`` to commit the
+      recipe and produce a COMPLETED terminal. step_advance is pure and does not
+      run apply_recipe; emitting emit_turn_answered is the handler's
+      responsibility.
+    - chosen == ["build_manually"]: advance to STEP_3_TRANSFORMS with a
+      ``guided_step_advanced`` directive.
+
+    Any other chosen value is a protocol violation — raises ValueError.
+    Non-RECIPE_OFFER turn types are intra-step turns; no advance.
+    """
+    if turn_type is not TurnType.RECIPE_OFFER:
+        return (session, None, None, [])
+
+    chosen = response["chosen"] or []
+    if list(chosen) == ["accept"]:
+        # Endpoint handler reads response["chosen"] == ["accept"] and runs
+        # apply_recipe (Errata C2). step_advance leaves the session at
+        # STEP_2_5 unchanged; the handler advances to terminal=COMPLETED after
+        # committing. No directive here — the handler emits emit_turn_answered.
+        return (session, None, None, [])
+    if list(chosen) == ["build_manually"]:
+        directives = [
+            GuidedAuditDirective(
+                tool_name="guided_step_advanced",
+                arguments={
+                    "prev_step": GuidedStep.STEP_2_5_RECIPE_MATCH.value,
+                    "next_step": GuidedStep.STEP_3_TRANSFORMS.value,
+                    "reason": "user_advanced",
+                },
+            ),
+        ]
+        new_sess = replace(session, step=GuidedStep.STEP_3_TRANSFORMS)
+        return (new_sess, None, None, directives)
+    raise ValueError(f"unexpected chosen for recipe_offer: {chosen!r}")
 
 
 def _advance_step_3(

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from elspeth.contracts.freeze import deep_thaw, freeze_fields
 from elspeth.web.composer.guided.errors import InvariantError
-from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse, TurnType
+from elspeth.web.composer.guided.protocol import ControlSignal, GuidedStep, Turn, TurnResponse, TurnType
 
 if TYPE_CHECKING:
     # Imported for type annotations only — avoids a circular dependency.
@@ -526,14 +526,14 @@ def step_advance(
     ``emit_*`` helper in ``composer.guided.audit``.
 
     Per spec §5.3:
-    - A ``control_signal`` of ``"exit_to_freeform"`` terminates the wizard with
+    - A ``control_signal`` of ``ControlSignal.EXIT_TO_FREEFORM`` terminates the wizard with
       ``TerminalKind.EXITED_TO_FREEFORM / TerminalReason.USER_PRESSED_EXIT``
       and produces a ``guided_dropped_to_freeform`` directive.
     - Otherwise, the current ``session.step`` selects the branch handler.
     """
     directives: list[GuidedAuditDirective] = []
 
-    if response["control_signal"] == "exit_to_freeform":
+    if response["control_signal"] is ControlSignal.EXIT_TO_FREEFORM:
         directives.append(
             GuidedAuditDirective(
                 tool_name="guided_dropped_to_freeform",

--- a/src/elspeth/web/composer/guided/state_machine.py
+++ b/src/elspeth/web/composer/guided/state_machine.py
@@ -1,0 +1,145 @@
+"""Guided-mode state machine: audit-tier (Tier 1) dataclasses.
+
+Frozen dataclasses representing session state at the SDA wizard boundary.
+Every field is immutable. Container fields undergo deep-freeze in __post_init__.
+
+See docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md §3.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from elspeth.contracts.freeze import freeze_fields
+from elspeth.web.composer.guided.protocol import GuidedStep, Turn, TurnResponse
+
+
+class TerminalKind(StrEnum):
+    """The outcome classification when a guided session ends."""
+
+    COMPLETED = "completed"
+    EXITED_TO_FREEFORM = "exited_to_freeform"
+    FAILED = "failed"
+
+
+class TerminalReason(StrEnum):
+    """The reason a guided session ended."""
+
+    USER_CHOSE_FREEFORM = "user_chose_freeform"
+    USER_REJECTED_PROPOSAL = "user_rejected_proposal"
+    RECIPE_NOT_FOUND = "recipe_not_found"
+    SOLVER_ERROR = "solver_error"
+    STEP_HANDLER_ERROR = "step_handler_error"
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalState:
+    """Marks the end of a guided session.
+
+    Frozen, audit-tier. Persisted in GuidedSession.terminal.
+    """
+
+    kind: TerminalKind
+    reason: TerminalReason | None
+
+
+@dataclass(frozen=True, slots=True)
+class TurnRecord:
+    """A single turn in the guided-mode dialog.
+
+    Frozen, audit-tier. Appended to GuidedSession.history.
+    Carries both the wizard turn (what was emitted) and the user's response.
+    """
+
+    turn: Turn
+    response: TurnResponse
+
+
+@dataclass(frozen=True, slots=True)
+class SourceResolved:
+    """Source plugin state after Step 1.
+
+    Frozen, audit-tier. Stored in GuidedSession.step_1_result.
+    """
+
+    plugin: str
+    options: Mapping[str, Any]
+    observed_columns: Sequence[str]
+    sample_rows: Sequence[Mapping[str, Any]]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "options", "observed_columns", "sample_rows")
+
+
+@dataclass(frozen=True, slots=True)
+class SinkOutputResolved:
+    """A single sink output after Step 2.
+
+    Frozen, audit-tier. Part of SinkResolved.outputs sequence.
+    """
+
+    plugin: str
+    options: Mapping[str, Any]
+    required_fields: Sequence[str]
+    schema_mode: str  # "fixed" | "flexible" | "observed"
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "options", "required_fields")
+
+
+@dataclass(frozen=True, slots=True)
+class SinkResolved:
+    """Sink configuration after Step 2.
+
+    Frozen, audit-tier. Stored in GuidedSession.step_2_result.
+    """
+
+    outputs: Sequence[SinkOutputResolved]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "outputs")
+
+
+@dataclass(frozen=True, slots=True)
+class ChainProposal:
+    """A transform chain proposed by Step 3 LLM.
+
+    Frozen, audit-tier. Stored in GuidedSession.step_3_proposal.
+    """
+
+    steps: Sequence[Mapping[str, Any]]  # each step: {plugin, options, rationale}
+    why: str
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "steps")
+
+
+@dataclass(frozen=True, slots=True)
+class GuidedSession:
+    """The guided-mode session state.
+
+    Persisted in CompositionState.guided_session. `terminal` becomes non-None
+    when the wizard ends; subsequent freeform turns honour progressive
+    disclosure (see §8.2 of the spec).
+    """
+
+    step: GuidedStep
+    history: tuple[TurnRecord, ...]
+    step_1_result: SourceResolved | None
+    step_2_result: SinkResolved | None
+    step_3_proposal: ChainProposal | None
+    terminal: TerminalState | None
+
+    @classmethod
+    def initial(cls) -> GuidedSession:
+        return cls(
+            step=GuidedStep.STEP_1_SOURCE,
+            history=(),
+            step_1_result=None,
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+        )

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -35,6 +35,7 @@ from elspeth.web.composer.tools import (
     _execute_set_output,
     _execute_set_pipeline,
     _execute_set_source,
+    _sync_get_blob_by_storage_path,
 )
 from elspeth.web.composer.yaml_generator import generate_yaml
 
@@ -65,6 +66,8 @@ def handle_step_1_source(
     resolved: SourceResolved,
     catalog: CatalogService,
     data_dir: str | None = None,
+    session_engine: Engine | None = None,
+    session_id: str | None = None,
 ) -> StepHandlerResult:
     """Commit *resolved* as the pipeline source via _execute_set_source.
 
@@ -79,6 +82,25 @@ def handle_step_1_source(
 
     The session step pointer is NOT advanced here — that is the
     dispatcher's (route handler's) responsibility in Task 3.4.
+
+    blob_ref enrichment
+    ~~~~~~~~~~~~~~~~~~~
+    If the source options contain a ``path`` key and ``session_engine`` /
+    ``session_id`` are provided, we look up the blob by storage_path.  When
+    a blob row is found the blob UUID is injected as ``blob_ref`` into the
+    stored ``step_1_result.options`` (the ``SourceResolved`` snapshot).
+
+    This lets the recipe slot resolvers in ``recipe_match.py`` read
+    ``source.options["blob_ref"]`` even when the operator supplied the path
+    via the guided SchemaForm rather than the ``set_source_from_blob`` tool.
+    The lookup is authoritative (DB query) rather than path-parsing, so it
+    cannot be fooled by paths that coincidentally look like blob paths but
+    aren't registered blobs.
+
+    If no matching blob is found (path-only source, not blob-backed), the
+    enrichment is silently skipped — recipe matching will not populate
+    ``source_blob_id`` and the recipe offer is omitted, which is the correct
+    behavior for non-blob sources.
     """
     args = {
         "plugin": resolved.plugin,
@@ -96,9 +118,25 @@ def handle_step_1_source(
             tool_result=tool_result,
         )
 
+    # Attempt to enrich step_1_result with blob_ref when the source path
+    # points to an uploaded blob.  This is the authoritative lookup —
+    # we query by storage_path rather than parsing the filename.
+    enriched_resolved = resolved
+    source_path = resolved.options.get("path")
+    if source_path is not None and session_engine is not None and session_id is not None:
+        blob = _sync_get_blob_by_storage_path(session_engine, str(source_path), session_id)
+        if blob is not None:
+            # Inject blob_ref into the SourceResolved snapshot so that
+            # _classify_slot_resolver (recipe_match.py) can read it.
+            # The original options are Tier-3 (user-submitted SchemaForm
+            # values); we add blob_ref as an authoritative overlay from our
+            # own DB (Tier 1 source), so no .get() or coercion needed here.
+            enriched_options: dict[str, Any] = {**dict(resolved.options), "blob_ref": blob["id"]}
+            enriched_resolved = dataclasses.replace(resolved, options=enriched_options)
+
     return StepHandlerResult(
         state=tool_result.updated_state,
-        session=dataclasses.replace(session, step_1_result=resolved),
+        session=dataclasses.replace(session, step_1_result=enriched_resolved),
         tool_result=tool_result,
     )
 

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -195,7 +195,17 @@ def handle_step_2_sink(
         current_state = tool_result.updated_state
         last_result = tool_result
 
-    assert last_result is not None  # guaranteed: loop ran ≥1 time (empty check above)
+    if last_result is None:
+        # The empty-outputs check at the top of this function raises before the
+        # loop; therefore reaching this point with last_result=None means the
+        # loop body never ran despite resolved.outputs being non-empty — a bug
+        # in iteration logic that would otherwise silently feed None to the
+        # StepHandlerResult dataclass constructor.  Use InvariantError (not a
+        # bare assert) so python -O does not strip the gate.
+        raise InvariantError(
+            "step 2 sink handler loop completed with last_result=None despite "
+            "non-empty resolved.outputs — bug in the empty-outputs guard above"
+        )
 
     return StepHandlerResult(
         state=current_state,

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -16,9 +16,9 @@ import dataclasses
 from dataclasses import dataclass
 
 from elspeth.web.catalog.protocol import CatalogService
-from elspeth.web.composer.guided.state_machine import GuidedSession, SourceResolved
+from elspeth.web.composer.guided.state_machine import GuidedSession, SinkResolved, SourceResolved
 from elspeth.web.composer.state import CompositionState
-from elspeth.web.composer.tools import ToolResult, _execute_set_source
+from elspeth.web.composer.tools import ToolResult, _execute_set_output, _execute_set_source
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,4 +82,66 @@ def handle_step_1_source(
         state=tool_result.updated_state,
         session=dataclasses.replace(session, step_1_result=resolved),
         tool_result=tool_result,
+    )
+
+
+def handle_step_2_sink(
+    *,
+    state: CompositionState,
+    session: GuidedSession,
+    resolved: SinkResolved,
+    catalog: CatalogService,
+    data_dir: str | None = None,
+) -> StepHandlerResult:
+    """Commit each resolved sink output via _execute_set_output.
+
+    Constructs the args dict the freeform handler expects and delegates
+    entirely to _execute_set_output. The handler does not validate or
+    coerce — validation is the tool handler's responsibility.
+
+    MVP constraint: all outputs use sink_name="main" to match the
+    source's on_success="main" wiring set in handle_step_1_source.
+    Multi-output pipelines will collide on "main" on the second iteration
+    — that is the correct behaviour; multi-output support is deferred to
+    the Phase 4 chain solver.
+
+    Returns a StepHandlerResult with:
+    - state, session unchanged (entry state) if ANY underlying handler
+      reports failure — partial commits are NOT retained.
+    - state advanced, session.step_2_result=resolved on success of all outputs.
+
+    Raises:
+        ValueError: if resolved.outputs is empty. The dispatcher upstream
+            guarantees at least one output.
+    """
+    if not resolved.outputs:
+        raise ValueError("step 2 sink resolved with no outputs — handler refuses empty list")
+
+    entry_state = state
+    current_state = state
+    last_result: ToolResult | None = None
+
+    for output in resolved.outputs:
+        args = {
+            "plugin": output.plugin,
+            "sink_name": "main",
+            "options": dict(output.options),
+            "on_write_failure": "discard",
+        }
+        tool_result = _execute_set_output(args, current_state, catalog, data_dir)
+        if not tool_result.success:
+            return StepHandlerResult(
+                state=entry_state,
+                session=session,
+                tool_result=tool_result,
+            )
+        current_state = tool_result.updated_state
+        last_result = tool_result
+
+    assert last_result is not None  # guaranteed: loop ran ≥1 time (empty check above)
+
+    return StepHandlerResult(
+        state=current_state,
+        session=dataclasses.replace(session, step_2_result=resolved),
+        tool_result=last_result,
     )

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -19,6 +19,7 @@ from typing import Any
 from sqlalchemy import Engine
 
 from elspeth.web.catalog.protocol import CatalogService
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.recipe_match import RecipeMatch
 from elspeth.web.composer.guided.state_machine import (
     ChainProposal,
@@ -171,7 +172,7 @@ def handle_step_2_sink(
             guarantees at least one output.
     """
     if not resolved.outputs:
-        raise ValueError("step 2 sink resolved with no outputs — handler refuses empty list")
+        raise InvariantError("step 2 sink resolved with no outputs — handler refuses empty list")
 
     entry_state = state
     current_state = state
@@ -308,11 +309,11 @@ def handle_step_3_chain_accept(
             Step 1 and Step 2 have committed before reaching Step 3).
     """
     if not proposal.steps:
-        raise ValueError("step 3 proposal had zero steps; refusing empty commit")
+        raise InvariantError("step 3 proposal had zero steps; refusing empty commit")
     if state.source is None:
-        raise ValueError("step 3 reached without a committed source; dispatcher bug")
+        raise InvariantError("step 3 reached without a committed source; dispatcher bug")
     if not state.outputs:
-        raise ValueError("step 3 reached without committed outputs; dispatcher bug")
+        raise InvariantError("step 3 reached without committed outputs; dispatcher bug")
 
     n = len(proposal.steps)
     node_args: list[dict[str, Any]] = []

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -168,7 +168,7 @@ def handle_step_2_sink(
     - state advanced, session.step_2_result=resolved on success of all outputs.
 
     Raises:
-        ValueError: if resolved.outputs is empty. The dispatcher upstream
+        InvariantError: if resolved.outputs is empty. The dispatcher upstream
             guarantees at least one output.
     """
     if not resolved.outputs:
@@ -304,7 +304,7 @@ def handle_step_3_chain_accept(
         session_id: Optional session ID (forwarded with session_engine).
 
     Raises:
-        ValueError: if the proposal has zero steps, or if state has no source
+        InvariantError: if the proposal has zero steps, or if state has no source
             or no outputs (handler invariant violation — dispatcher guarantees
             Step 1 and Step 2 have committed before reaching Step 3).
     """

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
+from typing import Any
 
 from sqlalchemy import Engine
 
 from elspeth.web.catalog.protocol import CatalogService
 from elspeth.web.composer.guided.recipe_match import RecipeMatch
 from elspeth.web.composer.guided.state_machine import (
+    ChainProposal,
     GuidedSession,
     SinkResolved,
     SourceResolved,
@@ -31,6 +33,7 @@ from elspeth.web.composer.tools import (
     ToolResult,
     _execute_apply_pipeline_recipe,
     _execute_set_output,
+    _execute_set_pipeline,
     _execute_set_source,
 )
 from elspeth.web.composer.yaml_generator import generate_yaml
@@ -211,6 +214,132 @@ def handle_step_2_5_recipe_apply(
         pipeline_yaml=yaml_text,
     )
     new_session = dataclasses.replace(session, terminal=terminal)
+
+    return StepHandlerResult(
+        state=tool_result.updated_state,
+        session=new_session,
+        tool_result=tool_result,
+    )
+
+
+def handle_step_3_chain_accept(
+    *,
+    state: CompositionState,
+    session: GuidedSession,
+    proposal: ChainProposal,
+    catalog: CatalogService,
+    data_dir: str | None = None,
+    session_engine: Engine | None = None,
+    session_id: str | None = None,
+) -> StepHandlerResult:
+    """Commit *proposal* atomically via _execute_set_pipeline and terminate the session.
+
+    Reconstructs the full pipeline spec from the existing state.source +
+    state.outputs and the new transforms from the proposal. Source.on_success
+    is rewired to "chain_in" so the chain sits between source and sinks; the
+    last transform produces "main" so outputs (which were committed against
+    the source's original "main" label in Step 2) remain reachable.
+
+    Wiring for N transforms:
+        source.on_success="chain_in"
+        idx=0:   input="chain_in", on_success="chain_0" (or "main" if N==1)
+        idx=k:   input=f"chain_{k-1}", on_success=f"chain_{k}"   (0<k<N-1)
+        idx=N-1: input=f"chain_{N-2}", on_success="main"          (N>1)
+        outputs: unchanged — still consume "main"
+
+    On _execute_set_pipeline success the session terminal is COMPLETED with
+    rendered YAML and step_3_proposal is recorded. On failure the state and
+    session are unchanged and the route layer re-emits the propose_chain turn
+    with the validation errors.
+
+    Args:
+        state: Current composition state. MUST have a committed source and
+            at least one output (dispatcher invariant — Steps 1 and 2 must
+            have completed before Step 3).
+        session: Current guided session.
+        proposal: Chain proposal with one or more transform steps.
+        catalog: Plugin catalogue service.
+        data_dir: Optional data directory for blob path validation.
+        session_engine: Optional session DB engine (forwarded to
+            _execute_set_pipeline for inline-blob and source-blob support).
+        session_id: Optional session ID (forwarded with session_engine).
+
+    Raises:
+        ValueError: if the proposal has zero steps, or if state has no source
+            or no outputs (handler invariant violation — dispatcher guarantees
+            Step 1 and Step 2 have committed before reaching Step 3).
+    """
+    if not proposal.steps:
+        raise ValueError("step 3 proposal had zero steps; refusing empty commit")
+    if state.source is None:
+        raise ValueError("step 3 reached without a committed source; dispatcher bug")
+    if not state.outputs:
+        raise ValueError("step 3 reached without committed outputs; dispatcher bug")
+
+    n = len(proposal.steps)
+    node_args: list[dict[str, Any]] = []
+    for idx, step in enumerate(proposal.steps):
+        input_label = "chain_in" if idx == 0 else f"chain_{idx - 1}"
+        on_success_label = "main" if idx == n - 1 else f"chain_{idx}"
+        node_args.append(
+            {
+                "id": f"guided_xform_{idx}",
+                "node_type": "transform",
+                "plugin": step["plugin"],
+                "input": input_label,
+                "on_success": on_success_label,
+                "options": dict(step["options"]),
+            }
+        )
+
+    arguments: dict[str, Any] = {
+        "source": {
+            "plugin": state.source.plugin,
+            "on_success": "chain_in",  # rewired; was "main" pre-Step-3
+            "options": dict(state.source.options),
+            "on_validation_failure": state.source.on_validation_failure,
+        },
+        "nodes": node_args,
+        "edges": [],
+        "outputs": [
+            {
+                "sink_name": o.name,
+                "plugin": o.plugin,
+                "options": dict(o.options),
+                "on_write_failure": o.on_write_failure,
+            }
+            for o in state.outputs
+        ],
+        "metadata": {},
+    }
+
+    tool_result = _execute_set_pipeline(
+        arguments,
+        state,
+        catalog,
+        data_dir,
+        session_engine=session_engine,
+        session_id=session_id,
+    )
+
+    if not tool_result.success:
+        return StepHandlerResult(
+            state=state,
+            session=session,
+            tool_result=tool_result,
+        )
+
+    yaml_text = generate_yaml(tool_result.updated_state)
+    terminal = TerminalState(
+        kind=TerminalKind.COMPLETED,
+        reason=None,
+        pipeline_yaml=yaml_text,
+    )
+    new_session = dataclasses.replace(
+        session,
+        step_3_proposal=proposal,
+        terminal=terminal,
+    )
 
     return StepHandlerResult(
         state=tool_result.updated_state,

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -1,0 +1,85 @@
+"""Step handlers for guided mode commit logic.
+
+Each handler takes a resolved Step result (decided plugin + options +
+observed columns) and writes it to CompositionState via the existing
+freeform tools.py handlers. Handlers do NOT decide what to commit —
+that's the route handler's job. They translate already-resolved data
+into ToolResult calls.
+
+Handlers thread CatalogService and data_dir from the route handler;
+they never touch HTTP, session storage, or audit emission directly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+from elspeth.web.catalog.protocol import CatalogService
+from elspeth.web.composer.guided.state_machine import GuidedSession, SourceResolved
+from elspeth.web.composer.state import CompositionState
+from elspeth.web.composer.tools import ToolResult, _execute_set_source
+
+
+@dataclass(frozen=True, slots=True)
+class StepHandlerResult:
+    """Result returned by each step commit handler.
+
+    Attributes:
+        state: The CompositionState after the handler ran. Unchanged if
+            the underlying tool handler reports failure.
+        session: The GuidedSession after the handler ran. Unchanged if
+            the underlying tool handler reports failure.
+        tool_result: The raw ToolResult from the underlying tool handler.
+            Callers inspect tool_result.success to decide whether to
+            advance the session step or re-emit the inspect turn.
+    """
+
+    state: CompositionState
+    session: GuidedSession
+    tool_result: ToolResult
+
+
+def handle_step_1_source(
+    *,
+    state: CompositionState,
+    session: GuidedSession,
+    resolved: SourceResolved,
+    catalog: CatalogService,
+    data_dir: str | None = None,
+) -> StepHandlerResult:
+    """Commit *resolved* as the pipeline source via _execute_set_source.
+
+    Constructs the args dict the freeform handler expects and delegates
+    entirely to _execute_set_source. The handler does not validate or
+    coerce — validation is the tool handler's responsibility.
+
+    Returns a StepHandlerResult with:
+    - state, session unchanged if the underlying handler reports failure
+      (the route layer turns that into a re-emit of the inspect turn).
+    - state advanced, session.step_1_result=resolved on success.
+
+    The session step pointer is NOT advanced here — that is the
+    dispatcher's (route handler's) responsibility in Task 3.4.
+    """
+    args = {
+        "plugin": resolved.plugin,
+        "options": dict(resolved.options),
+        "on_success": "main",
+        "on_validation_failure": "discard",
+    }
+
+    tool_result = _execute_set_source(args, state, catalog, data_dir)
+
+    if not tool_result.success:
+        return StepHandlerResult(
+            state=state,
+            session=session,
+            tool_result=tool_result,
+        )
+
+    return StepHandlerResult(
+        state=tool_result.updated_state,
+        session=dataclasses.replace(session, step_1_result=resolved),
+        tool_result=tool_result,
+    )

--- a/src/elspeth/web/composer/guided/steps.py
+++ b/src/elspeth/web/composer/guided/steps.py
@@ -15,10 +15,25 @@ from __future__ import annotations
 import dataclasses
 from dataclasses import dataclass
 
+from sqlalchemy import Engine
+
 from elspeth.web.catalog.protocol import CatalogService
-from elspeth.web.composer.guided.state_machine import GuidedSession, SinkResolved, SourceResolved
+from elspeth.web.composer.guided.recipe_match import RecipeMatch
+from elspeth.web.composer.guided.state_machine import (
+    GuidedSession,
+    SinkResolved,
+    SourceResolved,
+    TerminalKind,
+    TerminalState,
+)
 from elspeth.web.composer.state import CompositionState
-from elspeth.web.composer.tools import ToolResult, _execute_set_output, _execute_set_source
+from elspeth.web.composer.tools import (
+    ToolResult,
+    _execute_apply_pipeline_recipe,
+    _execute_set_output,
+    _execute_set_source,
+)
+from elspeth.web.composer.yaml_generator import generate_yaml
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,4 +159,61 @@ def handle_step_2_sink(
         state=current_state,
         session=dataclasses.replace(session, step_2_result=resolved),
         tool_result=last_result,
+    )
+
+
+def handle_step_2_5_recipe_apply(
+    *,
+    state: CompositionState,
+    session: GuidedSession,
+    match: RecipeMatch,
+    catalog: CatalogService,
+    data_dir: str | None = None,
+    session_engine: Engine | None = None,
+    session_id: str | None = None,
+) -> StepHandlerResult:
+    """Apply the matched recipe and mark the session COMPLETED.
+
+    On success the returned state is the recipe-applied pipeline,
+    session.terminal is TerminalState(COMPLETED, reason=None,
+    pipeline_yaml=<rendered>), and tool_result is the canonical
+    ToolResult from _execute_apply_pipeline_recipe.
+
+    On failure the state and session are unchanged, tool_result
+    reflects the failure; the route layer will re-emit the recipe-
+    offer turn with the validation errors attached.
+    """
+    arguments: dict[str, object] = {
+        "recipe_name": match.recipe_name,
+        "slots": dict(match.slots),
+    }
+
+    tool_result = _execute_apply_pipeline_recipe(
+        arguments,
+        state,
+        catalog,
+        data_dir,
+        session_engine=session_engine,
+        session_id=session_id,
+    )
+
+    if not tool_result.success:
+        return StepHandlerResult(
+            state=state,
+            session=session,
+            tool_result=tool_result,
+        )
+
+    yaml_text = generate_yaml(tool_result.updated_state)
+    terminal = TerminalState(
+        kind=TerminalKind.COMPLETED,
+        reason=None,
+        pipeline_yaml=yaml_text,
+    )
+    new_session = dataclasses.replace(session, terminal=terminal)
+
+    return StepHandlerResult(
+        state=tool_result.updated_state,
+        session=new_session,
+        tool_result=tool_result,
     )

--- a/src/elspeth/web/composer/prompts.py
+++ b/src/elspeth/web/composer/prompts.py
@@ -16,6 +16,8 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from elspeth.web.catalog.protocol import CatalogService
+from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+from elspeth.web.composer.guided.state_machine import TerminalKind
 from elspeth.web.composer.redaction import redact_source_storage_path
 from elspeth.web.composer.skills import load_deployment_skill, load_skill
 from elspeth.web.composer.state import CompositionState
@@ -240,9 +242,6 @@ def build_messages(
     # ``data_dir is None → SYSTEM_PROMPT`` fast path bypassed it. The
     # @lru_cache on build_system_prompt makes repeat calls free.
     if guided_terminal is not None:
-        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
-        from elspeth.web.composer.guided.state_machine import TerminalKind
-
         if guided_terminal.kind is TerminalKind.COMPLETED:
             reason_str = "completed_pipeline"
         else:

--- a/src/elspeth/web/composer/prompts.py
+++ b/src/elspeth/web/composer/prompts.py
@@ -249,7 +249,16 @@ def build_messages(
             if guided_terminal.reason is None:
                 raise RuntimeError(f"EXITED_TO_FREEFORM terminal must have a reason: {guided_terminal!r}")
             reason_str = guided_terminal.reason.value
-        prompt = build_mode_transition_system_prompt(terminal_reason=reason_str)
+        # Thread data_dir and advisor_enabled through the transition prompt so the
+        # first freeform turn after guided exit carries the same deployment overlay
+        # and advisor-strip policy as all subsequent freeform turns (Codex #17).
+        # build_system_prompt is @lru_cache'd — this call hits the same cache entry
+        # as the non-transition branch below.
+        freeform_skill = build_system_prompt(data_dir, advisor_enabled=advisor_enabled)
+        prompt = build_mode_transition_system_prompt(
+            terminal_reason=reason_str,
+            freeform_skill=freeform_skill,
+        )
     else:
         prompt = build_system_prompt(data_dir, advisor_enabled=advisor_enabled)
     messages.append({"role": "system", "content": prompt})

--- a/src/elspeth/web/composer/prompts.py
+++ b/src/elspeth/web/composer/prompts.py
@@ -16,6 +16,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from elspeth.web.catalog.protocol import CatalogService
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
 from elspeth.web.composer.guided.state_machine import TerminalKind
 from elspeth.web.composer.redaction import redact_source_storage_path
@@ -245,9 +246,21 @@ def build_messages(
         if guided_terminal.kind is TerminalKind.COMPLETED:
             reason_str = "completed_pipeline"
         else:
-            # EXITED_TO_FREEFORM — reason must be non-None for this kind
+            # EXITED_TO_FREEFORM — reason must be non-None for this kind.
+            # Use InvariantError (server-bug sentinel) rather than RuntimeError
+            # so the send_message / recompose route handlers route this through
+            # the B1-sanitized static-500 path (slog event + _safe_frame_strings
+            # capture) rather than landing at FastAPI's default 500.
+            #
+            # The diagnostic value here is the invariant name; we deliberately
+            # drop the ``{guided_terminal!r}`` interpolation that would otherwise
+            # embed ``pipeline_yaml`` (Tier-1 — may contain source paths, plugin
+            # options, secret references) into the exception message. Same leak
+            # vector that B1 (commit eb30f669) and I1 (commit ba424ad9)
+            # sanitized at routes.py:4634/4696; this site was missed by the
+            # original PR sweep (obs-ae69e10e00).
             if guided_terminal.reason is None:
-                raise RuntimeError(f"EXITED_TO_FREEFORM terminal must have a reason: {guided_terminal!r}")
+                raise InvariantError("EXITED_TO_FREEFORM terminal must have a reason")
             reason_str = guided_terminal.reason.value
         # Thread data_dir and advisor_enabled through the transition prompt so the
         # first freeform turn after guided exit carries the same deployment overlay

--- a/src/elspeth/web/composer/prompts.py
+++ b/src/elspeth/web/composer/prompts.py
@@ -13,12 +13,15 @@ import json
 import re
 from collections.abc import Mapping
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from elspeth.web.catalog.protocol import CatalogService
 from elspeth.web.composer.redaction import redact_source_storage_path
 from elspeth.web.composer.skills import load_deployment_skill, load_skill
 from elspeth.web.composer.state import CompositionState
+
+if TYPE_CHECKING:
+    from elspeth.web.composer.guided.state_machine import TerminalState
 
 # Load the pipeline composer skill once at module level (static content).
 _PIPELINE_SKILL = load_skill("pipeline_composer")
@@ -179,6 +182,7 @@ def build_messages(
     data_dir: str | None = None,
     *,
     advisor_enabled: bool = True,
+    guided_terminal: TerminalState | None = None,
 ) -> list[dict[str, Any]]:
     """Build the full message list for the LLM.
 
@@ -198,6 +202,12 @@ def build_messages(
     system message, so keeping the mutating state JSON in the second
     message lets follow-up turns reuse the expensive stable skill prefix.
 
+    When ``guided_terminal`` is set, this is the first freeform turn after
+    a guided-mode exit.  The system prompt is replaced with a layered
+    prompt (guided skill → transition header → freeform skill) per spec §8.2.
+    The caller is responsible for the gate logic and the ``transition_consumed``
+    flip; this function is pure (no state mutation).
+
     Args:
         chat_history: Chat history as plain dicts (role/content keys).
         state: Current CompositionState.
@@ -207,6 +217,9 @@ def build_messages(
             overlay.  When provided, the deployment skill at
             ``{data_dir}/skills/pipeline_composer.md`` is appended to
             the core skill in the system prompt.
+        guided_terminal: When set, the resolved TerminalState from the
+            completed guided session; triggers the layered transition
+            prompt instead of the freeform-only prompt.
         advisor_enabled: When False, strip advisor-specific sections from
             the core skill before forming the system prompt — the LLM
             should not learn about the ``request_advisor_hint`` tool when
@@ -219,11 +232,27 @@ def build_messages(
     messages: list[dict[str, Any]] = []
 
     # 1. Stable system prompt only.
+    # When guided_terminal is set, this is the first freeform turn after
+    # a guided-mode exit — use the layered transition prompt (spec §8.2).
+    # Otherwise fall through to the standard freeform-only prompt.
     # F1: route through build_system_prompt unconditionally so the
     # advisor-strip transformation applies consistently — the previous
     # ``data_dir is None → SYSTEM_PROMPT`` fast path bypassed it. The
     # @lru_cache on build_system_prompt makes repeat calls free.
-    prompt = build_system_prompt(data_dir, advisor_enabled=advisor_enabled)
+    if guided_terminal is not None:
+        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+        from elspeth.web.composer.guided.state_machine import TerminalKind
+
+        if guided_terminal.kind is TerminalKind.COMPLETED:
+            reason_str = "completed_pipeline"
+        else:
+            # EXITED_TO_FREEFORM — reason must be non-None for this kind
+            if guided_terminal.reason is None:
+                raise RuntimeError(f"EXITED_TO_FREEFORM terminal must have a reason: {guided_terminal!r}")
+            reason_str = guided_terminal.reason.value
+        prompt = build_mode_transition_system_prompt(terminal_reason=reason_str)
+    else:
+        prompt = build_system_prompt(data_dir, advisor_enabled=advisor_enabled)
     messages.append({"role": "system", "content": prompt})
 
     # 2. Dynamic state/plugin context. Keep this outside the first

--- a/src/elspeth/web/composer/protocol.py
+++ b/src/elspeth/web/composer/protocol.py
@@ -620,6 +620,7 @@ class ComposerService(Protocol):
         session_id: str | None = None,
         user_id: str | None = None,
         progress: ComposerProgressSink | None = None,
+        guided_terminal: Any | None = None,
     ) -> ComposerResult:
         """Run the LLM composition loop.
 
@@ -632,6 +633,9 @@ class ComposerService(Protocol):
                 depend on SessionService (seam contract B).
             state: The current CompositionState.
             user_id: Current user ID. Passed through to secret tools.
+            guided_terminal: When set, the resolved TerminalState from the
+                completed guided session; triggers the layered mode-transition
+                prompt for this first freeform turn (spec §8.2).
 
         Returns:
             ComposerResult with assistant message and updated state.

--- a/src/elspeth/web/composer/protocol.py
+++ b/src/elspeth/web/composer/protocol.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol
+
+if TYPE_CHECKING:
+    from elspeth.web.composer.guided.state_machine import TerminalState
 
 from elspeth.contracts.composer_audit import ComposerToolInvocation
 from elspeth.contracts.composer_llm_audit import ComposerLLMCall
@@ -620,7 +623,7 @@ class ComposerService(Protocol):
         session_id: str | None = None,
         user_id: str | None = None,
         progress: ComposerProgressSink | None = None,
-        guided_terminal: Any | None = None,
+        guided_terminal: TerminalState | None = None,
     ) -> ComposerResult:
         """Run the LLM composition loop.
 

--- a/src/elspeth/web/composer/service.py
+++ b/src/elspeth/web/composer/service.py
@@ -23,7 +23,10 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from typing import Any, Final, Literal, NoReturn, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, TypedDict, cast
+
+if TYPE_CHECKING:
+    from elspeth.web.composer.guided.state_machine import TerminalState
 
 import structlog
 from opentelemetry import metrics
@@ -1607,7 +1610,7 @@ class ComposerServiceImpl:
         session_id: str | None = None,
         user_id: str | None = None,
         progress: ComposerProgressSink | None = None,
-        guided_terminal: Any | None = None,
+        guided_terminal: TerminalState | None = None,
     ) -> ComposerResult:
         """Run the LLM composition loop with dual-counter budget.
 
@@ -1735,7 +1738,7 @@ class ComposerServiceImpl:
         user_id: str | None = None,
         deadline: float = 0.0,
         progress: ComposerProgressSink | None = None,
-        guided_terminal: Any | None = None,
+        guided_terminal: TerminalState | None = None,
     ) -> ComposerResult:
         """Inner composition loop with dual-counter budget tracking.
 
@@ -2910,7 +2913,7 @@ class ComposerServiceImpl:
         chat_history: list[dict[str, Any]],
         state: CompositionState,
         user_message: str,
-        guided_terminal: Any | None = None,
+        guided_terminal: TerminalState | None = None,
     ) -> list[dict[str, Any]]:
         """Build the message list. Returns a NEW list on every call.
 

--- a/src/elspeth/web/composer/service.py
+++ b/src/elspeth/web/composer/service.py
@@ -1607,6 +1607,7 @@ class ComposerServiceImpl:
         session_id: str | None = None,
         user_id: str | None = None,
         progress: ComposerProgressSink | None = None,
+        guided_terminal: Any | None = None,
     ) -> ComposerResult:
         """Run the LLM composition loop with dual-counter budget.
 
@@ -1615,6 +1616,10 @@ class ComposerServiceImpl:
             messages: Chat history as plain dicts (pre-converted from
                 ChatMessageRecord by route handler; seam contract B).
             state: The current CompositionState.
+            guided_terminal: When set, the resolved TerminalState from the
+                completed guided session; triggers the layered mode-transition
+                prompt for this first freeform turn (spec §8.2). The caller
+                is responsible for gate logic and ``transition_consumed`` flip.
 
         Returns:
             ComposerResult with assistant message and updated state.
@@ -1630,7 +1635,7 @@ class ComposerServiceImpl:
         from litellm.exceptions import APIError as LiteLLMAPIError
 
         try:
-            return await self._compose_loop(message, messages, state, session_id, user_id, deadline, progress)
+            return await self._compose_loop(message, messages, state, session_id, user_id, deadline, progress, guided_terminal)
         except ComposerConvergenceError as exc:
             await _emit_progress(
                 progress,
@@ -1730,6 +1735,7 @@ class ComposerServiceImpl:
         user_id: str | None = None,
         deadline: float = 0.0,
         progress: ComposerProgressSink | None = None,
+        guided_terminal: Any | None = None,
     ) -> ComposerResult:
         """Inner composition loop with dual-counter budget tracking.
 
@@ -1743,9 +1749,13 @@ class ComposerServiceImpl:
         LLM calls are wrapped in per-call asyncio.wait_for(remaining)
         because they are pure network I/O with no side effects and
         can be safely cancelled.
+
+        Args:
+            guided_terminal: When set, this is the first freeform turn after
+                guided-mode exit; the layered transition prompt is used.
         """
         initial_version = state.version
-        llm_messages = self._build_messages(messages, state, message)
+        llm_messages = self._build_messages(messages, state, message, guided_terminal)
         tools = self._get_litellm_tools()
         # Per-call audit recorder. Surfaced on ComposerResult and on
         # the three partial-state-carrier exceptions so the route handler
@@ -2900,6 +2910,7 @@ class ComposerServiceImpl:
         chat_history: list[dict[str, Any]],
         state: CompositionState,
         user_message: str,
+        guided_terminal: Any | None = None,
     ) -> list[dict[str, Any]]:
         """Build the message list. Returns a NEW list on every call.
 
@@ -2922,6 +2933,10 @@ class ComposerServiceImpl:
         commits 1a30d985 (SQLAlchemy 422 path) and 127417cb (sibling
         HTTP-path slog sites) — both narrow the HTTP surface to
         class-name-only while preserving structured server-side detail.
+
+        Args:
+            guided_terminal: When set, forward to ``build_messages`` so the
+                layered mode-transition prompt is used for this turn.
         """
         try:
             return build_messages(
@@ -2931,6 +2946,7 @@ class ComposerServiceImpl:
                 catalog=self._catalog,
                 data_dir=self._data_dir,
                 advisor_enabled=self._settings.composer_advisor_enabled,
+                guided_terminal=guided_terminal,
             )
         except OSError as exc:
             raise ComposerServiceError(f"Failed to load deployment skill ({type(exc).__name__})") from exc

--- a/src/elspeth/web/composer/state.py
+++ b/src/elspeth/web/composer/state.py
@@ -34,6 +34,7 @@ from elspeth.core.dag.coalesce_merge import merge_guaranteed_fields
 from elspeth.engine.orchestrator.validation import (
     _ALLOWED_FAILSINK_PLUGINS,
 )
+from elspeth.web.composer.guided.state_machine import GuidedSession
 
 NodeType = Literal["transform", "gate", "aggregation", "coalesce"]
 EdgeType = Literal["on_success", "on_error", "route_true", "route_false", "fork"]
@@ -1628,6 +1629,9 @@ class CompositionState:
         outputs: Sink configurations.
         metadata: Pipeline name and description.
         version: Monotonically increasing per session, starting at 1.
+        guided_session: Optional guided-mode session pointer. None for freeform
+            sessions; set to GuidedSession.initial() at session-create time for
+            guided sessions (spec §5.2).
     """
 
     source: SourceSpec | None
@@ -1636,6 +1640,7 @@ class CompositionState:
     outputs: tuple[OutputSpec, ...]
     metadata: PipelineMetadata
     version: int
+    guided_session: GuidedSession | None = None
 
     def __post_init__(self) -> None:
         if self.version < 1:

--- a/src/elspeth/web/composer/tools.py
+++ b/src/elspeth/web/composer/tools.py
@@ -76,6 +76,7 @@ _FULL_STATE_COMPONENT_ALIASES: Final[tuple[str, ...]] = ("", "full", "all", "pip
 _FULL_STATE_COMPONENT_ALIAS_SET: Final[frozenset[str]] = frozenset(_FULL_STATE_COMPONENT_ALIASES)
 _NODE_ROUTING_OPTION_PATCH_KEYS: Final[frozenset[str]] = frozenset({"input", "on_success", "on_error", "routes", "fork_to"})
 _DEFAULT_SOURCE_VALIDATION_FAILURE: Final[str] = "discard"
+_DATA_ERROR_KEY: Final[str] = "error"
 _SOURCE_VALIDATION_FAILURE_DESCRIPTION: Final[str] = (
     "How to handle source validation failures. Use 'discard' to drop invalid rows without routing. "
     "Any other value, including 'quarantine', must match a configured output/sink name."
@@ -1721,7 +1722,7 @@ def _failure_result(
         updated_state=state,
         validation=validation,
         affected_nodes=(),
-        data={"error": error_msg},
+        data={_DATA_ERROR_KEY: error_msg},
     )
 
 
@@ -1804,7 +1805,7 @@ def _credential_wiring_contract_failure(
         validation=validation,
         affected_nodes=(),
         data={
-            "error": error_msg,
+            _DATA_ERROR_KEY: error_msg,
             "credential_fields": credential_fields,
             "components": (
                 {
@@ -5401,7 +5402,7 @@ def _execute_diff_pipeline(
         return _discovery_result(
             state,
             {
-                "error": "No baseline available. Load or create a session first.",
+                _DATA_ERROR_KEY: "No baseline available. Load or create a session first.",
                 "current_version": state.version,
             },
         )

--- a/src/elspeth/web/composer/tools.py
+++ b/src/elspeth/web/composer/tools.py
@@ -1964,6 +1964,9 @@ class _ResolvedSourceBlob:
     options: Mapping[str, Any]
     payload: SourceBlobPayload
 
+    def __post_init__(self) -> None:
+        freeze_fields(self, "options")
+
 
 def _blob_row_to_tool_dict(row: Any) -> BlobToolRecord:
     """Serialize a validated blobs row to the tool-layer dict shape."""

--- a/src/elspeth/web/composer/tools.py
+++ b/src/elspeth/web/composer/tools.py
@@ -2064,6 +2064,30 @@ def _sync_get_blob(engine: Engine, blob_id: str, session_id: str | None = None) 
         return _blob_row_to_tool_dict(row)
 
 
+def _sync_get_blob_by_storage_path(
+    engine: Engine,
+    storage_path: str,
+    session_id: str,
+) -> BlobToolRecord | None:
+    """Look up a blob by its canonical storage_path within a session.
+
+    Used by ``handle_step_1_source`` (steps.py) to detect whether a path
+    supplied via the guided SchemaForm resolves to an already-uploaded blob.
+    When it does, the blob_id (= blob["id"]) can be injected as ``blob_ref``
+    into ``SourceResolved.options`` so that the recipe slot resolvers in
+    ``recipe_match.py`` have access to the UUID they need.
+
+    Returns None if no blob row matches the path, which is the correct
+    representation for path-based sources that are not blob-backed.
+    """
+    with engine.connect() as conn:
+        query = select(blobs_table).where(blobs_table.c.session_id == session_id).where(blobs_table.c.storage_path == storage_path)
+        row = conn.execute(query).first()
+        if row is None:
+            return None
+        return _blob_row_to_tool_dict(row)
+
+
 def _sync_list_blobs(engine: Engine, session_id: str) -> list[dict[str, Any]]:
     """Synchronous blob listing for use in the tool executor thread."""
     with engine.connect() as conn:

--- a/src/elspeth/web/execution/fanout_guard.py
+++ b/src/elspeth/web/execution/fanout_guard.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
+from elspeth.contracts.freeze import freeze_fields
 from elspeth.core.canonical import canonical_json, stable_hash
 from elspeth.plugins.infrastructure.manager import get_shared_plugin_manager
 from elspeth.web.composer.state import CompositionState, NodeSpec, SourceSpec
@@ -65,6 +66,9 @@ class ExecutionFanoutRisk:
     risk_level: _RiskLevel
     message: str
 
+    def __post_init__(self) -> None:
+        freeze_fields(self, "upstream_fanout")
+
     def to_dict(self) -> ExecutionFanoutRiskPayload:
         return {
             "node_id": self.node_id,
@@ -87,6 +91,9 @@ class ExecutionFanoutGuard:
     risk_level: _RiskLevel
     summary: str
     risks: Sequence[ExecutionFanoutRisk]
+
+    def __post_init__(self) -> None:
+        freeze_fields(self, "risks")
 
     def to_dict(self) -> ExecutionFanoutGuardPayload:
         return {

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4313,8 +4313,12 @@ summary:focus-visible {
   flex-shrink: 0;
 }
 
-/* Plugin name heading */
+/* Plugin name -- rendered as <h3> for SR landmark navigation.
+   Reset default <h*> margin so the visual layout matches the prior <span>;
+   font-size is pinned to --font-size-base so the browser's default <h3>
+   sizing does not leak in. */
 .guided-propose-step-plugin {
+  margin: 0;
   font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text);

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4232,7 +4232,13 @@ summary:focus-visible {
 
 /* ---------------------------------------------------------------------------
    ProposeChainTurn (Task 7.6)
-   Classes prefixed guided-propose-*. Card-list layout — no chip styles.
+   Classes prefixed guided-propose-*. Card-list layout -- no chip styles.
+
+   CARD-STYLE REUSE (Task 7.7): .guided-propose-step-card is SHARED with
+   RecipeOfferTurn.  It provides pure card chrome (surface-elevated, border-strong,
+   radius-lg, padding space-md) with no step-list-specific styling.  RecipeOfferTurn
+   applies it to a single card div; ProposeChainTurn applies it to each <li> in the
+   step list.  New recipe-specific rules live in the guided-recipe-* namespace below.
    --------------------------------------------------------------------------- */
 
 /* Overall rationale paragraph shown above the step cards */
@@ -4394,6 +4400,137 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   RecipeOfferTurn (Task 7.7)
+   Classes prefixed guided-recipe-*. Single-card layout.
+
+   Card chrome reuse: .guided-propose-step-card (Task 7.6, App.css:4285-4290)
+   is applied as the outer card shell.  guided-recipe-* rules cover the
+   recipe-specific interior: name heading, slots definition list, alternatives
+   list, and action row with two buttons.
+   --------------------------------------------------------------------------- */
+
+/* Recipe name as <h3> -- reset default <h3> margin and pin font-size to base
+   so the browser's default <h3> sizing does not leak in.  Same pattern as
+   .guided-propose-step-plugin (Task 7.6). */
+.guided-recipe-name {
+  margin: 0 0 var(--space-md) 0;
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+}
+
+/* Slot definition list */
+.guided-recipe-slots {
+  margin: 0 0 var(--space-sm) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+/* Each slot row: key and value side-by-side */
+.guided-recipe-slot-row {
+  display: flex;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.guided-recipe-slot-key {
+  color: var(--color-text-muted);
+  min-width: 120px;
+  flex-shrink: 0;
+  font-family: var(--font-mono, monospace);
+}
+
+.guided-recipe-slot-val {
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+  margin: 0; /* dd default margin reset */
+}
+
+/* Alternatives section -- only rendered when payload.alternatives is non-empty */
+.guided-recipe-alternatives {
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border);
+}
+
+.guided-recipe-alternatives-heading {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-xs) 0;
+}
+
+.guided-recipe-alternatives-list {
+  margin: 0;
+  padding-left: var(--space-lg);
+}
+
+.guided-recipe-alternative-item {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+  margin-bottom: var(--space-xs);
+}
+
+/* Action row: Apply recipe + Build manually buttons */
+.guided-recipe-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+/* Apply recipe -- primary action */
+.guided-recipe-apply-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease;
+}
+
+.guided-recipe-apply-btn:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-recipe-apply-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Build manually -- secondary action */
+.guided-recipe-build-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
+.guided-recipe-build-btn:hover {
+  background-color: var(--color-surface-elevated);
+  border-color: var(--color-accent);
+}
+
+.guided-recipe-build-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4410,7 +4547,9 @@ summary:focus-visible {
   .guided-schema-textarea,
   .guided-schema-advanced-toggle,
   .guided-schema-continue-btn,
-  .guided-propose-accept-btn {
+  .guided-propose-accept-btn,
+  .guided-recipe-apply-btn,
+  .guided-recipe-build-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3560,3 +3560,135 @@ summary:focus-visible {
 .catalog-status-message--center {
   text-align: center;
 }
+
+/* ---------------------------------------------------------------------------
+   Guided Mode Turn Widgets
+   Convention (Tasks 7.2-7.7): all guided widget classes share the
+   guided-* prefix and use CSS custom properties only — no hardcoded colours.
+   --------------------------------------------------------------------------- */
+
+/* Base wrapper — each widget is an isolated block in the chat stream */
+.guided-turn {
+  padding: var(--space-md) 0;
+}
+
+/* Chip-group fieldset — strips browser default fieldset chrome */
+.guided-chip-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.guided-chip-legend {
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  font-weight: 600;
+  margin-bottom: var(--space-md);
+  padding: 0;
+}
+
+/* Chip group: horizontal wrapping row of option buttons */
+.guided-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+/* One option: button + optional hint stacked vertically */
+.guided-chip-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  max-width: 280px;
+}
+
+/* The option button itself */
+.guided-chip-btn {
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  text-align: left;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
+.guided-chip-btn:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
+}
+
+.guided-chip-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Hint text — muted, associated via aria-describedby */
+.guided-chip-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+/* Custom-input row (allow_custom=true) */
+.guided-custom-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.guided-custom-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.guided-custom-input {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px;
+}
+
+.guided-custom-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.guided-custom-submit-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: not-allowed;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px;
+}
+
+.guided-custom-submit-btn:not(:disabled) {
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  cursor: pointer;
+}
+
+.guided-custom-submit-btn:not(:disabled):hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-custom-submit-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4230,6 +4230,166 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   ProposeChainTurn (Task 7.6)
+   Classes prefixed guided-propose-*. Card-list layout — no chip styles.
+   --------------------------------------------------------------------------- */
+
+/* Overall rationale paragraph shown above the step cards */
+.guided-propose-why {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-md);
+  line-height: 1.5;
+}
+
+/* Blockers section — only rendered when payload.blockers is non-empty */
+.guided-propose-blockers {
+  background-color: var(--color-surface-elevated);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.guided-propose-blockers-heading {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-warning);
+  margin-bottom: var(--space-xs);
+}
+
+.guided-propose-blockers-list {
+  margin: 0;
+  padding-left: var(--space-lg);
+}
+
+.guided-propose-blocker-item {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  margin-bottom: var(--space-xs);
+}
+
+/* Ordered list of step cards — reset list styles; numbers shown by .guided-propose-step-number */
+.guided-propose-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+/* Individual step card */
+.guided-propose-step-card {
+  background-color: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  padding: var(--space-md);
+}
+
+/* Card header: step number badge + plugin name */
+.guided-propose-step-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+/* Circular step number badge */
+.guided-propose-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-badge-transform-bg);
+  border: 1px solid var(--color-badge-transform-border);
+  color: var(--color-badge-transform);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* Plugin name heading */
+.guided-propose-step-plugin {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+}
+
+/* Options key-value definition list */
+.guided-propose-options {
+  margin: 0 0 var(--space-sm) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+/* Each option row: key and value side-by-side */
+.guided-propose-option-row {
+  display: flex;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.guided-propose-option-key {
+  color: var(--color-text-muted);
+  min-width: 120px;
+  flex-shrink: 0;
+  font-family: var(--font-mono, monospace);
+}
+
+.guided-propose-option-val {
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+  margin: 0; /* dd default margin reset */
+}
+
+/* LLM's rationale for this step */
+.guided-propose-step-rationale {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border);
+}
+
+/* Action row: Accept proposal button */
+.guided-propose-actions {
+  display: flex;
+  margin-top: var(--space-md);
+}
+
+/* Accept proposal button */
+.guided-propose-accept-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease;
+}
+
+.guided-propose-accept-btn:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-propose-accept-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4245,7 +4405,8 @@ summary:focus-visible {
   .guided-schema-select,
   .guided-schema-textarea,
   .guided-schema-advanced-toggle,
-  .guided-schema-continue-btn {
+  .guided-schema-continue-btn,
+  .guided-propose-accept-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3572,6 +3572,11 @@ summary:focus-visible {
        .guided-chip-hint, .guided-chip-fieldset, .guided-chip-legend) are
        designed for reuse by multi_select_with_custom and recipe_offer — do not
        redefine equivalent styles in those widgets' code.
+     - `.guided-chip-btn[aria-pressed="true"]` lights the pressed visual.
+       Only set `aria-pressed` on chips that have toggle semantics
+       (currently only `multi_select_with_custom`); a chip without toggle
+       semantics must NOT carry `aria-pressed` or it will silently inherit
+       the pressed visual state.
    --------------------------------------------------------------------------- */
 
 /* Base wrapper — each widget is an isolated block in the chat stream */

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4045,6 +4045,191 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   SchemaFormTurn (Task 7.5)
+   Classes prefixed guided-schema-*. No chip styles -- this widget owns a
+   form-field-per-row layout, not a chip group.
+   --------------------------------------------------------------------------- */
+
+/* One property row: label + control + optional hint/error stacked vertically */
+.guided-schema-field-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-md);
+}
+
+/* Field label */
+.guided-schema-label {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+/* Text / number input */
+.guided-schema-input {
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: border-color 0.1s ease;
+}
+
+.guided-schema-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Select dropdown */
+.guided-schema-select {
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px;
+  cursor: pointer;
+  transition: border-color 0.1s ease;
+}
+
+.guided-schema-select:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Checkbox row: inline checkbox + label side-by-side */
+.guided-schema-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+/* Checkbox itself */
+.guided-schema-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+/* JSON-fallback textarea */
+.guided-schema-textarea {
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+  resize: vertical;
+  transition: border-color 0.1s ease;
+}
+
+.guided-schema-textarea:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Error state border for JSON textarea */
+.guided-schema-textarea--error {
+  border-color: var(--color-error, var(--color-accent));
+}
+
+/* Hint text -- muted, associated via aria-describedby */
+.guided-schema-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+/* Inline error text for JSON parse failures */
+.guided-schema-error {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-error, var(--color-accent));
+  line-height: 1.4;
+}
+
+/* Required fields section */
+.guided-schema-required-section {
+  margin-bottom: var(--space-sm);
+}
+
+/* Optional fields section (shown when advanced is expanded) */
+.guided-schema-optional-section {
+  margin-top: var(--space-sm);
+}
+
+/* Show / Hide advanced toggle */
+.guided-schema-advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  margin-top: var(--space-xs);
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.guided-schema-advanced-toggle:hover {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+}
+
+.guided-schema-advanced-toggle:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Continue action row */
+.guided-schema-actions {
+  display: flex;
+  margin-top: var(--space-md);
+}
+
+/* Continue button */
+.guided-schema-continue-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease;
+}
+
+.guided-schema-continue-btn:hover:not(:disabled) {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-schema-continue-btn:disabled {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+}
+
+.guided-schema-continue-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4055,7 +4240,12 @@ summary:focus-visible {
   .guided-inspect-cancel-btn,
   .guided-inspect-apply-btn,
   .guided-multi-custom-remove-btn,
-  .guided-multi-continue-btn {
+  .guided-multi-continue-btn,
+  .guided-schema-input,
+  .guided-schema-select,
+  .guided-schema-textarea,
+  .guided-schema-advanced-toggle,
+  .guided-schema-continue-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3800,7 +3800,11 @@ summary:focus-visible {
 }
 
 /* Edit view — heading */
+/* Reset browser-default h3 sizing so the semantic heading bump (Task 7.3
+   reviewer M10) doesn't shift visual rank — it remains the same prominent
+   inline label as before, just navigable by screen-reader heading jump. */
 .guided-inspect-edit-heading {
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text);
   margin: 0 0 var(--space-md) 0;

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4568,6 +4568,114 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   GuidedHistory (Task 7.9)
+   Classes prefixed guided-history-*.
+
+   Collapsible read-only list of completed wizard steps.  Rendered above the
+   active turn widget so the user can see what was decided in prior steps.
+
+   Visual design:
+     - Muted appearance (secondary text colour) to avoid competing with the
+       active turn widget.
+     - Toggle button matches the ExitToFreeformButton secondary style
+       (transparent background, border, muted text) but is visually lighter.
+     - List items use small text with separator dots between step name,
+       turn type, and emitter.
+
+   Collapsible region contract (Task 7.5 I2):
+     The region is ALWAYS rendered (hidden attribute toggles, not conditional
+     mounting) so the toggle's aria-controls always resolves.  Native browser
+     `[hidden] { display: none; }` handles both visual and AT-tree hiding —
+     no additional CSS required for the hidden state.
+
+   Sized to WCAG 2.5.8 minimum target (min-height: 44px on toggle button).
+   Focus ring and hover match the guided-* family convention.
+   --------------------------------------------------------------------------- */
+
+.guided-history {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.guided-history-toggle {
+  align-self: flex-start;
+  padding: var(--space-xs) var(--space-sm);
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease,
+    color 0.1s ease;
+}
+
+.guided-history-toggle:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-strong);
+  color: var(--color-text-secondary);
+}
+
+.guided-history-toggle:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* The region itself: native [hidden] { display: none; } handles collapse.
+   No explicit display rule needed here — the browser default applies.  */
+.guided-history-region {
+  padding: var(--space-xs) 0;
+}
+
+.guided-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.guided-history-item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.guided-history-step-number {
+  font-weight: 600;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.guided-history-step-name {
+  color: var(--color-text-secondary);
+}
+
+.guided-history-separator {
+  color: var(--color-text-muted);
+  user-select: none;
+}
+
+.guided-history-turn-type {
+  font-family: monospace;
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--color-text-muted);
+}
+
+.guided-history-emitter {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4587,7 +4695,8 @@ summary:focus-visible {
   .guided-propose-accept-btn,
   .guided-recipe-apply-btn,
   .guided-recipe-build-btn,
-  .guided-exit-button {
+  .guided-exit-button,
+  .guided-history-toggle {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4531,6 +4531,43 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   ExitToFreeformButton (Task 7.8)
+   Class: guided-exit-button.
+
+   Secondary / tertiary visual weight -- deliberately quieter than the primary
+   action buttons (accent background) used by individual widgets.  The button
+   must be visible but not compete with the widget's own call-to-action.
+
+   Sized to WCAG 2.5.8 minimum target (min-height: 44px).  Focus ring and
+   hover match the guided-* family convention.
+   --------------------------------------------------------------------------- */
+
+.guided-exit-button {
+  padding: var(--space-sm) var(--space-md);
+  background-color: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease,
+    color 0.1s ease;
+}
+
+.guided-exit-button:hover {
+  background-color: var(--color-surface-elevated);
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
+}
+
+.guided-exit-button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4549,7 +4586,8 @@ summary:focus-visible {
   .guided-schema-continue-btn,
   .guided-propose-accept-btn,
   .guided-recipe-apply-btn,
-  .guided-recipe-build-btn {
+  .guided-recipe-build-btn,
+  .guided-exit-button {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3563,8 +3563,15 @@ summary:focus-visible {
 
 /* ---------------------------------------------------------------------------
    Guided Mode Turn Widgets
-   Convention (Tasks 7.2-7.7): all guided widget classes share the
-   guided-* prefix and use CSS custom properties only — no hardcoded colours.
+   Conventions (Tasks 7.2-7.7):
+     - All guided widget classes share the guided-* prefix.
+     - Use CSS custom properties only — no hardcoded colours.
+     - All transitions/animations MUST have a matching
+       @media (prefers-reduced-motion: reduce) rule (see block at end of section).
+     - Shared chip styles (.guided-chip-btn, .guided-chip-group, .guided-chip-item,
+       .guided-chip-hint, .guided-chip-fieldset, .guided-chip-legend) are
+       designed for reuse by multi_select_with_custom and recipe_offer — do not
+       redefine equivalent styles in those widgets' code.
    --------------------------------------------------------------------------- */
 
 /* Base wrapper — each widget is an isolated block in the chat stream */
@@ -3691,4 +3698,12 @@ summary:focus-visible {
 .guided-custom-submit-btn:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+/* Honour OS-level motion preferences. Any new transition/animation added in
+   the guided-* section above MUST be silenced here. */
+@media (prefers-reduced-motion: reduce) {
+  .guided-chip-btn {
+    transition: none;
+  }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3918,6 +3918,128 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   MultiSelectWithCustomTurn (Task 7.4)
+   Reuses guided-chip-btn / guided-chip-group / guided-chip-fieldset /
+   guided-chip-legend / guided-chip-item / guided-chip-hint for the option
+   chips (per the Task 7.2 SHAPE NOTE - chip-group family widgets share
+   the structure). The aria-pressed="true" selector below lights up the
+   pressed visual state - added here rather than in the chip-base block
+   because SingleSelectTurn does not use aria-pressed.
+   --------------------------------------------------------------------------- */
+
+/* Pressed-chip visual state for toggle-button chips. Applies wherever
+   aria-pressed="true" is set on a guided-chip-btn (currently only
+   MultiSelectWithCustomTurn). */
+.guided-chip-btn[aria-pressed="true"] {
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border-color: var(--color-accent);
+}
+
+.guided-chip-btn[aria-pressed="true"]:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+  border-color: var(--color-btn-primary-bg-hover);
+}
+
+/* Custom-add row: reuses .guided-custom-label, .guided-custom-input,
+   .guided-custom-submit-btn from the SingleSelectTurn block above. */
+.guided-multi-custom-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+/* Added-customs strip: chip-styled list items with an X removal button. */
+.guided-multi-custom-list {
+  list-style: none;
+  margin: var(--space-sm) 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.guided-multi-custom-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background-color: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.guided-multi-custom-chip-label {
+  line-height: 1;
+}
+
+.guided-multi-custom-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.guided-multi-custom-remove-btn:hover {
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.guided-multi-custom-remove-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Continue button row */
+.guided-multi-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.guided-multi-continue-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease;
+}
+
+.guided-multi-continue-btn:hover:not(:disabled) {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-multi-continue-btn:disabled {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+}
+
+.guided-multi-continue-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -3926,7 +4048,9 @@ summary:focus-visible {
   .guided-inspect-edit-btn,
   .guided-inspect-remove-btn,
   .guided-inspect-cancel-btn,
-  .guided-inspect-apply-btn {
+  .guided-inspect-apply-btn,
+  .guided-multi-custom-remove-btn,
+  .guided-multi-continue-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -3700,10 +3700,229 @@ summary:focus-visible {
   outline-offset: 2px;
 }
 
+/* ---------------------------------------------------------------------------
+   InspectAndConfirmTurn (Task 7.3)
+   Classes prefixed guided-inspect-*.  No chip styles — this widget owns
+   a column-table + editor layout, not a chip group.
+   --------------------------------------------------------------------------- */
+
+/* Main table */
+.guided-inspect-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-md);
+}
+
+.guided-inspect-th {
+  text-align: left;
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 2px solid var(--color-border-strong);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.guided-inspect-tr:nth-child(even) {
+  background-color: var(--color-surface-elevated);
+}
+
+.guided-inspect-td {
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+  vertical-align: top;
+}
+
+/* Warnings aside — announced to screen readers via aria-label */
+.guided-inspect-warnings {
+  background-color: var(--color-surface-elevated);
+  border-left: 3px solid var(--color-warning, var(--color-accent));
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.guided-inspect-warnings-list {
+  margin: 0;
+  padding: 0 0 0 var(--space-md);
+}
+
+.guided-inspect-warning-item {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+/* Inspect-view action buttons */
+.guided-inspect-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.guided-inspect-confirm-btn,
+.guided-inspect-edit-btn {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  cursor: pointer;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
+.guided-inspect-confirm-btn {
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+}
+
+.guided-inspect-confirm-btn:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-inspect-edit-btn {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+}
+
+.guided-inspect-edit-btn:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
+}
+
+.guided-inspect-confirm-btn:focus-visible,
+.guided-inspect-edit-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Edit view — heading */
+.guided-inspect-edit-heading {
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 var(--space-md) 0;
+}
+
+/* Edit view — column list */
+.guided-inspect-editor-list {
+  list-style: none;
+  margin: 0 0 var(--space-md) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.guided-inspect-editor-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.guided-inspect-editor-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  min-width: 72px;
+}
+
+.guided-inspect-editor-input {
+  flex: 1;
+  padding: var(--space-xs) var(--space-sm);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 36px;
+}
+
+.guided-inspect-editor-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.guided-inspect-remove-btn {
+  padding: var(--space-xs) var(--space-sm);
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  min-height: 36px;
+  white-space: nowrap;
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.guided-inspect-remove-btn:hover {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+}
+
+.guided-inspect-remove-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Edit view — action buttons (Cancel / Apply edits) */
+.guided-inspect-editor-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.guided-inspect-cancel-btn,
+.guided-inspect-apply-btn {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  cursor: pointer;
+  min-height: 44px;
+  transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
+.guided-inspect-cancel-btn {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+}
+
+.guided-inspect-cancel-btn:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
+}
+
+.guided-inspect-apply-btn {
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+}
+
+.guided-inspect-apply-btn:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-inspect-cancel-btn:focus-visible,
+.guided-inspect-apply-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
-  .guided-chip-btn {
+  .guided-chip-btn,
+  .guided-inspect-confirm-btn,
+  .guided-inspect-edit-btn,
+  .guided-inspect-remove-btn,
+  .guided-inspect-cancel-btn,
+  .guided-inspect-apply-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/App.css
+++ b/src/elspeth/web/frontend/src/App.css
@@ -4676,6 +4676,124 @@ summary:focus-visible {
   font-style: italic;
 }
 
+/* ---------------------------------------------------------------------------
+   CompletionSummary (Task 7.10)
+   Classes prefixed guided-completion-*.
+
+   Terminal widget rendered when the guided wizard reaches kind="completed"
+   and pipeline_yaml is non-null.  Displays the finalized pipeline YAML in a
+   syntax-highlighted block (prism-react-renderer, vsDark / vsLight) with two
+   action buttons that both call exitToFreeform():
+     "Save and exit"                   -- committed-state UX framing.
+     "Drop to freeform to keep editing" -- further-edit UX framing.
+
+   Visual hierarchy:
+     heading     -- "Pipeline ready", h3, muted weight to avoid competing
+                    with surrounding chat layout.
+     yaml block  -- monospace pre inside a scrollable container with an
+                    inset surface to visually contain the code.
+     action row  -- primary button (Save and exit) + secondary button
+                    (Drop to freeform to keep editing).
+
+   Reduced-motion: guided-completion-save-btn and guided-completion-edit-btn
+   both carry transitions; both are silenced in the @media block below.
+   --------------------------------------------------------------------------- */
+
+/* Outer wrapper */
+.guided-completion {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background-color: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  border-radius: var(--radius-lg);
+}
+
+/* Section heading -- "Pipeline ready" */
+.guided-completion-heading {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-success);
+}
+
+/* Scrollable YAML preview container */
+.guided-completion-yaml-container {
+  overflow: auto;
+  max-height: 400px;
+  background-color: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+}
+
+/* <pre> block produced by prism-react-renderer.
+   Reset browser default pre margins; monospace font family to match YamlView. */
+.guided-completion-pre {
+  margin: 0;
+  padding: var(--space-md);
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
+    monospace;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* Action row: Save and exit + Drop to freeform to keep editing */
+.guided-completion-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+/* Primary action: Save and exit */
+.guided-completion-save-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease;
+}
+
+.guided-completion-save-btn:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+}
+
+.guided-completion-save-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Secondary action: Drop to freeform to keep editing */
+.guided-completion-edit-btn {
+  padding: var(--space-sm) var(--space-lg);
+  background-color: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  min-height: 44px; /* WCAG 2.5.8 minimum target size */
+  transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
+.guided-completion-edit-btn:hover {
+  background-color: var(--color-surface-elevated);
+  border-color: var(--color-accent);
+}
+
+.guided-completion-edit-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* Honour OS-level motion preferences. Any new transition/animation added in
    the guided-* section above MUST be silenced here. */
 @media (prefers-reduced-motion: reduce) {
@@ -4696,7 +4814,9 @@ summary:focus-visible {
   .guided-recipe-apply-btn,
   .guided-recipe-build-btn,
   .guided-exit-button,
-  .guided-history-toggle {
+  .guided-history-toggle,
+  .guided-completion-save-btn,
+  .guided-completion-edit-btn {
     transition: none;
   }
 }

--- a/src/elspeth/web/frontend/src/api/client.guided.test.ts
+++ b/src/elspeth/web/frontend/src/api/client.guided.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Tests for src/api/client.ts (producer side).
+ *
+ * Strategy: vi.spyOn(globalThis, "fetch") — NOT vi.mock("./client").
+ *
+ * Consumer tests (e.g. src/stores/sessionStore.test.ts) mock the
+ * @/api/client module because they're testing wiring around it.  This
+ * file is the producer; mocking the module we import from would mock
+ * the unit under test.  We spy on the underlying fetch instead, which
+ * lets us exercise the real getGuided/respondGuided code paths
+ * including authHeaders() and parseResponse<T>().
+ *
+ * Future API-client tests should follow this same pattern.
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getGuided, respondGuided } from "./client";
 import type {
@@ -60,9 +75,9 @@ function makeRespondResponse(): GuidedRespondResponse {
   };
 }
 
-// ── getGuided ────────────────────────────────────────────────────────────────
+// ── Suites ───────────────────────────────────────────────────────────────────
 
-describe("client.getGuided", () => {
+describe("api/client guided functions", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -73,106 +88,99 @@ describe("client.getGuided", () => {
     fetchSpy.mockRestore();
   });
 
-  it("calls GET /api/sessions/:id/guided and returns parsed body", async () => {
-    const body = makeGetGuidedResponse();
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => body,
-    } as Response);
+  describe("getGuided", () => {
+    it("calls GET /api/sessions/:id/guided and returns parsed body", async () => {
+      const body = makeGetGuidedResponse();
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response);
 
-    const result = await getGuided("sess-1");
+      const result = await getGuided("sess-1");
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/sessions/sess-1/guided");
-    expect(init.method).toBe("GET");
-    // GET has no Content-Type
-    expect((init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
-    expect(result).toEqual(body);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/sessions/sess-1/guided");
+      expect(init.method).toBe("GET");
+      expect(
+        (init.headers as Record<string, string>)["Content-Type"],
+      ).toBeUndefined();
+      expect(result).toEqual(body);
+    });
+
+    it("propagates AbortSignal to fetch", async () => {
+      const controller = new AbortController();
+      // Mock fetch to throw an AbortError when called — this simulates the
+      // native behaviour when the signal fires.  We don't actually abort here;
+      // we just confirm the signal was forwarded by inspecting the call args.
+      const abortError = new DOMException("Aborted", "AbortError");
+      fetchSpy.mockRejectedValue(abortError);
+
+      await expect(getGuided("sess-abort", controller.signal)).rejects.toThrow(
+        "Aborted",
+      );
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBe(controller.signal);
+    });
   });
 
-  it("propagates AbortSignal to fetch", async () => {
-    const controller = new AbortController();
-    // Mock fetch to throw an AbortError when called — this simulates the
-    // native behaviour when the signal fires.  We don't actually abort here;
-    // we just confirm the signal was forwarded by inspecting the call args.
-    const abortError = new DOMException("Aborted", "AbortError");
-    fetchSpy.mockRejectedValue(abortError);
+  describe("respondGuided", () => {
+    it("calls POST /api/sessions/:id/guided/respond and returns parsed body", async () => {
+      const body = makeRespondResponse();
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response);
 
-    await expect(getGuided("sess-abort", controller.signal)).rejects.toThrow(
-      "Aborted",
-    );
+      const request = makeRespondRequest();
+      const result = await respondGuided("sess-1", request);
 
-    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(init.signal).toBe(controller.signal);
-  });
-});
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/sessions/sess-1/guided/respond");
+      expect(init.method).toBe("POST");
+      expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+        "application/json",
+      );
+      // Verify the parsed shape rather than the raw byte sequence: JSON key
+      // ordering is incidental, and the server consumes the parsed object.
+      const bodyStr = init.body as string;
+      expect(JSON.parse(bodyStr)).toEqual(request);
+      expect(result).toEqual(body);
+    });
 
-// ── respondGuided ────────────────────────────────────────────────────────────
+    it("propagates AbortSignal to fetch", async () => {
+      const controller = new AbortController();
+      const abortError = new DOMException("Aborted", "AbortError");
+      fetchSpy.mockRejectedValue(abortError);
 
-describe("client.respondGuided", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+      const request = makeRespondRequest();
+      await expect(
+        respondGuided("sess-abort", request, controller.signal),
+      ).rejects.toThrow("Aborted");
 
-  beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, "fetch");
-  });
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBe(controller.signal);
+    });
 
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
+    it("throws ApiError (does not swallow) when server returns 500", async () => {
+      // parseResponse throws an ApiError-shaped object for non-2xx responses.
+      // Use 500 to avoid the 401 interceptor which dynamically imports authStore.
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: async () => ({ detail: "boom" }),
+      } as Response);
 
-  it("calls POST /api/sessions/:id/guided/respond and returns parsed body", async () => {
-    const body = makeRespondResponse();
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => body,
-    } as Response);
-
-    const request = makeRespondRequest();
-    const result = await respondGuided("sess-1", request);
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/sessions/sess-1/guided/respond");
-    expect(init.method).toBe("POST");
-    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
-      "application/json",
-    );
-    expect(init.body).toBe(JSON.stringify(request));
-    expect(result).toEqual(body);
-  });
-
-  it("propagates AbortSignal to fetch", async () => {
-    const controller = new AbortController();
-    const abortError = new DOMException("Aborted", "AbortError");
-    fetchSpy.mockRejectedValue(abortError);
-
-    const request = makeRespondRequest();
-    await expect(
-      respondGuided("sess-abort", request, controller.signal),
-    ).rejects.toThrow("Aborted");
-
-    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(init.signal).toBe(controller.signal);
-  });
-
-  it("throws ApiError (does not swallow) when server returns 500", async () => {
-    // parseResponse throws an ApiError-shaped object for non-2xx responses.
-    // Use 500 to avoid the 401 interceptor which dynamically imports authStore.
-    fetchSpy.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      json: async () => ({ detail: "boom" }),
-    } as Response);
-
-    const request = makeRespondRequest();
-    // Confirm the error propagates — we don't swallow it in respondGuided.
-    await expect(respondGuided("sess-err", request)).rejects.toMatchObject({
-      status: 500,
-      detail: "boom",
+      const request = makeRespondRequest();
+      await expect(respondGuided("sess-err", request)).rejects.toMatchObject({
+        status: 500,
+        detail: "boom",
+      });
     });
   });
 });

--- a/src/elspeth/web/frontend/src/api/client.guided.test.ts
+++ b/src/elspeth/web/frontend/src/api/client.guided.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getGuided, respondGuided } from "./client";
+import type {
+  GetGuidedResponse,
+  GuidedRespondRequest,
+  GuidedRespondResponse,
+} from "@/types/guided";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal but well-formed GetGuidedResponse fixture. */
+function makeGetGuidedResponse(): GetGuidedResponse {
+  return {
+    guided_session: {
+      step: "step_1_source",
+      history: [],
+      terminal: null,
+    },
+    next_turn: null,
+    terminal: null,
+    composition_state: null,
+  };
+}
+
+/** Minimal GuidedRespondRequest — all optional fields null. */
+function makeRespondRequest(): GuidedRespondRequest {
+  return {
+    chosen: ["foo"],
+    edited_values: null,
+    custom_inputs: null,
+    accepted_step_index: null,
+    edit_step_index: null,
+    control_signal: null,
+  };
+}
+
+/** Minimal GuidedRespondResponse — same shape as GetGuidedResponse. */
+function makeRespondResponse(): GuidedRespondResponse {
+  return {
+    guided_session: {
+      step: "step_2_sink",
+      history: [
+        {
+          step: "step_1_source",
+          turn_type: "single_select",
+          payload_hash: "abc123",
+          response_hash: "def456",
+          emitter: "server",
+        },
+      ],
+      terminal: null,
+    },
+    next_turn: {
+      type: "single_select",
+      step_index: 1,
+      payload: { options: ["csv", "json"] },
+    },
+    terminal: null,
+    composition_state: null,
+  };
+}
+
+// ── getGuided ────────────────────────────────────────────────────────────────
+
+describe("client.getGuided", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("calls GET /api/sessions/:id/guided and returns parsed body", async () => {
+    const body = makeGetGuidedResponse();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response);
+
+    const result = await getGuided("sess-1");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/sessions/sess-1/guided");
+    expect(init.method).toBe("GET");
+    // GET has no Content-Type
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
+    expect(result).toEqual(body);
+  });
+
+  it("propagates AbortSignal to fetch", async () => {
+    const controller = new AbortController();
+    // Mock fetch to throw an AbortError when called — this simulates the
+    // native behaviour when the signal fires.  We don't actually abort here;
+    // we just confirm the signal was forwarded by inspecting the call args.
+    const abortError = new DOMException("Aborted", "AbortError");
+    fetchSpy.mockRejectedValue(abortError);
+
+    await expect(getGuided("sess-abort", controller.signal)).rejects.toThrow(
+      "Aborted",
+    );
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+});
+
+// ── respondGuided ────────────────────────────────────────────────────────────
+
+describe("client.respondGuided", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("calls POST /api/sessions/:id/guided/respond and returns parsed body", async () => {
+    const body = makeRespondResponse();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response);
+
+    const request = makeRespondRequest();
+    const result = await respondGuided("sess-1", request);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/sessions/sess-1/guided/respond");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    expect(init.body).toBe(JSON.stringify(request));
+    expect(result).toEqual(body);
+  });
+
+  it("propagates AbortSignal to fetch", async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException("Aborted", "AbortError");
+    fetchSpy.mockRejectedValue(abortError);
+
+    const request = makeRespondRequest();
+    await expect(
+      respondGuided("sess-abort", request, controller.signal),
+    ).rejects.toThrow("Aborted");
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("throws ApiError (does not swallow) when server returns 500", async () => {
+    // parseResponse throws an ApiError-shaped object for non-2xx responses.
+    // Use 500 to avoid the 401 interceptor which dynamically imports authStore.
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({ detail: "boom" }),
+    } as Response);
+
+    const request = makeRespondRequest();
+    // Confirm the error propagates — we don't swallow it in respondGuided.
+    await expect(respondGuided("sess-err", request)).rejects.toMatchObject({
+      status: 500,
+      detail: "boom",
+    });
+  });
+});

--- a/src/elspeth/web/frontend/src/api/client.ts
+++ b/src/elspeth/web/frontend/src/api/client.ts
@@ -31,6 +31,11 @@ import type {
   ValidationResult,
   SystemStatus,
 } from "@/types/index";
+import type {
+  GetGuidedResponse,
+  GuidedRespondRequest,
+  GuidedRespondResponse,
+} from "@/types/guided";
 
 // ── Token Management ────────────────────────────────────────────────────────
 
@@ -309,6 +314,48 @@ export async function recompose(
   return parseResponse<{ message: ChatMessage; state: CompositionState | null }>(
     response,
   );
+}
+
+/**
+ * Fetch the current guided-session state for a session.
+ *
+ * Returns the active GuidedSession (step + history + terminal), the
+ * server-emitted next turn payload (if any), and the current composition
+ * state.  When no guided session has started for the session, the server
+ * initialises one and returns the Step 1 turn.
+ */
+export async function getGuided(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<GetGuidedResponse> {
+  const response = await fetch(`/api/sessions/${sessionId}/guided`, {
+    method: "GET",
+    headers: authHeaders(),
+    signal,
+  });
+  return parseResponse<GetGuidedResponse>(response);
+}
+
+/**
+ * Post a user response to the active guided turn.
+ *
+ * Server consumes the response, advances the state machine, and returns
+ * the replacement GuidedSession + next turn (or terminal state).  The
+ * client is expected to atomically replace its cached guided state with
+ * the response shape — no optimistic updates (spec §7.3).
+ */
+export async function respondGuided(
+  sessionId: string,
+  body: GuidedRespondRequest,
+  signal?: AbortSignal,
+): Promise<GuidedRespondResponse> {
+  const response = await fetch(`/api/sessions/${sessionId}/guided/respond`, {
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify(body),
+    signal,
+  });
+  return parseResponse<GuidedRespondResponse>(response);
 }
 
 /** Fork a session from a specific user message. */

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -5,6 +5,13 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { resetStore } from "@/test/store-helpers";
 import { useComposer } from "@/hooks/useComposer";
 import type { ChatMessage, ComposerProgressSnapshot, Session } from "@/types/api";
+import type {
+  GuidedSession,
+  SingleSelectPayload,
+  TerminalState,
+  TurnPayload,
+  TurnRecord,
+} from "@/types/guided";
 
 vi.mock("@/hooks/useComposer", () => ({
   useComposer: vi.fn(),
@@ -81,5 +88,232 @@ describe("ChatPanel", () => {
     expect(screen.getByText("The model requested plugin schemas.")).toBeInTheDocument();
     expect(screen.getByText("Checking available source, transform, and sink tools.")).toBeInTheDocument();
     expect(screen.queryByText("Working on: convert HTML into JSON")).not.toBeInTheDocument();
+  });
+});
+
+// ── Mode discriminator tests (Task 8.1) ─────────────────────────────────────────
+//
+// These cover the top-level mode switch added to ChatPanel:
+//   1. completed terminal  -> CompletionSummary surface
+//   2. guided-active       -> GuidedTurn + ExitToFreeformButton surface
+//   3. exited_to_freeform  -> falls through to freeform body
+//   4. defensive (guidedSession set, guidedNextTurn null) -> falls through
+//   5. no guided session   -> freeform body (existing behaviour)
+//
+// Fixtures use the exact wire shapes from src/types/guided.ts.  GuidedTurn
+// is exercised via SingleSelectTurn (which renders <fieldset> with implicit
+// role="group").
+describe("ChatPanel mode discriminator", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    resetStore(useSessionStore);
+    (useComposer as ReturnType<typeof vi.fn>).mockReturnValue({
+      sendMessage: vi.fn(),
+      retryMessage: vi.fn(),
+      isComposing: false,
+      compositionState: null,
+      error: null,
+    });
+  });
+
+  const guidedSessionFixture: Session = {
+    id: "session-guided",
+    title: "Guided composer session",
+    created_at: "2026-05-12T10:00:00Z",
+    updated_at: "2026-05-12T10:00:00Z",
+  };
+
+  function activeGuidedSession(): GuidedSession {
+    return {
+      step: "step_1_source",
+      history: [],
+      terminal: null,
+    };
+  }
+
+  function singleSelectTurn(): TurnPayload {
+    const payload: SingleSelectPayload = {
+      question: "Which source plugin should we use?",
+      options: [
+        { id: "csv", label: "CSV", hint: null },
+        { id: "api", label: "API", hint: null },
+      ],
+      allow_custom: false,
+    };
+    return { type: "single_select", step_index: 0, payload };
+  }
+
+  it("renders guided-active surface (GuidedTurn + ExitToFreeformButton) when guidedSession is active and next turn is present", () => {
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: singleSelectTurn(),
+    });
+
+    render(<ChatPanel />);
+
+    // GuidedTurn → SingleSelectTurn renders a <fieldset> (implicit role="group")
+    // with the question as the accessible name (via <legend>).
+    expect(
+      screen.getByRole("group", { name: "Which source plugin should we use?" }),
+    ).toBeInTheDocument();
+
+    // ExitToFreeformButton present.
+    expect(
+      screen.getByRole("button", { name: "Exit to freeform" }),
+    ).toBeInTheDocument();
+
+    // Freeform surface suppressed.
+    expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+  });
+
+  it("renders CompletionSummary surface when terminal.kind === 'completed'", () => {
+    const completedHistory: TurnRecord[] = [
+      {
+        step: "step_1_source",
+        turn_type: "single_select",
+        payload_hash: "h1",
+        response_hash: "r1",
+        emitter: "server",
+      },
+    ];
+    const terminal: TerminalState = {
+      kind: "completed",
+      reason: null,
+      pipeline_yaml: "source:\n  plugin: csv\n",
+    };
+
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: {
+        step: "step_3_transforms",
+        history: completedHistory,
+        terminal,
+      },
+      guidedTerminal: terminal,
+    });
+
+    const { container } = render(<ChatPanel />);
+
+    // CompletionSummary renders both action buttons.
+    expect(
+      screen.getByRole("button", { name: "Save and exit" }),
+    ).toBeInTheDocument();
+
+    // Container carries the per-branch CSS hook AND preserves the skip-link anchor.
+    const chatMain = container.querySelector("#chat-main");
+    expect(chatMain).not.toBeNull();
+    expect(chatMain?.classList.contains("chat-panel--completed")).toBe(true);
+
+    // Freeform surface suppressed.
+    expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+  });
+
+  it("does not render ExitToFreeformButton on the completed surface (regression pin for elspeth-obs-0a1002de6d)", () => {
+    // Same fixture as the completed-surface test, plus an asserted absence.
+    // The button label "Exit to freeform" is identical to ExitToFreeformButton.tsx.
+    // If the discriminator forgot to suppress ExitToFreeformButton in the completed
+    // branch, three identical-action buttons would coexist on the completed surface
+    // (Save and exit, Drop to freeform to keep editing, Exit to freeform).
+    const terminal: TerminalState = {
+      kind: "completed",
+      reason: null,
+      pipeline_yaml: "source:\n  plugin: csv\n",
+    };
+
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: {
+        step: "step_3_transforms",
+        history: [],
+        terminal,
+      },
+      guidedTerminal: terminal,
+    });
+
+    render(<ChatPanel />);
+
+    expect(
+      screen.queryByRole("button", { name: "Exit to freeform" }),
+    ).toBeNull();
+  });
+
+  it("renders the existing freeform body when guidedSession is null", () => {
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: null,
+      guidedNextTurn: null,
+    });
+
+    render(<ChatPanel />);
+
+    // ChatInput is mocked at file scope with data-testid="chat-input".
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    // Neither guided nor completed surface should be present.
+    expect(
+      screen.queryByRole("button", { name: "Save and exit" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Exit to freeform" }),
+    ).toBeNull();
+  });
+
+  it("falls through to the freeform body when terminal.kind === 'exited_to_freeform'", () => {
+    const terminal: TerminalState = {
+      kind: "exited_to_freeform",
+      reason: "user_pressed_exit",
+      pipeline_yaml: null,
+    };
+
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: {
+        step: "step_1_source",
+        history: [],
+        terminal,
+      },
+      guidedNextTurn: null,
+      guidedTerminal: terminal,
+    });
+
+    render(<ChatPanel />);
+
+    // Freeform surface visible.
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    // CompletionSummary NOT rendered (its guard fails on kind !== "completed").
+    expect(
+      screen.queryByRole("button", { name: "Save and exit" }),
+    ).toBeNull();
+  });
+
+  it("falls through to the freeform body when guidedSession is active but guidedNextTurn is null", () => {
+    // Defensive: this transient invariant should not crash the surface by passing
+    // null into GuidedTurn — it should fall through to freeform.
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: null,
+    });
+
+    render(<ChatPanel />);
+
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    // No guided-mode chrome rendered.
+    expect(
+      screen.queryByRole("button", { name: "Exit to freeform" }),
+    ).toBeNull();
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -153,7 +153,7 @@ describe("ChatPanel mode discriminator", () => {
       guidedNextTurn: singleSelectTurn(),
     });
 
-    render(<ChatPanel />);
+    const { container } = render(<ChatPanel />);
 
     // GuidedTurn → SingleSelectTurn renders a <fieldset> (implicit role="group")
     // with the question as the accessible name (via <legend>).
@@ -165,6 +165,18 @@ describe("ChatPanel mode discriminator", () => {
     expect(
       screen.getByRole("button", { name: "Exit to freeform" }),
     ).toBeInTheDocument();
+
+    // Discriminator-anchored class assertion: pins the guided-active branch to
+    // its own output (the `chat-panel--guided` class on `#chat-main`), parallel
+    // to how the completed-branch test asserts `chat-panel--completed`. Without
+    // this, a future change to `SingleSelectTurn`'s DOM (e.g., swap to
+    // `<div role="radiogroup">`) would break the `getByRole("group", …)` check
+    // and the failure would point at the discriminator test rather than at the
+    // widget. The class assertion fails only when the discriminator itself
+    // misroutes.
+    const chatMain = container.querySelector("#chat-main");
+    expect(chatMain).not.toBeNull();
+    expect(chatMain?.classList.contains("chat-panel--guided")).toBe(true);
 
     // Freeform surface suppressed.
     expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
@@ -215,11 +227,16 @@ describe("ChatPanel mode discriminator", () => {
   });
 
   it("does not render ExitToFreeformButton on the completed surface (regression pin for elspeth-obs-0a1002de6d)", () => {
-    // Same fixture as the completed-surface test, plus an asserted absence.
-    // The button label "Exit to freeform" is identical to ExitToFreeformButton.tsx.
-    // If the discriminator forgot to suppress ExitToFreeformButton in the completed
-    // branch, three identical-action buttons would coexist on the completed surface
-    // (Save and exit, Drop to freeform to keep editing, Exit to freeform).
+    // Regression pin for observation `elspeth-obs-0a1002de6d`. The completed
+    // branch renders `CompletionSummary` alone — it must NOT also render
+    // `<ExitToFreeformButton />`. If a future change forgets the if/else split
+    // and rehoists the button above the discriminator, a button with label
+    // "Exit to freeform" will appear on the completed surface alongside
+    // `CompletionSummary`'s "Save and exit" and "Drop to freeform to keep
+    // editing" buttons (which have wire-identical semantics but different UX
+    // framing). This `queryByRole` predicate catches that regression — it
+    // returns `null` when the button is absent (correct state) and a non-null
+    // element when present (regression).
     const terminal: TerminalState = {
       kind: "completed",
       reason: null,

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -314,6 +314,74 @@ describe("ChatPanel mode discriminator", () => {
     ).toBeNull();
   });
 
+  it("wraps the guided turn surface in a role=log aria-live=polite region (Task 8.2 a11y)", () => {
+    // Task 8.2 a11y fix: the guided branch must wrap the live turn surface in
+    // role="log" aria-live="polite" so screen readers are notified when a new
+    // turn arrives.  InspectAndConfirmTurn.tsx:39-46 documents the dependency
+    // (its warnings <aside> omits its own live region in favour of the parent).
+    // This test pins the contract on the parent side.
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: singleSelectTurn(),
+    });
+
+    const { container } = render(<ChatPanel />);
+
+    // The log region is the inner wrapper around <GuidedTurn>.
+    const logRegion = container.querySelector<HTMLElement>(
+      '[role="log"][aria-live="polite"]',
+    );
+    expect(logRegion).not.toBeNull();
+    // Co-attributes that complete the contract (parallel to chat-panel-messages
+    // in the freeform body).
+    expect(logRegion?.getAttribute("aria-relevant")).toBe("additions");
+    expect(logRegion?.getAttribute("aria-label")).toBe("Guided wizard step");
+
+    // The log region contains the turn surface (GuidedTurn → SingleSelectTurn's
+    // <fieldset> with the question as accessible name).
+    const fieldset = logRegion?.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.textContent).toContain("Which source plugin should we use?");
+
+    // ExitToFreeformButton lives OUTSIDE the log region (persistent affordance,
+    // not "new content" on turn change).  Document the layout decision via test.
+    const exitButton = screen.getByRole("button", { name: "Exit to freeform" });
+    expect(logRegion?.contains(exitButton)).toBe(false);
+  });
+
+  it("does not add a log region on the completed surface (regression pin for Task 8.2 a11y scope)", () => {
+    // The completed branch shows a static summary — no new turns ever arrive,
+    // so there must be no aria-live log region.  This test prevents an
+    // over-zealous future refactor from rehoisting the log wrapper above the
+    // discriminator and announcing the completion summary as if it were a
+    // turn arrival event.
+    const terminal: TerminalState = {
+      kind: "completed",
+      reason: null,
+      pipeline_yaml: "source:\n  plugin: csv\n",
+    };
+
+    useSessionStore.setState({
+      activeSessionId: "session-guided",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: {
+        step: "step_3_transforms",
+        history: [],
+        terminal,
+      },
+      guidedTerminal: terminal,
+    });
+
+    render(<ChatPanel />);
+
+    // No live region on the completed surface.
+    expect(screen.queryByRole("log")).toBeNull();
+  });
+
   it("falls through to the freeform body when guidedSession is active but guidedNextTurn is null", () => {
     // Defensive: this transient invariant should not crash the surface by passing
     // null into GuidedTurn — it should fall through to freeform.

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -317,8 +317,9 @@ describe("ChatPanel mode discriminator", () => {
   it("wraps the guided turn surface in a role=log aria-live=polite region (Task 8.2 a11y)", () => {
     // Task 8.2 a11y fix: the guided branch must wrap the live turn surface in
     // role="log" aria-live="polite" so screen readers are notified when a new
-    // turn arrives.  InspectAndConfirmTurn.tsx:39-46 documents the dependency
-    // (its warnings <aside> omits its own live region in favour of the parent).
+    // turn arrives.  InspectAndConfirmTurn.tsx ("Warnings accessibility"
+    // comment block) documents the dependency (its warnings <aside> omits its
+    // own live region in favour of the parent).
     // This test pins the contract on the parent side.
     useSessionStore.setState({
       activeSessionId: "session-guided",

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatPanel } from "./ChatPanel";
 import { useSessionStore } from "@/stores/sessionStore";
@@ -401,5 +401,141 @@ describe("ChatPanel mode discriminator", () => {
     expect(
       screen.queryByRole("button", { name: "Exit to freeform" }),
     ).toBeNull();
+  });
+});
+
+// ── Focus-on-step-advance tests (Phase 8 fix-up, spec §7.4) ─────────────────
+//
+// Verifies the useEffect in ChatPanel that moves focus to the first interactive
+// element inside chat-panel-guided-log when the guided wizard advances to a
+// new step.  Without this, a step-advancing button click unmounts the button
+// before the browser returns focus, so focus falls to <body>.
+//
+// GuidedTurn is NOT mocked — tests use the real SingleSelectTurn widget (rendered
+// by the singleSelectTurn() fixture) which produces genuine <button> children
+// inside a <fieldset>.
+describe("ChatPanel guided step-advance focus (spec §7.4)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    resetStore(useSessionStore);
+    (useComposer as ReturnType<typeof vi.fn>).mockReturnValue({
+      sendMessage: vi.fn(),
+      retryMessage: vi.fn(),
+      isComposing: false,
+      compositionState: null,
+      error: null,
+    });
+  });
+
+  const guidedSessionFixture: Session = {
+    id: "session-focus",
+    title: "Guided focus test session",
+    created_at: "2026-05-12T10:00:00Z",
+    updated_at: "2026-05-12T10:00:00Z",
+  };
+
+  function activeGuidedSession(): GuidedSession {
+    return { step: "step_1_source", history: [], terminal: null };
+  }
+
+  function singleSelectTurn(stepIndex: number): TurnPayload {
+    const payload: SingleSelectPayload = {
+      question: "Which source plugin should we use?",
+      options: [
+        { id: "csv", label: "CSV", hint: null },
+        { id: "api", label: "API", hint: null },
+      ],
+      allow_custom: false,
+    };
+    return { type: "single_select", step_index: stepIndex, payload };
+  }
+
+  it("moves focus to the first button in chat-panel-guided-log when the turn first renders (step 0)", async () => {
+    useSessionStore.setState({
+      activeSessionId: "session-focus",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: singleSelectTurn(0),
+    });
+
+    render(<ChatPanel />);
+
+    // SingleSelectTurn renders one button per option; the first should receive
+    // focus via the step-advance effect.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "CSV" }),
+      );
+    });
+  });
+
+  it("moves focus to the first button again when step_index advances (step 0 → step 1)", async () => {
+    useSessionStore.setState({
+      activeSessionId: "session-focus",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: singleSelectTurn(0),
+    });
+
+    render(<ChatPanel />);
+
+    // Wait for initial focus (step 0).
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "CSV" }),
+      );
+    });
+
+    // Advance to step 1 with a new turn payload.
+    useSessionStore.setState({
+      guidedNextTurn: singleSelectTurn(1),
+    });
+
+    // Focus should still land on the first button in the new turn.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "CSV" }),
+      );
+    });
+  });
+
+  it("does NOT re-focus when step_index is unchanged (same-step store mutation)", async () => {
+    useSessionStore.setState({
+      activeSessionId: "session-focus",
+      sessions: [guidedSessionFixture],
+      messages: [],
+      guidedSession: activeGuidedSession(),
+      guidedNextTurn: singleSelectTurn(0),
+    });
+
+    render(<ChatPanel />);
+
+    // Wait for the initial focus (step 0, first button = "CSV").
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "CSV" }),
+      );
+    });
+
+    // Manually move focus to the second button as the user would after interacting
+    // with the widget.
+    const apiButton = screen.getByRole("button", { name: "API" });
+    apiButton.focus();
+    expect(document.activeElement).toBe(apiButton);
+
+    // Issue a same-step store mutation: new object reference, same step_index.
+    // The effect dep [guidedNextTurn?.step_index] should NOT re-fire.
+    useSessionStore.setState({
+      guidedNextTurn: { ...singleSelectTurn(0) },
+    });
+
+    // Flush React updates — give the effect a chance to incorrectly re-fire.
+    await Promise.resolve();
+
+    // Focus must remain on the API button; effect did not pull it back to CSV.
+    expect(document.activeElement).toBe(apiButton);
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatPanel } from "./ChatPanel";
 import { useSessionStore } from "@/stores/sessionStore";
@@ -439,13 +439,24 @@ describe("ChatPanel guided step-advance focus (spec §7.4)", () => {
     return { step: "step_1_source", history: [], terminal: null };
   }
 
+  // Options are intentionally distinct per step so that test 2's assertion at
+  // step 1 can only pass if the effect actually re-fired (i.e. the button it
+  // checks — "Database" — only exists in step 1's render, not step 0's).
+  // Step 0 → "CSV" / "API"; step 1 → "Database" / "Streaming".
   function singleSelectTurn(stepIndex: number): TurnPayload {
+    const options: SingleSelectPayload["options"] =
+      stepIndex === 0
+        ? [
+            { id: "csv", label: "CSV", hint: null },
+            { id: "api", label: "API", hint: null },
+          ]
+        : [
+            { id: "database", label: "Database", hint: null },
+            { id: "streaming", label: "Streaming", hint: null },
+          ];
     const payload: SingleSelectPayload = {
       question: "Which source plugin should we use?",
-      options: [
-        { id: "csv", label: "CSV", hint: null },
-        { id: "api", label: "API", hint: null },
-      ],
+      options,
       allow_custom: false,
     };
     return { type: "single_select", step_index: stepIndex, payload };
@@ -490,14 +501,19 @@ describe("ChatPanel guided step-advance focus (spec §7.4)", () => {
     });
 
     // Advance to step 1 with a new turn payload.
-    useSessionStore.setState({
-      guidedNextTurn: singleSelectTurn(1),
+    act(() => {
+      useSessionStore.setState({
+        guidedNextTurn: singleSelectTurn(1),
+      });
     });
 
-    // Focus should still land on the first button in the new turn.
+    // Focus should land on the first button of the step-1 turn ("Database").
+    // The label only exists in step 1's options, so this assertion can only pass
+    // if the focus effect re-fired after step_index changed (not if focus simply
+    // persisted at the same DOM position as step 0).
     await waitFor(() => {
       expect(document.activeElement).toBe(
-        screen.getByRole("button", { name: "CSV" }),
+        screen.getByRole("button", { name: "Database" }),
       );
     });
   });
@@ -528,8 +544,10 @@ describe("ChatPanel guided step-advance focus (spec §7.4)", () => {
 
     // Issue a same-step store mutation: new object reference, same step_index.
     // The effect dep [guidedNextTurn?.step_index] should NOT re-fire.
-    useSessionStore.setState({
-      guidedNextTurn: { ...singleSelectTurn(0) },
+    act(() => {
+      useSessionStore.setState({
+        guidedNextTurn: { ...singleSelectTurn(0) },
+      });
     });
 
     // Flush React updates — give the effect a chance to incorrectly re-fire.

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -44,6 +44,7 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const guidedLogRef = useRef<HTMLDivElement>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [showBlobManager, setShowBlobManager] = useState(false);
   const [inputText, setInputText] = useState("");
@@ -83,6 +84,26 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   useEffect(() => {
     setShowScrollButton(false);
   }, [activeSessionId]);
+
+  // Spec §7.4 — maintain focus on the first interactive element of the new turn
+  // after step advance.  Without this, a step-advancing button click unmounts
+  // the button before the browser can return focus elsewhere, so focus falls to
+  // <body>.  Keyboard users then have to Tab from the very top to reach the new
+  // turn widget — unacceptable for the demo SLA budget and for general a11y.
+  //
+  // Keyed on step_index: fires only when the guided wizard advances to a new
+  // step, not on every store mutation that produces a new TurnPayload object
+  // with the same step_index.  The ref-null short-circuit handles all non-guided
+  // branches implicitly — guidedLogRef.current is null whenever the
+  // chat-panel-guided-log div is not mounted (completed surface, freeform
+  // surface, no session).  Observation elspeth-obs-5ea21f94af documents the
+  // original defect and the chosen Option (c) implementation.
+  useEffect(() => {
+    if (!guidedLogRef.current) return;
+    const FOCUSABLE = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const first = guidedLogRef.current.querySelector<HTMLElement>(FOCUSABLE);
+    first?.focus();
+  }, [guidedNextTurn?.step_index]);
 
   const handleSend = useCallback(
     (content: string) => {
@@ -202,6 +223,7 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
         */}
         <GuidedHistory history={guidedSession.history} />
         <div
+          ref={guidedLogRef}
           className="chat-panel-guided-log"
           role="log"
           aria-label="Guided wizard step"

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -7,6 +7,10 @@ import { ComposingIndicator } from "./ComposingIndicator";
 import { ChatInput } from "./ChatInput";
 import { TemplateCards } from "./TemplateCards";
 import { BlobManager } from "@/components/blobs/BlobManager";
+import { CompletionSummary } from "./guided/CompletionSummary";
+import { ExitToFreeformButton } from "./guided/ExitToFreeformButton";
+import { GuidedHistory } from "./guided/GuidedHistory";
+import { GuidedTurn } from "./guided/GuidedTurn";
 import type { BlobMetadata, ChatMessage } from "@/types/api";
 
 interface ChatPanelProps {
@@ -27,6 +31,12 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   const composerProgress = useSessionStore((s) => s.composerProgress);
   const clearError = useSessionStore((s) => s.clearError);
   const forkFromMessage = useSessionStore((s) => s.forkFromMessage);
+  // Guided-mode discriminator state.  Selectors are hoisted here (not inside a
+  // branch) to comply with React's Rules of Hooks; the discriminator early
+  // returns below decide which surface to render based on these values.
+  const guidedSession = useSessionStore((s) => s.guidedSession);
+  const guidedNextTurn = useSessionStore((s) => s.guidedNextTurn);
+  const respondGuided = useSessionStore((s) => s.respondGuided);
 
   const activeSessionTitle = sessions.find((s) => s.id === activeSessionId)?.title;
   const { sendMessage, retryMessage, isComposing, error } = useComposer();
@@ -122,6 +132,51 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
       >
         Select a session from the sidebar, or create a new one to get
         started.
+      </div>
+    );
+  }
+
+  // ── Guided-mode discriminator ────────────────────────────────────────────────
+  //
+  // Precedence (intentional):
+  //   1. terminal.kind === "completed"  → CompletionSummary surface.
+  //   2. active guided session + non-null next turn  → GuidedTurn surface.
+  //   3. anything else (no guidedSession, exited_to_freeform terminal, or a
+  //      transient state where guidedSession is set but guidedNextTurn is null)
+  //      → fall through to the freeform body below.
+  //
+  // The completed branch is checked FIRST so that a stale `guidedNextTurn`
+  // alongside a completed terminal still surfaces the summary (correct UX)
+  // rather than dispatching a widget.
+  //
+  // Both branches preserve `id="chat-main"` so the skip-link target is honoured;
+  // the modifier class (`--guided` / `--completed`) provides a per-branch hook
+  // for future CSS without coupling layout to the freeform surface.
+  if (guidedSession?.terminal?.kind === "completed") {
+    return (
+      <div
+        id="chat-main"
+        className="chat-panel chat-panel--completed"
+        aria-label="Pipeline summary"
+      >
+        <CompletionSummary terminal={guidedSession.terminal} />
+      </div>
+    );
+  }
+
+  if (guidedSession && !guidedSession.terminal && guidedNextTurn) {
+    return (
+      <div
+        id="chat-main"
+        className="chat-panel chat-panel--guided"
+        aria-label="Guided composer"
+      >
+        <GuidedHistory history={guidedSession.history} />
+        <GuidedTurn
+          turn={guidedNextTurn}
+          onSubmit={(body) => void respondGuided(body)}
+        />
+        <ExitToFreeformButton />
       </div>
     );
   }

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -195,9 +195,10 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
             That replacement IS the "new content" event that SRs need to hear
             about — hence the wrapping log region.
 
-          Load-bearing for InspectAndConfirmTurn.tsx:39-46 (the widget's
-          warnings <aside> deliberately omits its own aria-live region under
-          the convention that the parent ChatPanel wraps turn content in one).
+          Load-bearing for `InspectAndConfirmTurn.tsx` — search for the
+          "Warnings accessibility" comment block (the widget's warnings <aside>
+          deliberately omits its own aria-live region under the convention that
+          the parent ChatPanel wraps turn content in one).
         */}
         <GuidedHistory history={guidedSession.history} />
         <div

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -178,8 +178,8 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
         aria-label="Guided composer"
       >
         {/*
-          aria-live region scope (mirrors the freeform body's chat-panel-messages
-          region; see ChatPanel.tsx around line 218-225 of post-Task-8.1 state).
+          aria-live region scope (mirrors the freeform body's
+          `<div className="chat-panel-messages">` region below).
 
           Only the live turn surface (<GuidedTurn>) lives inside the role="log"
           region.  Rationale:

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useSessionStore } from "@/stores/sessionStore";
 import { useComposer } from "@/hooks/useComposer";
+import { FOCUSABLE_SELECTOR } from "@/hooks/useFocusTrap";
 import { MessageBubble } from "./MessageBubble";
 import { ComposingIndicator } from "./ComposingIndicator";
 import { ChatInput } from "./ChatInput";
@@ -89,7 +90,7 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   // after step advance.  Without this, a step-advancing button click unmounts
   // the button before the browser can return focus elsewhere, so focus falls to
   // <body>.  Keyboard users then have to Tab from the very top to reach the new
-  // turn widget — unacceptable for the demo SLA budget and for general a11y.
+  // turn widget — unacceptable for general a11y.
   //
   // Keyed on step_index: fires only when the guided wizard advances to a new
   // step, not on every store mutation that produces a new TurnPayload object
@@ -100,8 +101,7 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   // original defect and the chosen Option (c) implementation.
   useEffect(() => {
     if (!guidedLogRef.current) return;
-    const FOCUSABLE = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-    const first = guidedLogRef.current.querySelector<HTMLElement>(FOCUSABLE);
+    const first = guidedLogRef.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
     first?.focus();
   }, [guidedNextTurn?.step_index]);
 

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -177,11 +177,41 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
         className="chat-panel chat-panel--guided"
         aria-label="Guided composer"
       >
+        {/*
+          aria-live region scope (mirrors the freeform body's chat-panel-messages
+          region; see ChatPanel.tsx around line 218-225 of post-Task-8.1 state).
+
+          Only the live turn surface (<GuidedTurn>) lives inside the role="log"
+          region.  Rationale:
+
+          * GuidedHistory is historical context — already-resolved turns that
+            were announced when they first arrived.  Replaying them through the
+            live region on every step transition would create redundant SR
+            chatter; keep it outside.
+          * ExitToFreeformButton is a persistent affordance (always present
+            in guided mode).  It is not "new content" on turn change, so it
+            also lives outside the log region.
+          * GuidedTurn replaces in place when a new step's payload arrives.
+            That replacement IS the "new content" event that SRs need to hear
+            about — hence the wrapping log region.
+
+          Load-bearing for InspectAndConfirmTurn.tsx:39-46 (the widget's
+          warnings <aside> deliberately omits its own aria-live region under
+          the convention that the parent ChatPanel wraps turn content in one).
+        */}
         <GuidedHistory history={guidedSession.history} />
-        <GuidedTurn
-          turn={guidedNextTurn}
-          onSubmit={(body) => void respondGuided(body)}
-        />
+        <div
+          className="chat-panel-guided-log"
+          role="log"
+          aria-label="Guided wizard step"
+          aria-live="polite"
+          aria-relevant="additions"
+        >
+          <GuidedTurn
+            turn={guidedNextTurn}
+            onSubmit={(body) => void respondGuided(body)}
+          />
+        </div>
         <ExitToFreeformButton />
       </div>
     );

--- a/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/ChatPanel.tsx
@@ -149,6 +149,12 @@ export function ChatPanel({ onOpenSecrets }: ChatPanelProps) {
   // alongside a completed terminal still surfaces the summary (correct UX)
   // rather than dispatching a widget.
   //
+  // When `terminal.kind === "exited_to_freeform"`, branch 1 does not match
+  // (kind !== "completed") and branch 2 does not match (`!guidedSession.terminal`
+  // is false because `terminal` is set). Execution falls through to the existing
+  // freeform body — which is the correct outcome (the user has exited; show
+  // them the chat surface).
+  //
   // Both branches preserve `id="chat-main"` so the skip-link target is honoured;
   // the modifier class (`--guided` / `--completed`) provides a per-branch hook
   // for future CSS without coupling layout to the freeform surface.

--- a/src/elspeth/web/frontend/src/components/chat/guided/CompletionSummary.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/CompletionSummary.test.tsx
@@ -1,0 +1,246 @@
+// ============================================================================
+// CompletionSummary -- regression coverage for the guided-mode terminal widget.
+//
+// Pinned contracts:
+//   1. YAML text is rendered in the highlighted block -- the pipeline_yaml
+//      string appears in the document when terminal.kind === "completed" and
+//      pipeline_yaml is non-null.  (Does NOT assert Prism token structure --
+//      that is Prism's contract, not ours.)
+//   2. Both action buttons render as <button type="button"> -- "Save and exit"
+//      (committed-state framing) and "Drop to freeform to keep editing"
+//      (further-edit framing).  Both are visible and have type="button".
+//   3. Save-and-exit click invokes useSessionStore.exitToFreeform once.
+//   4. Keep-editing click also invokes useSessionStore.exitToFreeform once.
+//      WIRE-IDENTITY PIN: Both buttons call the same parameterless
+//      exitToFreeform() action.  The backend has no separate handler for
+//      "committed" vs "further edit" framing; the differentiation is pure UX.
+//      A future implementer must NOT introduce two separate wire paths without
+//      a backend protocol change.
+//   5. pipeline_yaml === null -> widget returns null (nothing rendered).
+//      This is the strict gate: no defensive ?? "" coercion to silently
+//      render an empty highlight block.
+//   6. terminal.kind !== "completed" handling -- the parent should not render
+//      CompletionSummary in non-completed terminals.  The widget defensively
+//      returns null in that case as well.  Negative-space pin.
+//   7. Distinctness pin (Task 7.4 I4 inheritance): two simultaneous
+//      CompletionSummary instances have per-instance IDs that differ.
+//      Asserted via not.toBe() on elements carrying useId()-scoped IDs.
+//   8. Initial-render no-auto-focus -- neither button has focus on mount
+//      (matches convention from InspectAndConfirmTurn, Task 7.3).
+//   9. Reduced-motion classes -- verified by CSS (not directly testable in
+//      jsdom); this file notes the expectation for the reviewer.
+//
+// Source of truth:
+//   - types/guided.ts:54-58 (TerminalState wire shape)
+//   - stores/sessionStore.ts:116 + 572-583 (exitToFreeform parameterless)
+//   - docs/superpowers/plans/2026-05-11-composer-guided-mode.md:4445
+// ============================================================================
+
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CompletionSummary } from "./CompletionSummary";
+import { useSessionStore } from "@/stores/sessionStore";
+import { resetStore } from "@/test/store-helpers";
+import type { TerminalState } from "@/types/guided";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const COMPLETED_TERMINAL: TerminalState = {
+  kind: "completed",
+  reason: null,
+  pipeline_yaml: 'source:\n  plugin: csv\n  options:\n    path: data.csv\n',
+};
+
+const COMPLETED_TERMINAL_NULL_YAML: TerminalState = {
+  kind: "completed",
+  reason: null,
+  pipeline_yaml: null,
+};
+
+const EXITED_TERMINAL: TerminalState = {
+  kind: "exited_to_freeform",
+  reason: "user_pressed_exit",
+  pipeline_yaml: null,
+};
+
+// ── Store reset ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetStore(useSessionStore);
+});
+
+// ── Contract 1: YAML text rendered in highlighted block ───────────────────────
+
+describe("CompletionSummary -- YAML rendering", () => {
+  it("renders pipeline_yaml text in the document when kind=completed and yaml is non-null", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    // The yaml text appears somewhere in the highlighted block.
+    // We don't assert Prism token structure -- that's Prism's contract.
+    const yamlText = COMPLETED_TERMINAL.pipeline_yaml!;
+    // At minimum the raw string or its fragments appear in the document.
+    // The Highlight component renders individual tokens; the pre element
+    // contains all token text concatenated.
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre!.textContent).toContain("source:");
+    expect(pre!.textContent).toContain("csv");
+    // Full text check (Prism may split by token but textContent reunites them)
+    expect(pre!.textContent).toContain(yamlText.split("\n")[0]);
+  });
+
+  it("renders a heading element for the completion state", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    // Heading per Task 7.6 M3 convention for primary entity names
+    const heading = screen.getByRole("heading");
+    expect(heading).toBeInTheDocument();
+  });
+});
+
+// ── Contract 2: Both buttons render with type="button" ───────────────────────
+
+describe("CompletionSummary -- button identity", () => {
+  it("renders a 'Save and exit' button with type='button'", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    const btn = screen.getByRole("button", { name: /save and exit/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn.getAttribute("type")).toBe("button");
+  });
+
+  it("renders a 'Drop to freeform to keep editing' button with type='button'", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    const btn = screen.getByRole("button", {
+      name: /drop to freeform to keep editing/i,
+    });
+    expect(btn).toBeInTheDocument();
+    expect(btn.getAttribute("type")).toBe("button");
+  });
+
+  it("renders exactly two action buttons", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    // Precisely two buttons -- no phantom controls
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+  });
+});
+
+// ── Contract 3: Save-and-exit calls exitToFreeform ────────────────────────────
+
+describe("CompletionSummary -- save-and-exit action", () => {
+  it("clicking 'Save and exit' calls exitToFreeform once", async () => {
+    const user = userEvent.setup();
+    const mockExit = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExit });
+
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    await user.click(screen.getByRole("button", { name: /save and exit/i }));
+
+    expect(mockExit).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith();
+  });
+});
+
+// ── Contract 4: Keep-editing calls exitToFreeform (wire-identity pin) ─────────
+
+describe("CompletionSummary -- keep-editing action (wire-identity pin)", () => {
+  it("clicking 'Drop to freeform to keep editing' calls the same exitToFreeform", async () => {
+    const user = userEvent.setup();
+    const mockExit = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExit });
+
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    await user.click(
+      screen.getByRole("button", { name: /drop to freeform to keep editing/i }),
+    );
+
+    // Wire-identity: same action, same call count expectation as save-and-exit
+    expect(mockExit).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith();
+  });
+
+  it("each button independently fires exitToFreeform once when clicked separately", async () => {
+    const user = userEvent.setup();
+    const mockExit = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExit });
+
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    await user.click(screen.getByRole("button", { name: /save and exit/i }));
+    await user.click(
+      screen.getByRole("button", { name: /drop to freeform to keep editing/i }),
+    );
+
+    expect(mockExit).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Contract 5: pipeline_yaml === null -> widget returns null ─────────────────
+
+describe("CompletionSummary -- null pipeline_yaml guard", () => {
+  it("returns null (renders nothing) when terminal.pipeline_yaml is null", () => {
+    const { container } = render(
+      <CompletionSummary terminal={COMPLETED_TERMINAL_NULL_YAML} />,
+    );
+    // Strict null render -- no buttons, no heading, no pre
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render any button when pipeline_yaml is null", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL_NULL_YAML} />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+// ── Contract 6: non-completed terminal -> null ────────────────────────────────
+
+describe("CompletionSummary -- non-completed terminal guard (negative space)", () => {
+  it("returns null when terminal.kind is 'exited_to_freeform'", () => {
+    const { container } = render(
+      <CompletionSummary terminal={EXITED_TERMINAL} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ── Contract 7: distinctness pin (two simultaneous instances) ─────────────────
+
+describe("CompletionSummary -- distinctness pin (Task 7.4 I4 inheritance)", () => {
+  it("two simultaneous CompletionSummary instances have distinct heading IDs", () => {
+    render(
+      <div>
+        <CompletionSummary terminal={COMPLETED_TERMINAL} />
+        <CompletionSummary terminal={COMPLETED_TERMINAL} />
+      </div>,
+    );
+    const headings = screen.getAllByRole("heading");
+    // Two instances => two headings
+    expect(headings).toHaveLength(2);
+    // Headings are distinct DOM nodes (not.toBe per Task 7.4 I4 convention)
+    expect(headings[0]).not.toBe(headings[1]);
+  });
+
+  it("pre blocks in two simultaneous instances are distinct DOM nodes", () => {
+    const { container } = render(
+      <div>
+        <CompletionSummary terminal={COMPLETED_TERMINAL} />
+        <CompletionSummary terminal={COMPLETED_TERMINAL} />
+      </div>,
+    );
+    const pres = container.querySelectorAll("pre");
+    expect(pres).toHaveLength(2);
+    expect(pres[0]).not.toBe(pres[1]);
+  });
+});
+
+// ── Contract 8: no auto-focus on mount ────────────────────────────────────────
+
+describe("CompletionSummary -- no auto-focus on initial render", () => {
+  it("neither button has focus immediately after render", () => {
+    render(<CompletionSummary terminal={COMPLETED_TERMINAL} />);
+    const saveBtn = screen.getByRole("button", { name: /save and exit/i });
+    const keepBtn = screen.getByRole("button", {
+      name: /drop to freeform to keep editing/i,
+    });
+    expect(document.activeElement).not.toBe(saveBtn);
+    expect(document.activeElement).not.toBe(keepBtn);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/CompletionSummary.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/CompletionSummary.tsx
@@ -1,0 +1,125 @@
+// src/components/chat/guided/CompletionSummary.tsx
+//
+// Guided-mode terminal widget for the "completed" outcome (Task 7.10).
+// Conventions inherited from ExitToFreeformButton (Task 7.8) and
+// ProposeChainTurn (Task 7.6).
+//
+//   - Props: { terminal: TerminalState } -- read-only consumer of the terminal.
+//   - Renders only when terminal.kind === "completed" AND pipeline_yaml !== null.
+//     Returns null otherwise.  No defensive ?? "" coercion: an absent yaml is
+//     evidence (absence), not an invitation to render empty syntax-highlighted
+//     content.
+//   - Two action buttons, both calling useSessionStore.exitToFreeform():
+//       "Save and exit"                   -- committed-state UX framing.
+//       "Drop to freeform to keep editing" -- further-edit UX framing.
+//     WIRE-IDENTITY: Both buttons call the same parameterless exitToFreeform().
+//     The backend (routes.py + sessionStore.ts:572-583) has ONE handler for
+//     control_signal="exit_to_freeform" -- it does NOT distinguish between the
+//     two mental models above.  Do NOT introduce two separate wire paths without
+//     a backend protocol change (see sessionStore.ts:116).
+//   - useTheme() for Prism theme-awareness, matching YamlView.tsx:164.
+//   - <button type="button"> (never <div onClick>).
+//   - CSS via App.css guided-completion-* classes with design tokens.
+//   - No auto-focus on mount.
+
+import { useId } from "react";
+import { Highlight, themes } from "prism-react-renderer";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useTheme } from "@/hooks/useTheme";
+import type { TerminalState } from "@/types/guided";
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface CompletionSummaryProps {
+  terminal: TerminalState;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function CompletionSummary({ terminal }: CompletionSummaryProps) {
+  // Guard: only render in the completed+yaml-present state.
+  if (terminal.kind !== "completed" || terminal.pipeline_yaml === null) {
+    return null;
+  }
+
+  return <CompletionSummaryInner yaml={terminal.pipeline_yaml} />;
+}
+
+// ── Inner component (separated so hooks run unconditionally) ──────────────────
+//
+// React hooks must not be called conditionally.  The outer CompletionSummary
+// returns null before reaching any hook calls.  CompletionSummaryInner is the
+// always-rendered branch; it can call hooks without violating the Rules of Hooks.
+
+interface CompletionSummaryInnerProps {
+  yaml: string;
+}
+
+function CompletionSummaryInner({ yaml }: CompletionSummaryInnerProps) {
+  const reactId = useId();
+  const headingId = `${reactId}-heading`;
+  const preId = `${reactId}-pre`;
+
+  const exitToFreeform = useSessionStore((s) => s.exitToFreeform);
+  const { resolvedTheme } = useTheme();
+
+  // Match the theme-awareness pattern from YamlView.tsx:164.
+  const highlightTheme =
+    resolvedTheme === "dark" ? themes.vsDark : themes.vsLight;
+
+  function handleSaveAndExit(): void {
+    void exitToFreeform();
+  }
+
+  function handleKeepEditing(): void {
+    void exitToFreeform();
+  }
+
+  return (
+    <div className="guided-completion">
+      {/* Heading per Task 7.6 M3 convention for primary entity names */}
+      <h3 id={headingId} className="guided-completion-heading">
+        Pipeline ready
+      </h3>
+
+      {/* YAML preview -- syntax-highlighted via prism-react-renderer.
+          Theme-aware: dark/light resolved via useTheme() to match YamlView.
+          The pre id is used for distinctness testing across instances. */}
+      <div className="guided-completion-yaml-container">
+        <Highlight theme={highlightTheme} code={yaml} language="yaml">
+          {({ tokens, getLineProps, getTokenProps }) => (
+            <pre id={preId} className="guided-completion-pre">
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )}
+        </Highlight>
+      </div>
+
+      {/* Action row.
+          Both buttons call exitToFreeform() -- wire-identical by design.
+          See WIRE-IDENTITY note in file-level docstring. */}
+      <div className="guided-completion-actions">
+        <button
+          type="button"
+          className="guided-completion-save-btn"
+          onClick={handleSaveAndExit}
+        >
+          Save and exit
+        </button>
+        <button
+          type="button"
+          className="guided-completion-edit-btn"
+          onClick={handleKeepEditing}
+        >
+          Drop to freeform to keep editing
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.test.tsx
@@ -129,22 +129,6 @@ describe("ExitToFreeformButton -- two simultaneous instances fire independently"
     await user.click(btns[1]);
     expect(mockExitToFreeform).toHaveBeenCalledTimes(2);
   });
-
-  it("two simultaneous instances do not share state -- each click maps to one call", () => {
-    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
-    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
-
-    render(
-      <div>
-        <ExitToFreeformButton />
-        <ExitToFreeformButton />
-      </div>,
-    );
-
-    const btns = screen.getAllByRole("button", { name: /exit to freeform/i });
-    // Both are distinct DOM nodes.
-    expect(btns[0]).not.toBe(btns[1]);
-  });
 });
 
 // ── Contract 5: no auto-focus on mount ──────────────────────────────────────

--- a/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.test.tsx
@@ -1,0 +1,158 @@
+// ============================================================================
+// ExitToFreeformButton -- regression coverage for the guided-mode exit control.
+//
+// Pinned contracts:
+//   1. Button is type="button" and visible -- the label "Exit to freeform" is
+//      rendered inside a <button type="button"> so the browser never treats
+//      a stray Enter/Space as a form submission.
+//   2. Click invokes useSessionStore.exitToFreeform -- the button delegates
+//      entirely to the store action; it does NOT construct a GuidedRespondRequest
+//      body itself.  The mock asserts the delegation.
+//   3. No-confirmation path -- ExitToFreeformButton fires immediately on click
+//      (no intermediate confirm dialog).  This is intentionally simple for the
+//      demo path; the plan notes an operator may add confirmation later.
+//      This contract pins the *current* behaviour so a future "add confirmation"
+//      refactor must first update these tests rather than silently changing UX.
+//   4. Distinctness / independence -- two simultaneous ExitToFreeformButton
+//      instances each fire their *own* exitToFreeform call independently; there
+//      is no shared singleton or de-duplication across instances.
+//   5. No auto-focus on initial render -- the button must not steal focus on
+//      mount (matches the convention established in InspectAndConfirmTurn,
+//      Task 7.3).
+// ============================================================================
+
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExitToFreeformButton } from "./ExitToFreeformButton";
+import { useSessionStore } from "@/stores/sessionStore";
+import { resetStore } from "@/test/store-helpers";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetStore(useSessionStore);
+});
+
+// ── Contract 1: type="button" and visible ────────────────────────────────────
+
+describe("ExitToFreeformButton -- button identity", () => {
+  it("renders a visible button with label 'Exit to freeform'", () => {
+    render(<ExitToFreeformButton />);
+    const btn = screen.getByRole("button", { name: /exit to freeform/i });
+    expect(btn).toBeTruthy();
+  });
+
+  it("button has type='button' (not submit or reset)", () => {
+    render(<ExitToFreeformButton />);
+    const btn = screen.getByRole("button", { name: /exit to freeform/i });
+    expect(btn.getAttribute("type")).toBe("button");
+  });
+});
+
+// ── Contract 2: click invokes exitToFreeform ─────────────────────────────────
+
+describe("ExitToFreeformButton -- store action delegation", () => {
+  it("clicking the button calls useSessionStore.exitToFreeform once", async () => {
+    const user = userEvent.setup();
+    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
+
+    render(<ExitToFreeformButton />);
+    await user.click(screen.getByRole("button", { name: /exit to freeform/i }));
+
+    expect(mockExitToFreeform).toHaveBeenCalledTimes(1);
+    expect(mockExitToFreeform).toHaveBeenCalledWith();
+  });
+
+  it("clicking the button a second time calls exitToFreeform a second time", async () => {
+    const user = userEvent.setup();
+    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
+
+    render(<ExitToFreeformButton />);
+    const btn = screen.getByRole("button", { name: /exit to freeform/i });
+    await user.click(btn);
+    await user.click(btn);
+
+    expect(mockExitToFreeform).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Contract 3: no-confirmation (fires immediately) ──────────────────────────
+
+describe("ExitToFreeformButton -- no intermediate confirmation dialog", () => {
+  it("does NOT render any confirmation dialog on initial render", () => {
+    render(<ExitToFreeformButton />);
+    // Common confirmation patterns: role="alertdialog", role="dialog", or text
+    // containing "are you sure"/"confirm"/"cancel".
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByText(/are you sure/i)).toBeNull();
+    expect(screen.queryByText(/cancel/i)).toBeNull();
+  });
+
+  it("does NOT render a confirmation dialog after clicking the button", async () => {
+    const user = userEvent.setup();
+    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
+
+    render(<ExitToFreeformButton />);
+    await user.click(screen.getByRole("button", { name: /exit to freeform/i }));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+// ── Contract 4: distinctness / independence ──────────────────────────────────
+
+describe("ExitToFreeformButton -- two simultaneous instances fire independently", () => {
+  it("each instance calls exitToFreeform once when its own button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
+
+    render(
+      <div>
+        <ExitToFreeformButton />
+        <ExitToFreeformButton />
+      </div>,
+    );
+
+    const btns = screen.getAllByRole("button", { name: /exit to freeform/i });
+    expect(btns).toHaveLength(2);
+
+    await user.click(btns[0]);
+    expect(mockExitToFreeform).toHaveBeenCalledTimes(1);
+
+    await user.click(btns[1]);
+    expect(mockExitToFreeform).toHaveBeenCalledTimes(2);
+  });
+
+  it("two simultaneous instances do not share state -- each click maps to one call", () => {
+    const mockExitToFreeform = vi.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({ exitToFreeform: mockExitToFreeform });
+
+    render(
+      <div>
+        <ExitToFreeformButton />
+        <ExitToFreeformButton />
+      </div>,
+    );
+
+    const btns = screen.getAllByRole("button", { name: /exit to freeform/i });
+    // Both are distinct DOM nodes.
+    expect(btns[0]).not.toBe(btns[1]);
+  });
+});
+
+// ── Contract 5: no auto-focus on mount ──────────────────────────────────────
+
+describe("ExitToFreeformButton -- no auto-focus on initial render", () => {
+  it("the button does not have focus immediately after render", () => {
+    render(<ExitToFreeformButton />);
+    const btn = screen.getByRole("button", { name: /exit to freeform/i });
+    expect(document.activeElement).not.toBe(btn);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ExitToFreeformButton.tsx
@@ -1,0 +1,40 @@
+// ============================================================================
+// ExitToFreeformButton -- persistent guided-mode exit control.
+//
+// A single `<button type="button">` that delegates to `exitToFreeform()` in
+// useSessionStore.  The store action posts `{control_signal: "exit_to_freeform"}`
+// to the backend; this component owns no wire-body construction.
+//
+// Design decisions:
+//   NO confirmation dialog -- the button fires immediately on click.  The demo
+//   path prioritises minimal friction; a confirming-mode variant can be added
+//   later by wrapping this component rather than modifying it.
+//
+//   NO props -- the component is self-contained.  It reads exitToFreeform from
+//   the store directly.  There is nothing to parameterise for the demo.
+//
+// Placement: rendered alongside every guided turn by ChatPanel (Phase 8).
+// The component has no local state and mounts without stealing focus.
+// ============================================================================
+
+import { useSessionStore } from "@/stores/sessionStore";
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function ExitToFreeformButton() {
+  const exitToFreeform = useSessionStore((s) => s.exitToFreeform);
+
+  function handleClick(): void {
+    void exitToFreeform();
+  }
+
+  return (
+    <button
+      type="button"
+      className="guided-exit-button"
+      onClick={handleClick}
+    >
+      Exit to freeform
+    </button>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.test.tsx
@@ -1,0 +1,323 @@
+// ============================================================================
+// GuidedHistory -- collapsible read-only step-history list regression coverage.
+//
+// Pins SEVEN contracts:
+//   1. Toggle button renders "Show steps (N)" / "Hide steps (N)" per state.
+//   2. Initial state is collapsed: history items region has `hidden` attribute.
+//   3. aria-controls cross-state resolution: toggle's aria-controls points to an
+//      existing DOM element in BOTH collapsed AND expanded states.  This is the
+//      regression pin for the Task 7.5 I2 fix — the expanded-only conditional
+//      render pattern ({expanded && <div id={...}>}) is BROKEN because the id
+//      becomes a dangling reference while collapsed.  The `hidden` attribute
+//      pattern (div always present, hidden toggles) is the required approach.
+//   4. aria-expanded toggles correctly on click.
+//   5. Per-entry rendering: one <li> per TurnRecord when expanded; step label +
+//      turn type + emitter visible.
+//   6. Empty-history negative space: returns nothing when history is empty.
+//   7. Distinctness pin (useId, Task 7.4 I4 inheritance): two simultaneous
+//      GuidedHistory instances have distinct aria-controls IDs, proving useId()
+//      scoping prevents cross-instance collision.
+//   8. Focus management: focus stays on the toggle button after expand/collapse
+//      (history items are non-interactive read-only <li>s; moving focus into
+//      the list would require non-standard tabindex=-1 ref dance).
+//   9. Initial-mount no-auto-focus: rendering the widget does not steal focus.
+//  10. Scope reduction documented: wire carries only step/turn_type/emitter,
+//      not rich summary data.  See Tracker: elspeth-obs-cc8fa78524.
+//
+// Source of truth:
+//   - types/guided.ts:44-51 (TurnRecord wire shape — hashes only, no summary)
+//   - schemas.py:213-220 (TurnRecordResponse — confirms scope reduction)
+//   - SchemaFormTurn.test.tsx:659-673 (aria-controls cross-state regression pin template)
+// ============================================================================
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GuidedHistory } from "./GuidedHistory";
+import type { TurnRecord } from "@/types/guided";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const TURN_1: TurnRecord = {
+  step: "step_1_source",
+  turn_type: "single_select",
+  payload_hash: "aabbcc001122",
+  response_hash: "ddeeff334455",
+  emitter: "server",
+};
+
+const TURN_2: TurnRecord = {
+  step: "step_2_sink",
+  turn_type: "schema_form",
+  payload_hash: "112233aabbcc",
+  response_hash: null,
+  emitter: "llm",
+};
+
+const TWO_TURNS: TurnRecord[] = [TURN_1, TURN_2];
+
+// ── 1. Toggle button label ────────────────────────────────────────────────────
+
+describe("toggle button label", () => {
+  it("shows 'Show steps (N)' when collapsed (initial state)", () => {
+    render(<GuidedHistory history={TWO_TURNS} />);
+    expect(
+      screen.getByRole("button", { name: /show steps \(2\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'Hide steps (N)' when expanded", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps \(2\)/i }));
+    expect(
+      screen.getByRole("button", { name: /hide steps \(2\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows correct count for single entry", () => {
+    render(<GuidedHistory history={[TURN_1]} />);
+    expect(
+      screen.getByRole("button", { name: /show steps \(1\)/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── 2. Initial state collapsed ────────────────────────────────────────────────
+
+describe("initial collapsed state", () => {
+  it("history region has the hidden attribute on initial render", () => {
+    render(<GuidedHistory history={TWO_TURNS} />);
+    const toggle = screen.getByRole("button", { name: /show steps/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId!);
+    expect(region).not.toBeNull();
+    // The `hidden` attribute collapses the region and removes it from the AT
+    // tree, but the element stays in the DOM so aria-controls resolves.
+    expect(region!.hasAttribute("hidden")).toBe(true);
+  });
+
+  it("list items are not visible (region hidden) on initial render", () => {
+    render(<GuidedHistory history={TWO_TURNS} />);
+    // Items inside a `hidden` container are excluded from the accessible role
+    // tree; getByRole would not find them.
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("respects initiallyExpanded=true prop", () => {
+    render(<GuidedHistory history={TWO_TURNS} initiallyExpanded={true} />);
+    const toggle = screen.getByRole("button", { name: /hide steps/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    const region = document.getElementById(controlsId!);
+    expect(region!.hasAttribute("hidden")).toBe(false);
+  });
+});
+
+// ── 3. aria-controls cross-state resolution (Task 7.5 I2 contract) ───────────
+
+describe("aria-controls / aria-expanded contract", () => {
+  it(
+    "aria-controls id resolves to a DOM element even when collapsed (initial render)",
+    () => {
+      // Regression pin: mirrors SchemaFormTurn.test.tsx:660-673.
+      // If GuidedHistory were to conditionally render the region only when
+      // expanded ({expanded && <div id={controlsId}>...}), the id would be a
+      // dangling reference while collapsed. The `hidden` attribute pattern
+      // (always rendered, hidden toggles) is the required approach.
+      render(<GuidedHistory history={TWO_TURNS} />);
+      const toggle = screen.getByRole("button", { name: /show steps/i });
+      const controlsId = toggle.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+      // MUST resolve — not null — in the collapsed state.
+      expect(document.getElementById(controlsId!)).not.toBeNull();
+    },
+  );
+
+  it("aria-controls id resolves after expand", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    const toggle = screen.getByRole("button", { name: /show steps/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    await user.click(toggle);
+    // Must still resolve in expanded state (same element, hidden removed).
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+  });
+
+  it("aria-controls id resolves after collapse (re-hidden)", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    const toggle = screen.getByRole("button", { name: /hide steps/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    await user.click(toggle);
+    // Must still resolve after re-collapsing.
+    const showBtn = screen.getByRole("button", { name: /show steps/i });
+    expect(document.getElementById(showBtn.getAttribute("aria-controls")!)).not.toBeNull();
+    expect(controlsId).toBeTruthy();
+  });
+
+  it("aria-expanded starts false and flips to true on expand", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    const toggle = screen.getByRole("button", { name: /show steps/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await user.click(toggle);
+    expect(
+      screen.getByRole("button", { name: /hide steps/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("history region announces itself as a labelled region when expanded", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    // role=region + aria-label gives screen readers a discoverable landmark.
+    expect(
+      screen.getByRole("region", { name: /wizard step history/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── 4. Per-entry rendering when expanded ─────────────────────────────────────
+
+describe("per-entry rendering", () => {
+  it("renders one list item per TurnRecord when expanded", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+  });
+
+  it("shows step label for step_1_source entry", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={[TURN_1]} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    // Should render a human-readable step label, not the raw enum value.
+    expect(screen.getByText(/source/i)).toBeInTheDocument();
+  });
+
+  it("shows turn_type for each entry", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={[TURN_1]} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    expect(screen.getByText(/single_select/i)).toBeInTheDocument();
+  });
+
+  it("shows emitter for each entry", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={[TURN_1]} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    expect(screen.getByText(/server/i)).toBeInTheDocument();
+  });
+
+  it("renders entries for both turns with distinct step labels", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    // Both step labels should appear (Source and Sink).
+    expect(screen.getByText(/source/i)).toBeInTheDocument();
+    expect(screen.getByText(/sink/i)).toBeInTheDocument();
+  });
+
+  it("shows ordinal step numbers (1-based index)", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    // Step 1 and Step 2 ordinals should appear.
+    expect(screen.getByText(/step 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 2/i)).toBeInTheDocument();
+  });
+});
+
+// ── 5. Empty-history negative space ──────────────────────────────────────────
+
+describe("empty history", () => {
+  it("renders nothing when history is empty", () => {
+    const { container } = render(<GuidedHistory history={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ── 6. Distinctness pin (useId scoping — Task 7.4 I4 inheritance) ─────────────
+
+describe("useId distinctness", () => {
+  it(
+    "two simultaneous GuidedHistory instances have distinct aria-controls IDs",
+    () => {
+      // Regression pin: mirrors SchemaFormTurn.test.tsx:726-755.
+      // Each GuidedHistory instance must get its own useId() prefix so the
+      // toggle↔region aria-controls pair is unique per instance.
+      render(
+        <>
+          <GuidedHistory history={TWO_TURNS} />
+          <GuidedHistory history={TWO_TURNS} />
+        </>,
+      );
+      const toggles = screen.getAllByRole("button", {
+        name: /show steps \(2\)/i,
+      });
+      expect(toggles).toHaveLength(2);
+
+      const id1 = toggles[0].getAttribute("aria-controls");
+      const id2 = toggles[1].getAttribute("aria-controls");
+      expect(id1).toBeTruthy();
+      expect(id2).toBeTruthy();
+      // IDs must be distinct strings (different useId() prefixes).
+      expect(id1).not.toBe(id2);
+      // The DOM elements they reference must be distinct nodes.
+      const region1 = document.getElementById(id1!);
+      const region2 = document.getElementById(id2!);
+      expect(region1).not.toBeNull();
+      expect(region2).not.toBeNull();
+      expect(region1).not.toBe(region2);
+    },
+  );
+});
+
+// ── 7. Focus management ───────────────────────────────────────────────────────
+
+describe("focus management", () => {
+  it("focus stays on toggle button after expand", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    const showBtn = screen.getByRole("button", { name: /show steps/i });
+    await user.click(showBtn);
+    // After expand, the button (now "Hide steps") retains focus.
+    // History items are non-interactive read-only <li>s; focusing them would
+    // require non-standard tabindex=-1 ref dance and isn't idiomatic for
+    // a read-only list.
+    const hideBtn = screen.getByRole("button", { name: /hide steps/i });
+    expect(document.activeElement).toBe(hideBtn);
+  });
+
+  it("focus stays on toggle button after collapse", async () => {
+    const user = userEvent.setup();
+    render(<GuidedHistory history={TWO_TURNS} />);
+    await user.click(screen.getByRole("button", { name: /show steps/i }));
+    await user.click(screen.getByRole("button", { name: /hide steps/i }));
+    // After collapse, the button (now "Show steps") retains focus.
+    const showBtn = screen.getByRole("button", { name: /show steps/i });
+    expect(document.activeElement).toBe(showBtn);
+  });
+});
+
+// ── 8. Initial-render no-auto-focus ──────────────────────────────────────────
+
+describe("initial-render no-auto-focus", () => {
+  it("does not steal focus from the document on mount", () => {
+    // Create a button to hold focus before rendering GuidedHistory.
+    const outside = document.createElement("button");
+    outside.textContent = "Outside";
+    document.body.appendChild(outside);
+    outside.focus();
+
+    render(<GuidedHistory history={TWO_TURNS} />);
+
+    // GuidedHistory must not have moved focus away from the outside element.
+    expect(document.activeElement).toBe(outside);
+
+    document.body.removeChild(outside);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.test.tsx
@@ -22,7 +22,8 @@
 //      the list would require non-standard tabindex=-1 ref dance).
 //   9. Initial-mount no-auto-focus: rendering the widget does not steal focus.
 //  10. Scope reduction documented: wire carries only step/turn_type/emitter,
-//      not rich summary data.  See Tracker: elspeth-obs-cc8fa78524.
+//      not rich summary data.  See Tracker: filigree elspeth-611fc01d94
+//      (rich step summaries — wire extension or payload-fetch endpoint).
 //
 // Source of truth:
 //   - types/guided.ts:44-51 (TurnRecord wire shape — hashes only, no summary)

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.tsx
@@ -27,7 +27,7 @@
 //   To enable rich summaries, the backend would need a cross-layer protocol
 //   change (adding a denormalized summary string to TurnRecordResponse), which
 //   requires operator adjudication before implementation.
-//   Tracker: elspeth-obs-cc8fa78524.
+//   Tracker: filigree elspeth-611fc01d94 (rich step summaries — wire extension or payload-fetch endpoint)
 
 import { useId, useState } from "react";
 import type { GuidedStep, TurnRecord, TurnType } from "@/types/guided";

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedHistory.tsx
@@ -1,0 +1,146 @@
+// src/components/chat/guided/GuidedHistory.tsx
+//
+// Guided-mode collapsible read-only list of completed wizard steps (Task 7.9).
+// Conventions inherited from the 7.x widget family:
+//   - useId() per-instance scoping (Task 7.4 I2): the toggle↔region
+//     aria-controls pair uses a useId() prefix so multiple GuidedHistory
+//     instances coexist without DOM id collisions.
+//   - aria-controls + hidden attribute (Task 7.5 I2): the collapsible region is
+//     ALWAYS rendered (hidden attribute toggles) so aria-controls resolves in
+//     both expanded and collapsed states. The conditional {expanded && children}
+//     pattern is BROKEN for aria-controls — a screen reader reaching the toggle
+//     while collapsed cannot resolve "expanded/collapsed WHAT" if the id is a
+//     dangling reference. Children remain gated on `expanded` to skip rendering
+//     work when collapsed.
+//   - <button type="button"> — never <div onClick>.
+//   - CSS via App.css class names with design tokens; no hardcoded colours.
+//   - Read-only: no onSubmit, no event handlers other than the toggle.
+//   - No auto-focus on mount (firstRunRef pattern inherited from
+//     InspectAndConfirmTurn.tsx): the widget appears because a turn was
+//     completed, not because the user requested focus.
+//
+// SCOPE REDUCTION (wire-shape gap):
+//   The plan body described rich summaries like "Step 1: CSV with cols [price, qty]".
+//   The actual TurnRecordResponse wire shape (schemas.py:213-220) carries only
+//   step, turn_type, payload_hash, response_hash, and emitter — no summary field.
+//   GuidedHistory therefore renders only step label + turn type + emitter.
+//   To enable rich summaries, the backend would need a cross-layer protocol
+//   change (adding a denormalized summary string to TurnRecordResponse), which
+//   requires operator adjudication before implementation.
+//   Tracker: elspeth-obs-cc8fa78524.
+
+import { useId, useState } from "react";
+import type { GuidedStep, TurnRecord, TurnType } from "@/types/guided";
+
+// ── Display mappings ─────────────────────────────────────────────────────────
+
+/**
+ * Human-readable labels for each GuidedStep enum value.
+ * CLOSED LIST — mirrors GuidedStep in types/guided.ts:28-32.
+ * Update here whenever protocol.py adds a new step.
+ */
+const STEP_LABELS: Record<GuidedStep, string> = {
+  step_1_source: "Source",
+  step_2_sink: "Sink",
+  step_2_5_recipe_match: "Recipe match",
+  step_3_transforms: "Transforms",
+};
+
+/**
+ * Human-readable labels for turn types.
+ * CLOSED LIST — mirrors TurnType in types/guided.ts:15-21.
+ */
+const TURN_TYPE_LABELS: Record<TurnType, string> = {
+  inspect_and_confirm: "inspect_and_confirm",
+  single_select: "single_select",
+  multi_select_with_custom: "multi_select_with_custom",
+  schema_form: "schema_form",
+  propose_chain: "propose_chain",
+  recipe_offer: "recipe_offer",
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface Props {
+  /** Completed turn records from GuidedSession.history. */
+  history: TurnRecord[];
+  /** When true, the list starts expanded. Defaults to false. */
+  initiallyExpanded?: boolean;
+}
+
+/**
+ * Collapsible read-only list of completed guided-mode wizard steps.
+ *
+ * Returns null when history is empty — the parent should not render this
+ * widget unless there are completed steps to show.
+ */
+export function GuidedHistory({ history, initiallyExpanded = false }: Props): React.ReactElement | null {
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+  const reactId = useId();
+  const regionId = `${reactId}-history-region`;
+
+  // Empty history: nothing to show.
+  if (history.length === 0) {
+    return null;
+  }
+
+  const count = history.length;
+  const toggleLabel = expanded
+    ? `Hide steps (${count})`
+    : `Show steps (${count})`;
+
+  return (
+    <div className="guided-history">
+      {/* Toggle button — aria-controls always resolves because the region is
+          always rendered (hidden toggles, not conditional mounting). */}
+      <button
+        type="button"
+        className="guided-history-toggle"
+        aria-expanded={expanded}
+        aria-controls={regionId}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {toggleLabel}
+      </button>
+
+      {/* Region container: ALWAYS rendered so aria-controls resolves in both
+          expanded and collapsed states (Task 7.5 I2 contract).
+          The `hidden` attribute removes this from the AT tree when collapsed —
+          no spurious "empty region" announcement — while keeping the id
+          resolvable. Children are gated on `expanded` to skip render work
+          while collapsed. */}
+      <div
+        id={regionId}
+        role="region"
+        aria-label="Wizard step history"
+        className="guided-history-region"
+        hidden={!expanded}
+      >
+        {expanded && (
+          <ol className="guided-history-list">
+            {history.map((turn, idx) => (
+              <li key={`${turn.step}-${idx}`} className="guided-history-item">
+                <span className="guided-history-step-number">
+                  Step {idx + 1}
+                </span>
+                <span className="guided-history-step-name">
+                  {STEP_LABELS[turn.step]}
+                </span>
+                <span className="guided-history-separator" aria-hidden="true">
+                  ·
+                </span>
+                <span className="guided-history-turn-type">
+                  {TURN_TYPE_LABELS[turn.turn_type]}
+                </span>
+                <span className="guided-history-separator" aria-hidden="true">
+                  ·
+                </span>
+                <span className="guided-history-emitter">{turn.emitter}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
@@ -26,6 +26,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GuidedTurn } from "./GuidedTurn";
+import { nullResponse } from "@/test/guided-fixtures";
 import type {
   TurnPayload,
   SingleSelectPayload,
@@ -215,12 +216,9 @@ describe("GuidedTurn dispatcher — onSubmit forwarding", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(),
       chosen: ["csv"],
-      edited_values: null,
       custom_inputs: null,
-      accepted_step_index: null,
-      edit_step_index: null,
-      control_signal: null,
     });
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
@@ -93,6 +93,7 @@ const RECIPE_OFFER_PAYLOAD: RecipeOfferPayload = {
   recipe_name: "csv_to_json",
   slots: {},
   alternatives: ["build_manually"],
+  unsatisfied_slots: [],
 };
 
 /** Build a TurnPayload with the given type and typed payload. */

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.test.tsx
@@ -1,0 +1,268 @@
+// ============================================================================
+// GuidedTurn dispatcher -- routing contract regression coverage.
+//
+// Pins THREE contracts:
+//   1. Six-turn-type routing correctness: each TurnPayload.type routes to
+//      exactly the matching leaf widget, identifiable by a widget-specific
+//      rendered element.
+//   2. onSubmit forwarding: the dispatcher passes onSubmit through unchanged;
+//      a widget event fires the SAME fn reference the dispatcher received.
+//   3. Exhaustiveness compile-time check: the `const _exhaustive: never`
+//      pattern in the default case fails to compile if a new TurnType is
+//      added to guided.ts without a matching switch arm -- verified by the
+//      type-system, no runtime test needed (the default throw tests the
+//      runtime guard path in isolation).
+//
+// Widget-specific rendered identifiers used per routing test:
+//   single_select         -- payload.question text (legend text)
+//   inspect_and_confirm   -- "Looks right" button (inspect-view action)
+//   multi_select_with_custom -- payload.question text (legend text)
+//   schema_form           -- "Continue" button (submit action, present when canSubmit)
+//   propose_chain         -- "Accept proposal" button
+//   recipe_offer          -- <h3> recipe_name heading
+// ============================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GuidedTurn } from "./GuidedTurn";
+import type {
+  TurnPayload,
+  SingleSelectPayload,
+  InspectAndConfirmPayload,
+  MultiSelectWithCustomPayload,
+  SchemaFormPayload,
+  ProposeChainPayload,
+  RecipeOfferPayload,
+} from "@/types/guided";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SINGLE_SELECT_PAYLOAD: SingleSelectPayload = {
+  question: "Which data source should we use?",
+  options: [{ id: "csv", label: "CSV File", hint: null }],
+  allow_custom: false,
+};
+
+const INSPECT_AND_CONFIRM_PAYLOAD: InspectAndConfirmPayload = {
+  observed: {
+    columns: ["name", "value"],
+    samples: [{ name: "foo", value: 42 }],
+    warnings: [],
+  },
+};
+
+const MULTI_SELECT_PAYLOAD: MultiSelectWithCustomPayload = {
+  question: "Which output formats do you need?",
+  options: [
+    { id: "csv", label: "CSV", hint: null },
+    { id: "json", label: "JSON", hint: null },
+  ],
+  default_chosen: ["csv"],
+  escape_label: null,
+};
+
+// SchemaFormTurn renders a "Continue" button (enabled when canSubmit=true).
+// A required string field with a non-empty prefilled value satisfies canSubmit.
+const SCHEMA_FORM_PAYLOAD: SchemaFormPayload = {
+  plugin: "csv",
+  schema_block: {
+    type: "object",
+    properties: {
+      path: { type: "string", title: "Path" },
+    },
+    required: ["path"],
+  },
+  prefilled: { path: "/data/file.csv" },
+};
+
+const PROPOSE_CHAIN_PAYLOAD: ProposeChainPayload = {
+  steps: [
+    {
+      plugin: "llm_classify",
+      options: {},
+      rationale: "Classifies rows using an LLM.",
+    },
+  ],
+  why: "This chain addresses the stated classification goal.",
+  blockers: [],
+};
+
+const RECIPE_OFFER_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "csv_to_json",
+  slots: {},
+  alternatives: ["build_manually"],
+};
+
+/** Build a TurnPayload with the given type and typed payload. */
+function makeTurn(
+  type: "single_select",
+  payload: SingleSelectPayload,
+): TurnPayload;
+function makeTurn(
+  type: "inspect_and_confirm",
+  payload: InspectAndConfirmPayload,
+): TurnPayload;
+function makeTurn(
+  type: "multi_select_with_custom",
+  payload: MultiSelectWithCustomPayload,
+): TurnPayload;
+function makeTurn(
+  type: "schema_form",
+  payload: SchemaFormPayload,
+): TurnPayload;
+function makeTurn(
+  type: "propose_chain",
+  payload: ProposeChainPayload,
+): TurnPayload;
+function makeTurn(
+  type: "recipe_offer",
+  payload: RecipeOfferPayload,
+): TurnPayload;
+function makeTurn(type: TurnPayload["type"], payload: unknown): TurnPayload {
+  return { type, step_index: 0, payload };
+}
+
+// ── Suite 1: Six-turn-type routing correctness ────────────────────────────────
+
+describe("GuidedTurn dispatcher — routing", () => {
+  it("single_select: renders SingleSelectTurn (question legend)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("single_select", SINGLE_SELECT_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("Which data source should we use?"),
+    ).toBeTruthy();
+  });
+
+  it("inspect_and_confirm: renders InspectAndConfirmTurn ('Looks right' button)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("inspect_and_confirm", INSPECT_AND_CONFIRM_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Looks right" }),
+    ).toBeTruthy();
+  });
+
+  it("multi_select_with_custom: renders MultiSelectWithCustomTurn (question legend)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("multi_select_with_custom", MULTI_SELECT_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("Which output formats do you need?"),
+    ).toBeTruthy();
+  });
+
+  it("schema_form: renders SchemaFormTurn ('Continue' button)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("schema_form", SCHEMA_FORM_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    // "Continue" button is present when the required field is prefilled.
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
+  });
+
+  it("propose_chain: renders ProposeChainTurn ('Accept proposal' button)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("propose_chain", PROPOSE_CHAIN_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Accept proposal" }),
+    ).toBeTruthy();
+  });
+
+  it("recipe_offer: renders RecipeOfferTurn (recipe_name h3 heading)", () => {
+    render(
+      <GuidedTurn
+        turn={makeTurn("recipe_offer", RECIPE_OFFER_PAYLOAD)}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 3, name: "csv_to_json" }),
+    ).toBeTruthy();
+  });
+});
+
+// ── Suite 2: onSubmit forwarding ──────────────────────────────────────────────
+
+describe("GuidedTurn dispatcher — onSubmit forwarding", () => {
+  it("click on option chip forwards onSubmit with the correct GuidedRespondRequest body", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <GuidedTurn
+        turn={makeTurn("single_select", SINGLE_SELECT_PAYLOAD)}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "CSV File" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      chosen: ["csv"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  });
+});
+
+// ── Suite 3: Distinctness / independence pin ──────────────────────────────────
+
+describe("GuidedTurn dispatcher — widget instance independence", () => {
+  it("two simultaneous single_select turns render independently without state bleed", () => {
+    const onSubmit1 = vi.fn();
+    const onSubmit2 = vi.fn();
+
+    const { container } = render(
+      <div>
+        <GuidedTurn
+          turn={makeTurn("single_select", {
+            question: "First turn question",
+            options: [{ id: "opt_a", label: "Option A", hint: null }],
+            allow_custom: false,
+          })}
+          onSubmit={onSubmit1}
+        />
+        <GuidedTurn
+          turn={makeTurn("single_select", {
+            question: "Second turn question",
+            options: [{ id: "opt_b", label: "Option B", hint: null }],
+            allow_custom: false,
+          })}
+          onSubmit={onSubmit2}
+        />
+      </div>,
+    );
+
+    // Both question texts rendered separately.
+    expect(screen.getByText("First turn question")).toBeTruthy();
+    expect(screen.getByText("Second turn question")).toBeTruthy();
+
+    // Both option buttons present.
+    expect(screen.getByRole("button", { name: "Option A" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Option B" })).toBeTruthy();
+
+    // No state bleed: container has two distinct guided-turn roots.
+    const turnRoots = container.querySelectorAll(".guided-turn");
+    expect(turnRoots.length).toBe(2);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/GuidedTurn.tsx
@@ -1,0 +1,117 @@
+// ============================================================================
+// GuidedTurn dispatcher
+//
+// Routes a TurnPayload to its matching leaf widget based on turn.type.
+// This component owns no state; it is a pure switch on the wire type.
+//
+// Routing table:
+//   "single_select"           -> SingleSelectTurn
+//   "inspect_and_confirm"     -> InspectAndConfirmTurn
+//   "multi_select_with_custom"-> MultiSelectWithCustomTurn
+//   "schema_form"             -> SchemaFormTurn
+//   "propose_chain"           -> ProposeChainTurn
+//   "recipe_offer"            -> RecipeOfferTurn
+//
+// Exhaustiveness assertion:
+//   The `default:` branch contains `const _exhaustive: never = turn.type`.
+//   TypeScript will refuse to compile if a new TurnType is added to
+//   guided.ts without a matching case here -- making future omissions a
+//   build failure rather than a silent runtime gap.  The throw is also
+//   retained for the runtime path (belt-and-suspenders against a JS caller
+//   that bypasses type checking).
+//
+// A/B decision -- Option A (payload: unknown, per-case casts):
+//   TurnPayload.payload remains typed as `unknown` in guided.ts.  Each case
+//   casts to the appropriate per-type interface (e.g. `as SingleSelectPayload`).
+//   Option B (discriminated union) was evaluated but rejected because the
+//   existing test fixtures in client.guided.test.ts (line 71) and
+//   sessionStore.guided.test.ts (line 54-56) use partial payload literals
+//   that do not conform to the full per-type payload shapes (missing required
+//   fields such as `question` and `allow_custom` on SingleSelectPayload).
+//   Updating those fixtures would be a non-trivial cascade across multiple
+//   test files with no correctness gain: `payload: unknown` at the store and
+//   API layer is intentional (the dispatcher is the first consumer that needs
+//   typed payloads).  Option A limits the cast surface to this one file, where
+//   a backend schema mismatch will surface immediately as a runtime render
+//   failure rather than silently producing wrong output.
+// ============================================================================
+
+import type {
+  TurnPayload,
+  GuidedRespondRequest,
+  SingleSelectPayload,
+  InspectAndConfirmPayload,
+  MultiSelectWithCustomPayload,
+  SchemaFormPayload,
+  ProposeChainPayload,
+  RecipeOfferPayload,
+} from "@/types/guided";
+import { SingleSelectTurn } from "./SingleSelectTurn";
+import { InspectAndConfirmTurn } from "./InspectAndConfirmTurn";
+import { MultiSelectWithCustomTurn } from "./MultiSelectWithCustomTurn";
+import { SchemaFormTurn } from "./SchemaFormTurn";
+import { ProposeChainTurn } from "./ProposeChainTurn";
+import { RecipeOfferTurn } from "./RecipeOfferTurn";
+
+interface GuidedTurnProps {
+  turn: TurnPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+export function GuidedTurn({ turn, onSubmit }: GuidedTurnProps) {
+  switch (turn.type) {
+    case "single_select":
+      return (
+        <SingleSelectTurn
+          payload={turn.payload as SingleSelectPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    case "inspect_and_confirm":
+      return (
+        <InspectAndConfirmTurn
+          payload={turn.payload as InspectAndConfirmPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    case "multi_select_with_custom":
+      return (
+        <MultiSelectWithCustomTurn
+          payload={turn.payload as MultiSelectWithCustomPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    case "schema_form":
+      return (
+        <SchemaFormTurn
+          payload={turn.payload as SchemaFormPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    case "propose_chain":
+      return (
+        <ProposeChainTurn
+          payload={turn.payload as ProposeChainPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    case "recipe_offer":
+      return (
+        <RecipeOfferTurn
+          payload={turn.payload as RecipeOfferPayload}
+          onSubmit={onSubmit}
+        />
+      );
+    default: {
+      // Exhaustiveness check: if a new TurnType is added to guided.ts without
+      // a matching case here, TypeScript will report a compile error on this
+      // line because `turn.type` narrows to `never` only when all cases are
+      // handled.  The throw is retained for the runtime path (JS callers,
+      // stale type declarations) per the CLAUDE.md offensive-programming rule.
+      const _exhaustive: never = turn.type;
+      throw new Error(
+        `GuidedTurn: unknown turn type: ${String(_exhaustive)} (exhaustiveness check failed)`,
+      );
+    }
+  }
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
@@ -1,0 +1,328 @@
+// ============================================================================
+// InspectAndConfirmTurn — wire-response contract regression coverage.
+//
+// Pins three wire-response contracts and one UI-state contract:
+//   "Looks right" submit  → edited_values = payload.observed verbatim,
+//                           chosen=null, custom_inputs=null, all-other-fields null
+//   "Apply edits" submit  → edited_values.columns reflects user renames/removals;
+//                           samples and warnings pass through unchanged from payload.observed
+//   Editor sub-state      → "Edit columns..." opens the editor (rename inputs + remove
+//                           buttons per column); Cancel returns to inspect view without
+//                           submitting
+//   DOM ID isolation      → two simultaneous instances with overlapping column names
+//                           produce distinct element IDs for edit-mode inputs
+//
+// The GuidedRespondRequest shape is the unit under test; these tests will
+// catch any future refactor that silently drops a null field, changes which
+// fields are populated on each submit path, or corrupts samples/warnings
+// pass-through on the edit path.  Tasks 7.4-7.7 will replicate this
+// regression-intent structure with their own wire contracts.
+// ============================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InspectAndConfirmTurn } from "./InspectAndConfirmTurn";
+import { nullResponse } from "@/test/guided-fixtures";
+import type { InspectAndConfirmPayload } from "@/types/guided";
+import type { GuidedRespondRequest } from "@/types/guided";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PAYLOAD_WITH_WARNINGS: InspectAndConfirmPayload = {
+  observed: {
+    columns: ["name", "age", "city"],
+    samples: [
+      { name: "Alice", age: 30, city: "London" },
+      { name: "Bob", age: 25, city: "Paris" },
+    ],
+    warnings: ["Column 'age' contains mixed numeric and string values."],
+  },
+};
+
+const PAYLOAD_NO_WARNINGS: InspectAndConfirmPayload = {
+  observed: {
+    columns: ["id", "value"],
+    samples: [{ id: "x1", value: 42 }],
+    warnings: [],
+  },
+};
+
+// Sparse sample: 'value' key missing from second row — valid per wire schema.
+const PAYLOAD_SPARSE: InspectAndConfirmPayload = {
+  observed: {
+    columns: ["id", "value"],
+    samples: [
+      { id: "x1", value: "hello" },
+      { id: "x2" }, // 'value' absent
+    ],
+    warnings: [],
+  },
+};
+
+// ── Inspect view: column headers ──────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — column headers", () => {
+  it("renders every column as a <th>", () => {
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+    const headers = screen.getAllByRole("columnheader");
+    const headerTexts = headers.map((h) => h.textContent);
+    expect(headerTexts).toEqual(["name", "age", "city"]);
+  });
+});
+
+// ── Inspect view: sample rows ─────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — sample rows", () => {
+  it("renders one row per sample with all cell values", () => {
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+    // Each cell value is visible in the document
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("30")).toBeTruthy();
+    expect(screen.getByText("London")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("25")).toBeTruthy();
+    expect(screen.getByText("Paris")).toBeTruthy();
+  });
+
+  it("renders two <tr> elements in <tbody> for two samples", () => {
+    const { container } = render(
+      <InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />,
+    );
+    const tbody = container.querySelector("tbody");
+    expect(tbody).toBeTruthy();
+    const rows = tbody!.querySelectorAll("tr");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("missing sample key renders as empty string (not 'undefined')", () => {
+    const { container } = render(
+      <InspectAndConfirmTurn payload={PAYLOAD_SPARSE} onSubmit={vi.fn()} />,
+    );
+    const tbody = container.querySelector("tbody");
+    expect(tbody).toBeTruthy();
+    const secondRow = tbody!.querySelectorAll("tr")[1];
+    const cells = secondRow.querySelectorAll("td");
+    expect(cells[0].textContent).toBe("x2");
+    expect(cells[1].textContent).toBe(""); // missing key → empty string
+  });
+});
+
+// ── Inspect view: warnings ────────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — warnings", () => {
+  it("renders each warning text when warnings are non-empty", () => {
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+    expect(
+      screen.getByText("Column 'age' contains mixed numeric and string values."),
+    ).toBeTruthy();
+  });
+
+  it("renders warnings in a labelled aside (accessible to screen readers)", () => {
+    const { container } = render(
+      <InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />,
+    );
+    const aside = container.querySelector("aside");
+    expect(aside).toBeTruthy();
+    expect(aside!.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("does not render a warnings region when warnings array is empty", () => {
+    const { container } = render(
+      <InspectAndConfirmTurn payload={PAYLOAD_NO_WARNINGS} onSubmit={vi.fn()} />,
+    );
+    expect(container.querySelector("aside")).toBeNull();
+  });
+});
+
+// ── Inspect view: "Looks right" submit ───────────────────────────────────────
+
+describe("InspectAndConfirmTurn — Looks right submit", () => {
+  it("clicking 'Looks right' fires onSubmit with observed shape verbatim", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Looks right" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    // nullResponse() spread comes first so edited_values is not overridden by it.
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: null,
+      custom_inputs: null,
+      edited_values: {
+        columns: ["name", "age", "city"],
+        samples: [
+          { name: "Alice", age: 30, city: "London" },
+          { name: "Bob", age: 25, city: "Paris" },
+        ],
+        warnings: ["Column 'age' contains mixed numeric and string values."],
+      },
+    });
+  });
+
+  it("nullResponse() fields are explicitly null — not undefined or omitted", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_NO_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Looks right" }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body.accepted_step_index).toBeNull();
+    expect(body.edit_step_index).toBeNull();
+    expect(body.control_signal).toBeNull();
+  });
+});
+
+// ── Editor sub-state ──────────────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — editor sub-state", () => {
+  it("'Edit columns...' button is visible in inspect view", () => {
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Edit columns..." })).toBeTruthy();
+  });
+
+  it("clicking 'Edit columns...' reveals an editable input per column", async () => {
+    const user = userEvent.setup();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    // Three columns → three text inputs
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(3);
+    expect((inputs[0] as HTMLInputElement).value).toBe("name");
+    expect((inputs[1] as HTMLInputElement).value).toBe("age");
+    expect((inputs[2] as HTMLInputElement).value).toBe("city");
+  });
+
+  it("clicking 'Edit columns...' reveals a Remove button per column", async () => {
+    const user = userEvent.setup();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    const removeBtns = screen.getAllByRole("button", { name: "Remove" });
+    expect(removeBtns).toHaveLength(3);
+  });
+
+  it("Cancel returns to inspect view without firing onSubmit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+    expect(screen.queryByRole("button", { name: "Looks right" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Back to inspect view — "Looks right" is visible again
+    expect(screen.getByRole("button", { name: "Looks right" })).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+// ── Edit submit: rename ───────────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — edit submit with rename", () => {
+  it("renaming a column and applying edits sends edited columns; samples + warnings unchanged", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    // Rename "name" → "full_name"
+    const inputs = screen.getAllByRole("textbox");
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], "full_name");
+
+    await user.click(screen.getByRole("button", { name: "Apply edits" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    // nullResponse() spread comes first so edited_values is not overridden by it.
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: null,
+      custom_inputs: null,
+      edited_values: {
+        columns: ["full_name", "age", "city"],
+        // samples and warnings pass through unchanged
+        samples: [
+          { name: "Alice", age: 30, city: "London" },
+          { name: "Bob", age: 25, city: "Paris" },
+        ],
+        warnings: ["Column 'age' contains mixed numeric and string values."],
+      },
+    });
+  });
+});
+
+// ── Edit submit: remove ───────────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — edit submit with remove", () => {
+  it("removing a column and applying edits sends columns without removed entry; samples unchanged", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    // Remove the second column ("age")
+    const removeBtns = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(removeBtns[1]);
+
+    await user.click(screen.getByRole("button", { name: "Apply edits" }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    const ev = body.edited_values as { columns: string[]; samples: unknown[]; warnings: unknown[] };
+    expect(ev.columns).toEqual(["name", "city"]);
+    // Samples pass through unchanged from payload.observed
+    expect(ev.samples).toEqual([
+      { name: "Alice", age: 30, city: "London" },
+      { name: "Bob", age: 25, city: "Paris" },
+    ]);
+  });
+});
+
+// ── DOM ID isolation (useId) ──────────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — DOM ID isolation (useId)", () => {
+  // Regression: GuidedHistory (Task 7.9) renders past turns alongside the active
+  // one. Column names ("name", "age") recur across turns. Hard-coded edit-mode
+  // input IDs (e.g. "col-0") would collide. useId() prefixes per-instance.
+  it("two simultaneous instances in edit mode have distinct input IDs for column 0", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />
+        <InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />
+      </div>,
+    );
+
+    // Click "Edit columns..." on both instances
+    const editBtns = screen.getAllByRole("button", { name: "Edit columns..." });
+    expect(editBtns).toHaveLength(2);
+    await user.click(editBtns[0]);
+    await user.click(editBtns[1]);
+
+    // Each instance renders 3 inputs; total = 6
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(6);
+
+    // The first input from each instance (column 0) must have distinct IDs
+    const id0 = inputs[0].id;
+    const id3 = inputs[3].id;
+    expect(id0).toBeTruthy();
+    expect(id3).toBeTruthy();
+    expect(id0).not.toBe(id3);
+
+    // Each ID must resolve to its own input in the DOM
+    expect(document.getElementById(id0)).toBe(inputs[0]);
+    expect(document.getElementById(id3)).toBe(inputs[3]);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
@@ -289,6 +289,65 @@ describe("InspectAndConfirmTurn — edit submit with remove", () => {
   });
 });
 
+// ── Focus management on view toggle ──────────────────────────────────────────
+// Convention for 7.5 / 7.6: when a widget toggles between view sub-states,
+// the action button that received the click is unmounted, dumping focus to
+// <body>. Widgets MUST restore focus explicitly so keyboard and screen-reader
+// users don't lose their place. These tests pin the invariant; future multi-
+// view widgets should replicate this regression pattern.
+
+describe("InspectAndConfirmTurn — focus management", () => {
+  it("entering edit mode focuses the first column input", async () => {
+    const user = userEvent.setup();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    const inputs = screen.getAllByRole("textbox");
+    expect(document.activeElement).toBe(inputs[0]);
+  });
+
+  it("cancelling from edit mode focuses the 'Edit columns...' button", async () => {
+    const user = userEvent.setup();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    const editBtn = screen.getByRole("button", { name: "Edit columns..." });
+    expect(document.activeElement).toBe(editBtn);
+  });
+
+  it("initial mount does NOT auto-focus the 'Edit columns...' button", () => {
+    // Regression: widget mounting because a new turn arrived should not
+    // steal focus from elsewhere on the page (e.g. the chat input).
+    const priorActive = document.activeElement;
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    const editBtn = screen.getByRole("button", { name: "Edit columns..." });
+    expect(document.activeElement).not.toBe(editBtn);
+    // Focus should remain where it was (typically <body> in a fresh test env).
+    expect(document.activeElement).toBe(priorActive);
+  });
+});
+
+// ── Edit-mode heading semantics ──────────────────────────────────────────────
+
+describe("InspectAndConfirmTurn — edit-mode heading", () => {
+  it("'Edit columns' is rendered as a semantic heading (h3 — under ChatPanel's h2 session title)", async () => {
+    const user = userEvent.setup();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+
+    // getByRole("heading") finds h1-h6. level=3 nests beneath ChatPanel's
+    // session title <h2> (ChatPanel.tsx:138). Screen-reader users can now
+    // navigate to the editor via heading jump.
+    const heading = screen.getByRole("heading", { level: 3, name: "Edit columns" });
+    expect(heading).toBeTruthy();
+  });
+});
+
 // ── DOM ID isolation (useId) ──────────────────────────────────────────────────
 
 describe("InspectAndConfirmTurn — DOM ID isolation (useId)", () => {

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
@@ -2,10 +2,14 @@
 // InspectAndConfirmTurn — wire-response contract regression coverage.
 //
 // Pins three wire-response contracts and one UI-state contract:
-//   "Looks right" submit  → edited_values = payload.observed verbatim,
-//                           chosen=null, custom_inputs=null, all-other-fields null
-//   "Apply edits" submit  → edited_values.columns reflects user renames/removals;
-//                           samples and warnings pass through unchanged from payload.observed
+//   "Looks right" submit  → edited_values = { columns: payload.observed.columns }
+//                           chosen=null, custom_inputs=null, all-other-fields null.
+//                           Plugin, options, samples, and warnings are held server-side
+//                           in step_1_source_intent (state_machine.SourceIntent); the
+//                           widget never round-trips them.
+//   "Apply edits" submit  → edited_values = { columns: <edited> }
+//                           Only the column list is sent; server recovers the rest
+//                           from step_1_source_intent on advance.
 //   Editor sub-state      → "Edit columns..." opens the editor (rename inputs + remove
 //                           buttons per column); Cancel returns to inspect view without
 //                           submitting
@@ -14,9 +18,10 @@
 //
 // The GuidedRespondRequest shape is the unit under test; these tests will
 // catch any future refactor that silently drops a null field, changes which
-// fields are populated on each submit path, or corrupts samples/warnings
-// pass-through on the edit path.  Tasks 7.4-7.7 will replicate this
-// regression-intent structure with their own wire contracts.
+// fields are populated on each submit path, or re-introduces round-tripping
+// of samples/warnings (which would break the narrow wire contract).
+// Tasks 7.4-7.7 replicate this regression-intent structure with their own
+// wire contracts.
 // ============================================================================
 
 import { describe, it, expect, vi } from "vitest";
@@ -138,7 +143,7 @@ describe("InspectAndConfirmTurn — warnings", () => {
 // ── Inspect view: "Looks right" submit ───────────────────────────────────────
 
 describe("InspectAndConfirmTurn — Looks right submit", () => {
-  it("clicking 'Looks right' fires onSubmit with observed shape verbatim", async () => {
+  it("clicking 'Looks right' fires onSubmit with narrow {columns} shape", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
@@ -154,13 +159,23 @@ describe("InspectAndConfirmTurn — Looks right submit", () => {
       custom_inputs: null,
       edited_values: {
         columns: ["name", "age", "city"],
-        samples: [
-          { name: "Alice", age: 30, city: "London" },
-          { name: "Bob", age: 25, city: "Paris" },
-        ],
-        warnings: ["Column 'age' contains mixed numeric and string values."],
       },
     });
+  });
+
+  it("clicking 'Looks right' does NOT include samples or warnings in edited_values", async () => {
+    // Regression: narrow wire contract — samples/warnings stay server-side in
+    // step_1_source_intent; the widget must not round-trip them.
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Looks right" }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    const ev = body.edited_values as Record<string, unknown>;
+    expect("samples" in ev).toBe(false);
+    expect("warnings" in ev).toBe(false);
   });
 
   it("nullResponse() fields are explicitly null — not undefined or omitted", async () => {
@@ -228,7 +243,7 @@ describe("InspectAndConfirmTurn — editor sub-state", () => {
 // ── Edit submit: rename ───────────────────────────────────────────────────────
 
 describe("InspectAndConfirmTurn — edit submit with rename", () => {
-  it("renaming a column and applying edits sends edited columns; samples + warnings unchanged", async () => {
+  it("renaming a column and applying edits sends narrow {columns} shape with edited names", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
@@ -251,21 +266,30 @@ describe("InspectAndConfirmTurn — edit submit with rename", () => {
       custom_inputs: null,
       edited_values: {
         columns: ["full_name", "age", "city"],
-        // samples and warnings pass through unchanged
-        samples: [
-          { name: "Alice", age: 30, city: "London" },
-          { name: "Bob", age: 25, city: "Paris" },
-        ],
-        warnings: ["Column 'age' contains mixed numeric and string values."],
       },
     });
+  });
+
+  it("applying edits does NOT include samples or warnings in edited_values", async () => {
+    // Regression: narrow wire contract — samples/warnings stay server-side.
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit columns..." }));
+    await user.click(screen.getByRole("button", { name: "Apply edits" }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    const ev = body.edited_values as Record<string, unknown>;
+    expect("samples" in ev).toBe(false);
+    expect("warnings" in ev).toBe(false);
   });
 });
 
 // ── Edit submit: remove ───────────────────────────────────────────────────────
 
 describe("InspectAndConfirmTurn — edit submit with remove", () => {
-  it("removing a column and applying edits sends columns without removed entry; samples unchanged", async () => {
+  it("removing a column and applying edits sends narrow {columns} shape without removed entry", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<InspectAndConfirmTurn payload={PAYLOAD_WITH_WARNINGS} onSubmit={onSubmit} />);
@@ -279,13 +303,10 @@ describe("InspectAndConfirmTurn — edit submit with remove", () => {
     await user.click(screen.getByRole("button", { name: "Apply edits" }));
 
     const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
-    const ev = body.edited_values as { columns: string[]; samples: unknown[]; warnings: unknown[] };
+    const ev = body.edited_values as { columns: string[] };
     expect(ev.columns).toEqual(["name", "city"]);
-    // Samples pass through unchanged from payload.observed
-    expect(ev.samples).toEqual([
-      { name: "Alice", age: 30, city: "London" },
-      { name: "Bob", age: 25, city: "Paris" },
-    ]);
+    // Narrow contract: only columns in edited_values.
+    expect(Object.keys(ev)).toEqual(["columns"]);
   });
 });
 

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.test.tsx
@@ -4,9 +4,11 @@
 // Pins three wire-response contracts and one UI-state contract:
 //   "Looks right" submit  → edited_values = { columns: payload.observed.columns }
 //                           chosen=null, custom_inputs=null, all-other-fields null.
-//                           Plugin, options, samples, and warnings are held server-side
-//                           in step_1_source_intent (state_machine.SourceIntent); the
-//                           widget never round-trips them.
+//                           Plugin, options, and sample_rows are held server-side
+//                           in step_1_source_intent (state_machine.SourceIntent);
+//                           warnings come from SourceInspectionFacts at emit time
+//                           (advisory, not stored in intent). The widget never
+//                           round-trips any of them.
 //   "Apply edits" submit  → edited_values = { columns: <edited> }
 //                           Only the column list is sent; server recovers the rest
 //                           from step_1_source_intent on advance.

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -38,8 +38,10 @@
 //
 // Warnings accessibility (convention for 7.4-7.7 widgets with passive regions):
 //   The warnings <aside> does NOT declare its own aria-live region. The parent
-//   ChatPanel wraps turn content in role="log" aria-live="polite"
-//   (see ChatPanel.tsx:161-163), which announces the warnings on widget mount.
+//   ChatPanel's guided-active branch wraps the turn surface in a
+//   `<div className="chat-panel-guided-log" role="log" aria-live="polite">`
+//   region (see `ChatPanel.tsx` — search for `chat-panel-guided-log`), which
+//   announces the warnings on widget mount.
 //   ComposingIndicator follows the same "don't nest live regions" convention
 //   (see ComposingIndicator.test.tsx:99-103). If a future maintainer removes
 //   the parent live region, warnings will be silent — the contract is documented

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -1,0 +1,221 @@
+// src/components/chat/guided/InspectAndConfirmTurn.tsx
+//
+// Guided-mode widget for the inspect_and_confirm turn type (Task 7.3).
+// Conventions inherited from SingleSelectTurn (Task 7.2 template):
+//   - Props: { payload: InspectAndConfirmPayload; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC — the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <button type="button"> (never <div onClick>)
+//   - DOM IDs prefixed with React 18 useId() — multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and element IDs would collide without per-instance scoping
+//   - Visible labels (htmlFor / button text) ARE the accessible name; do not add
+//     redundant aria-label that overrides what sighted users see
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+//
+// SHAPE NOTE (differs from chip-group widgets):
+// This widget does NOT use <fieldset>+<legend> or chip buttons.
+// It has fundamentally different semantic structure:
+//   inspect-view: <table> of columns + samples, optional warnings <aside>, two actions
+//   edit-view:    per-column rename inputs + remove buttons, cancel/apply actions
+//
+// Edit-view state:
+//   editedColumns: string[] — starts as a copy of payload.observed.columns at
+//   edit-mode entry; mutated by renames and removals; null signals not-yet-entered.
+//   Rows (samples) and warnings pass through unchanged on both submit paths.
+//
+// Wire-response shapes:
+//   "Looks right": edited_values = { columns, samples, warnings } verbatim from payload.observed
+//   "Apply edits": edited_values = { columns: <edited>, samples: payload.observed.samples, warnings: payload.observed.warnings }
+
+import { useId, useState } from "react";
+import type { GuidedRespondRequest, InspectAndConfirmPayload } from "@/types/guided";
+
+interface InspectAndConfirmTurnProps {
+  payload: InspectAndConfirmPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTurnProps) {
+  const [editing, setEditing] = useState(false);
+  // null = not yet entered edit mode; non-null = user is editing (may equal original)
+  const [editedColumns, setEditedColumns] = useState<string[] | null>(null);
+
+  // useId scopes DOM IDs per-instance so multiple InspectAndConfirmTurns rendered
+  // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
+  // produce id collisions when edit-mode input IDs recur across turns.
+  const reactId = useId();
+  const warningsId = `${reactId}-warnings`;
+  const columnInputId = (index: number) => `${reactId}-col-${index}`;
+
+  function handleLooksRight() {
+    onSubmit({
+      chosen: null,
+      edited_values: {
+        columns: payload.observed.columns,
+        samples: payload.observed.samples,
+        warnings: payload.observed.warnings,
+      },
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  function handleOpenEditor() {
+    // Copy columns array so edits don't mutate the original payload
+    setEditedColumns([...payload.observed.columns]);
+    setEditing(true);
+  }
+
+  function handleCancelEdit() {
+    setEditing(false);
+    setEditedColumns(null);
+  }
+
+  function handleRenameColumn(index: number, newName: string) {
+    setEditedColumns((prev) => {
+      if (prev === null) return prev;
+      const next = [...prev];
+      next[index] = newName;
+      return next;
+    });
+  }
+
+  function handleRemoveColumn(index: number) {
+    setEditedColumns((prev) => {
+      if (prev === null) return prev;
+      return prev.filter((_, i) => i !== index);
+    });
+  }
+
+  function handleApplyEdits() {
+    // editedColumns is non-null when editing is true; assert to satisfy TS
+    const cols = editedColumns ?? payload.observed.columns;
+    onSubmit({
+      chosen: null,
+      edited_values: {
+        columns: cols,
+        samples: payload.observed.samples,
+        warnings: payload.observed.warnings,
+      },
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  // ── Edit view ────────────────────────────────────────────────────────────────
+  if (editing) {
+    const cols = editedColumns ?? payload.observed.columns;
+    return (
+      <div className="guided-turn guided-inspect-turn">
+        <p className="guided-inspect-edit-heading">Edit columns</p>
+        <ul className="guided-inspect-editor-list">
+          {cols.map((col, index) => (
+            <li key={`${reactId}-${index}`} className="guided-inspect-editor-row">
+              <label
+                htmlFor={columnInputId(index)}
+                className="guided-inspect-editor-label"
+              >
+                Column {index + 1}
+              </label>
+              <input
+                id={columnInputId(index)}
+                type="text"
+                className="guided-inspect-editor-input"
+                value={col}
+                onChange={(e) => handleRenameColumn(index, e.target.value)}
+              />
+              <button
+                type="button"
+                className="guided-inspect-remove-btn"
+                onClick={() => handleRemoveColumn(index)}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="guided-inspect-editor-actions">
+          <button
+            type="button"
+            className="guided-inspect-cancel-btn"
+            onClick={handleCancelEdit}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="guided-inspect-apply-btn"
+            onClick={handleApplyEdits}
+          >
+            Apply edits
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Inspect view (default) ───────────────────────────────────────────────────
+  return (
+    <div className="guided-turn guided-inspect-turn">
+      <table className="guided-inspect-table">
+        <thead>
+          <tr>
+            {payload.observed.columns.map((col) => (
+              <th key={col} className="guided-inspect-th" scope="col">
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {payload.observed.samples.map((sample, rowIndex) => (
+            <tr key={rowIndex} className="guided-inspect-tr">
+              {payload.observed.columns.map((col) => (
+                <td key={col} className="guided-inspect-td">
+                  {String(sample[col] ?? "")}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {payload.observed.warnings.length > 0 && (
+        <aside
+          id={warningsId}
+          className="guided-inspect-warnings"
+          aria-label="Data warnings"
+        >
+          <ul className="guided-inspect-warnings-list">
+            {payload.observed.warnings.map((warning, i) => (
+              <li key={i} className="guided-inspect-warning-item">
+                {warning}
+              </li>
+            ))}
+          </ul>
+        </aside>
+      )}
+
+      <div className="guided-inspect-actions">
+        <button
+          type="button"
+          className="guided-inspect-confirm-btn"
+          onClick={handleLooksRight}
+        >
+          Looks right
+        </button>
+        <button
+          type="button"
+          className="guided-inspect-edit-btn"
+          onClick={handleOpenEditor}
+        >
+          Edit columns...
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -18,16 +18,38 @@
 //   inspect-view: <table> of columns + samples, optional warnings <aside>, two actions
 //   edit-view:    per-column rename inputs + remove buttons, cancel/apply actions
 //
-// Edit-view state:
-//   editedColumns: string[] — starts as a copy of payload.observed.columns at
-//   edit-mode entry; mutated by renames and removals; null signals not-yet-entered.
-//   Rows (samples) and warnings pass through unchanged on both submit paths.
+// State encoding (load-bearing for 7.5 / 7.6 multi-view widgets):
+//   editorState: { columns: string[] } | null
+//   null     → inspect view; non-null → edit view, with the edited columns array.
+//   A single nullable struct makes illegal states unrepresentable: there is no
+//   way to be in "edit mode without edited columns" or "inspect mode while
+//   holding stale edits". TS narrowing inside `editorState !== null` proves
+//   `.columns` is set, removing the need for any `?? fallback` at submit time.
+//
+// Focus management (convention for 7.5 / 7.6):
+//   Toggling between inspect <-> edit unmounts the action buttons that received
+//   the click, dumping keyboard focus to <body>. We restore focus explicitly:
+//     - Entering edit mode  → focus the first column input.
+//     - Returning to inspect view → focus the "Edit columns..." button.
+//   Refs + an effect on `editorState !== null` perform the restore after the
+//   new view mounts. The effect skips its first run (initial widget mount)
+//   because the user hasn't requested a view change — they've just received
+//   a new turn from the protocol.
+//
+// Warnings accessibility (convention for 7.4-7.7 widgets with passive regions):
+//   The warnings <aside> does NOT declare its own aria-live region. The parent
+//   ChatPanel wraps turn content in role="log" aria-live="polite"
+//   (see ChatPanel.tsx:161-163), which announces the warnings on widget mount.
+//   ComposingIndicator follows the same "don't nest live regions" convention
+//   (see ComposingIndicator.test.tsx:99-103). If a future maintainer removes
+//   the parent live region, warnings will be silent — the contract is documented
+//   here so the dependency is discoverable.
 //
 // Wire-response shapes:
 //   "Looks right": edited_values = { columns, samples, warnings } verbatim from payload.observed
 //   "Apply edits": edited_values = { columns: <edited>, samples: payload.observed.samples, warnings: payload.observed.warnings }
 
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { GuidedRespondRequest, InspectAndConfirmPayload } from "@/types/guided";
 
 interface InspectAndConfirmTurnProps {
@@ -35,10 +57,13 @@ interface InspectAndConfirmTurnProps {
   onSubmit: (body: GuidedRespondRequest) => void;
 }
 
+/** Edit-mode state. `null` = inspect view; non-null = edit view. */
+interface EditorState {
+  columns: string[];
+}
+
 export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTurnProps) {
-  const [editing, setEditing] = useState(false);
-  // null = not yet entered edit mode; non-null = user is editing (may equal original)
-  const [editedColumns, setEditedColumns] = useState<string[] | null>(null);
+  const [editorState, setEditorState] = useState<EditorState | null>(null);
 
   // useId scopes DOM IDs per-instance so multiple InspectAndConfirmTurns rendered
   // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
@@ -46,6 +71,29 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
   const reactId = useId();
   const warningsId = `${reactId}-warnings`;
   const columnInputId = (index: number) => `${reactId}-col-${index}`;
+
+  // Focus-restoration refs. Attached only in the view that owns each element.
+  const firstEditInputRef = useRef<HTMLInputElement | null>(null);
+  const editButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Skip the first effect run: on initial widget mount the user did NOT toggle
+  // the view — the widget appeared because a new turn arrived. Auto-focusing
+  // the "Edit columns..." button on mount would steal focus from wherever the
+  // user actually was (e.g. the chat input). Only restore focus on subsequent
+  // toggles, which ARE user-initiated.
+  const firstRunRef = useRef(true);
+  const isEditing = editorState !== null;
+  useEffect(() => {
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      return;
+    }
+    if (isEditing) {
+      firstEditInputRef.current?.focus();
+    } else {
+      editButtonRef.current?.focus();
+    }
+  }, [isEditing]);
 
   function handleLooksRight() {
     onSubmit({
@@ -63,39 +111,43 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
   }
 
   function handleOpenEditor() {
-    // Copy columns array so edits don't mutate the original payload
-    setEditedColumns([...payload.observed.columns]);
-    setEditing(true);
+    // Copy columns array so edits don't mutate the original payload.
+    setEditorState({ columns: [...payload.observed.columns] });
   }
 
   function handleCancelEdit() {
-    setEditing(false);
-    setEditedColumns(null);
+    setEditorState(null);
   }
 
   function handleRenameColumn(index: number, newName: string) {
-    setEditedColumns((prev) => {
+    setEditorState((prev) => {
       if (prev === null) return prev;
-      const next = [...prev];
+      const next = [...prev.columns];
       next[index] = newName;
-      return next;
+      return { columns: next };
     });
   }
 
   function handleRemoveColumn(index: number) {
-    setEditedColumns((prev) => {
+    setEditorState((prev) => {
       if (prev === null) return prev;
-      return prev.filter((_, i) => i !== index);
+      return { columns: prev.columns.filter((_, i) => i !== index) };
     });
   }
 
   function handleApplyEdits() {
-    // editedColumns is non-null when editing is true; assert to satisfy TS
-    const cols = editedColumns ?? payload.observed.columns;
+    // TS narrowing: this handler is only reachable from the edit-view branch
+    // (which guards `editorState !== null`), but the type system can't prove
+    // that across the render boundary. The early-return is an offensive
+    // invariant check — illegal state would be a code bug worth catching, not
+    // user data to coerce. Returning silently here matches the convention used
+    // in handleRenameColumn / handleRemoveColumn (state updaters fast-out when
+    // prev is null) and keeps the function total under TS narrowing.
+    if (editorState === null) return;
     onSubmit({
       chosen: null,
       edited_values: {
-        columns: cols,
+        columns: editorState.columns,
         samples: payload.observed.samples,
         warnings: payload.observed.warnings,
       },
@@ -107,13 +159,18 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
   }
 
   // ── Edit view ────────────────────────────────────────────────────────────────
-  if (editing) {
-    const cols = editedColumns ?? payload.observed.columns;
+  if (editorState !== null) {
     return (
       <div className="guided-turn guided-inspect-turn">
-        <p className="guided-inspect-edit-heading">Edit columns</p>
+        <h3 className="guided-inspect-edit-heading">Edit columns</h3>
         <ul className="guided-inspect-editor-list">
-          {cols.map((col, index) => (
+          {editorState.columns.map((col, index) => (
+            // Positional key: stable across renames (input keeps DOM identity ->
+            // focus and IME state survive typing). On removal, surviving keys
+            // shift and React reconciles the moved inputs as the same nodes with
+            // new value props — behaviourally correct under controlled inputs.
+            // Do NOT switch to `${reactId}-${col}` (content-based): renames
+            // would remount the input mid-typing and lose focus.
             <li key={`${reactId}-${index}`} className="guided-inspect-editor-row">
               <label
                 htmlFor={columnInputId(index)}
@@ -123,6 +180,7 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
               </label>
               <input
                 id={columnInputId(index)}
+                ref={index === 0 ? firstEditInputRef : null}
                 type="text"
                 className="guided-inspect-editor-input"
                 value={col}
@@ -209,6 +267,7 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
           Looks right
         </button>
         <button
+          ref={editButtonRef}
           type="button"
           className="guided-inspect-edit-btn"
           onClick={handleOpenEditor}

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -43,7 +43,8 @@
 //   region (see `ChatPanel.tsx` — search for `chat-panel-guided-log`), which
 //   announces the warnings on widget mount.
 //   ComposingIndicator follows the same "don't nest live regions" convention
-//   (see ComposingIndicator.test.tsx:99-103). If a future maintainer removes
+//   (see `ComposingIndicator.test.tsx` — the "ComposingIndicator live region
+//   scope" describe block). If a future maintainer removes
 //   the parent live region, warnings will be silent — the contract is documented
 //   here so the dependency is discoverable.
 //

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -48,9 +48,11 @@
 //   the parent live region, warnings will be silent — the contract is documented
 //   here so the dependency is discoverable.
 //
-// Wire-response shapes:
-//   "Looks right": edited_values = { columns, samples, warnings } verbatim from payload.observed
-//   "Apply edits": edited_values = { columns: <edited>, samples: payload.observed.samples, warnings: payload.observed.warnings }
+// Wire-response shapes (narrow contract — state_machine.SourceIntent holds the rest server-side):
+//   "Looks right": edited_values = { columns: payload.observed.columns }
+//   "Apply edits": edited_values = { columns: <edited> }
+//   plugin, options, samples, and warnings are held in step_1_source_intent on the server;
+//   the widget never sends them back. The server recovers them from intent on advance.
 
 import { useEffect, useId, useRef, useState } from "react";
 import type { GuidedRespondRequest, InspectAndConfirmPayload } from "@/types/guided";
@@ -103,8 +105,6 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
       chosen: null,
       edited_values: {
         columns: payload.observed.columns,
-        samples: payload.observed.samples,
-        warnings: payload.observed.warnings,
       },
       custom_inputs: null,
       accepted_step_index: null,
@@ -151,8 +151,6 @@ export function InspectAndConfirmTurn({ payload, onSubmit }: InspectAndConfirmTu
       chosen: null,
       edited_values: {
         columns: editorState.columns,
-        samples: payload.observed.samples,
-        warnings: payload.observed.warnings,
       },
       custom_inputs: null,
       accepted_step_index: null,

--- a/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/InspectAndConfirmTurn.tsx
@@ -51,8 +51,9 @@
 // Wire-response shapes (narrow contract — state_machine.SourceIntent holds the rest server-side):
 //   "Looks right": edited_values = { columns: payload.observed.columns }
 //   "Apply edits": edited_values = { columns: <edited> }
-//   plugin, options, samples, and warnings are held in step_1_source_intent on the server;
+//   plugin, options, and sample_rows are held in step_1_source_intent on the server;
 //   the widget never sends them back. The server recovers them from intent on advance.
+//   warnings come from SourceInspectionFacts at emit time (advisory only, not stored in intent).
 
 import { useEffect, useId, useRef, useState } from "react";
 import type { GuidedRespondRequest, InspectAndConfirmPayload } from "@/types/guided";

--- a/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.test.tsx
@@ -1,0 +1,490 @@
+// ============================================================================
+// MultiSelectWithCustomTurn — wire-response contract regression coverage.
+//
+// Pins TWO contracts (the third — escape-button submission — is intentionally
+// deferred from Task 7.4; see NOTE in MultiSelectWithCustomTurn.tsx):
+//   1. Chip-toggle wire shape on Continue:
+//        chosen=[<sorted selected ids>], custom_inputs=[<added customs>],
+//        all four other fields explicitly null.
+//   2. Custom-add wire shape on Continue:
+//        custom_inputs reflects added strings in addition order, including
+//        when chosen is empty (custom_inputs=[..], chosen=[]).
+//
+// Continue is disabled when both chosen and customs are empty (the widget's
+// only way to surface "the user has asserted nothing" — preventing an empty
+// submit that would crash the backend's required-field reads).
+//
+// Custom-add discipline:
+//   - Empty / whitespace-only input → Add disabled.
+//   - Duplicate of an existing custom OR an option ID → Add disabled.
+//
+// useId() pin: two simultaneous instances must have distinct element-level IDs
+// (custom-input id, hint ids) so GuidedHistory replay (Task 7.9) does not
+// produce DOM id collisions.
+//
+// Escape branch coverage is INTENTIONALLY OUT OF SCOPE here — see the NOTE
+// in MultiSelectWithCustomTurn.tsx. Adding tests that pin the escape wire
+// would lock in a contract neither side currently agrees on.
+//
+// The GuidedRespondRequest shape is the unit under test; these tests will
+// catch any future refactor that silently drops a null field, swaps chosen
+// and custom_inputs, or relaxes the disabled-on-empty Continue invariant.
+// ============================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MultiSelectWithCustomTurn } from "./MultiSelectWithCustomTurn";
+import { nullResponse } from "@/test/guided-fixtures";
+import type {
+  GuidedRespondRequest,
+  MultiSelectWithCustomPayload,
+} from "@/types/guided";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PAYLOAD_THREE_OPTIONS_TWO_DEFAULT: MultiSelectWithCustomPayload = {
+  question: "Which fields must appear in the output?",
+  options: [
+    { id: "name", label: "name", hint: null },
+    { id: "price", label: "price", hint: "Numeric, currency-agnostic" },
+    { id: "qty", label: "qty", hint: null },
+  ],
+  default_chosen: ["name", "price"],
+  escape_label: "Let source decide (pass all fields through)",
+};
+
+const PAYLOAD_NO_DEFAULT_NO_ESCAPE: MultiSelectWithCustomPayload = {
+  question: "Pick the fields you want.",
+  options: [
+    { id: "alpha", label: "alpha", hint: null },
+    { id: "beta", label: "beta", hint: null },
+  ],
+  default_chosen: [],
+  escape_label: null,
+};
+
+const PAYLOAD_WITH_ESCAPE_LABEL: MultiSelectWithCustomPayload = {
+  question: "Pick fields.",
+  options: [{ id: "x", label: "x", hint: null }],
+  default_chosen: [],
+  escape_label: "Let source decide",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MultiSelectWithCustomTurn — initial render", () => {
+  it("renders the question text inside a fieldset legend", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("Which fields must appear in the output?"),
+    ).toBeTruthy();
+  });
+
+  it("renders one toggle button per option", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "name" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "price" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "qty" })).toBeTruthy();
+  });
+
+  it("chips for IDs in default_chosen are aria-pressed=true; others are aria-pressed=false", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "name" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: "price" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "qty" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("renders option hint text and wires aria-describedby for non-null hints only", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Numeric, currency-agnostic")).toBeTruthy();
+
+    const priceBtn = screen.getByRole("button", { name: "price" });
+    const describedBy = priceBtn.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const hintEl = document.getElementById(describedBy!);
+    expect(hintEl).toBeTruthy();
+    expect(hintEl!.textContent).toBe("Numeric, currency-agnostic");
+
+    const nameBtn = screen.getByRole("button", { name: "name" });
+    expect(nameBtn.getAttribute("aria-describedby")).toBeNull();
+  });
+});
+
+describe("MultiSelectWithCustomTurn — chip toggle behaviour", () => {
+  it("clicking an unpressed chip toggles it pressed", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const qtyBtn = screen.getByRole("button", { name: "qty" });
+    expect(qtyBtn.getAttribute("aria-pressed")).toBe("false");
+    await user.click(qtyBtn);
+    expect(qtyBtn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("clicking a pressed chip toggles it unpressed", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const nameBtn = screen.getByRole("button", { name: "name" });
+    expect(nameBtn.getAttribute("aria-pressed")).toBe("true");
+    await user.click(nameBtn);
+    expect(nameBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+});
+
+describe("MultiSelectWithCustomTurn — Continue submit (chip-only)", () => {
+  it("Continue with default selection submits chosen=[<defaults sorted>], custom_inputs=[]", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={onSubmit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: ["name", "price"],
+      custom_inputs: [],
+    });
+  });
+
+  it("toggle adds and removes are reflected in chosen on Continue (stable sort over option order)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Untoggle "name" (was a default), toggle "qty" on. Expected final
+    // chosen = ["price", "qty"] in option order.
+    await user.click(screen.getByRole("button", { name: "name" }));
+    await user.click(screen.getByRole("button", { name: "qty" }));
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: ["price", "qty"],
+      custom_inputs: [],
+    });
+  });
+});
+
+describe("MultiSelectWithCustomTurn — custom-add", () => {
+  it("Add button is disabled while the custom input is empty", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+    expect(addBtn).toHaveProperty("disabled", true);
+  });
+
+  it("Add button is disabled when input contains only whitespace", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "   ");
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+    expect(addBtn).toHaveProperty("disabled", true);
+  });
+
+  it("Add button is disabled when input duplicates an existing option ID", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "alpha");
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+    expect(addBtn).toHaveProperty("disabled", true);
+  });
+
+  it("Add button is disabled when input duplicates an already-added custom", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "extra");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    // After add: input cleared, custom chip rendered.
+    expect(screen.getByText("extra")).toBeTruthy();
+    // Re-typing the same value must keep Add disabled.
+    await user.type(input, "extra");
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+    expect(addBtn).toHaveProperty("disabled", true);
+  });
+
+  it("typing then pressing Enter appends the trimmed value to customs", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "  gamma  {Enter}");
+    expect(screen.getByText("gamma")).toBeTruthy();
+  });
+
+  it("clicking the X on a custom chip removes it from customs", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "delta");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    expect(screen.getByText("delta")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /remove delta/i }));
+    expect(screen.queryByText("delta")).toBeNull();
+  });
+});
+
+describe("MultiSelectWithCustomTurn — Continue submit (with customs)", () => {
+  it("Continue submits custom_inputs in addition order alongside chosen", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "first_extra");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    await user.type(input, "second_extra");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: ["name", "price"],
+      custom_inputs: ["first_extra", "second_extra"],
+    });
+  });
+
+  it("Continue submits with chosen=[] when only customs are provided", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "only_custom");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      ...nullResponse(),
+      chosen: [],
+      custom_inputs: ["only_custom"],
+    });
+  });
+});
+
+describe("MultiSelectWithCustomTurn — Continue disabled on empty assertion", () => {
+  it("Continue is disabled when both chosen and customs are empty", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toHaveProperty("disabled", true);
+  });
+
+  it("clicking the disabled Continue button does NOT fire onSubmit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={onSubmit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("Continue becomes enabled once a chip is toggled on", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toHaveProperty("disabled", true);
+    await user.click(screen.getByRole("button", { name: "alpha" }));
+    expect(continueBtn).toHaveProperty("disabled", false);
+  });
+
+  it("Continue becomes enabled once a custom is added", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toHaveProperty("disabled", true);
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    await user.type(input, "extra");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    expect(continueBtn).toHaveProperty("disabled", false);
+  });
+});
+
+describe("MultiSelectWithCustomTurn — escape_label NOT rendered (Task 7.4 deferral)", () => {
+  // The escape-button rendering is intentionally deferred from Task 7.4
+  // pending a cross-layer wire-shape decision. These pin the deferral so a
+  // future contributor doesn't "helpfully" add the button without doing the
+  // contract work. See NOTE in MultiSelectWithCustomTurn.tsx.
+  it("does NOT render an escape button when escape_label is non-null", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_WITH_ESCAPE_LABEL}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/let source decide/i)).toBeNull();
+  });
+
+  it("does NOT render an escape button when escape_label is null", () => {
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/let source decide/i)).toBeNull();
+  });
+});
+
+describe("MultiSelectWithCustomTurn — DOM ID isolation (useId)", () => {
+  // Regression: GuidedHistory (Task 7.9) renders past turns alongside the
+  // active one; option IDs and custom-input labels recur across turns.
+  // Hard-coded element IDs would collide. useId() prefixes per-instance.
+  it("two simultaneous instances with the same option ids have distinct hint IDs", () => {
+    render(
+      <div>
+        <MultiSelectWithCustomTurn
+          payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+          onSubmit={vi.fn()}
+        />
+        <MultiSelectWithCustomTurn
+          payload={PAYLOAD_THREE_OPTIONS_TWO_DEFAULT}
+          onSubmit={vi.fn()}
+        />
+      </div>,
+    );
+    const priceBtns = screen.getAllByRole("button", { name: "price" });
+    expect(priceBtns).toHaveLength(2);
+    const id0 = priceBtns[0].getAttribute("aria-describedby");
+    const id1 = priceBtns[1].getAttribute("aria-describedby");
+    expect(id0).toBeTruthy();
+    expect(id1).toBeTruthy();
+    expect(id0).not.toBe(id1);
+    expect(document.getElementById(id0!)).toBeTruthy();
+    expect(document.getElementById(id1!)).toBeTruthy();
+  });
+
+  it("two simultaneous instances have distinct custom-input IDs", () => {
+    render(
+      <div>
+        <MultiSelectWithCustomTurn
+          payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+          onSubmit={vi.fn()}
+        />
+        <MultiSelectWithCustomTurn
+          payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+          onSubmit={vi.fn()}
+        />
+      </div>,
+    );
+    const inputs = screen.getAllByRole("textbox", { name: /custom field/i });
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].id).not.toBe(inputs[1].id);
+    expect(inputs[0].id).toBeTruthy();
+    expect(inputs[1].id).toBeTruthy();
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.test.tsx
@@ -19,8 +19,14 @@
 //   - Duplicate of an existing custom OR an option ID → Add disabled.
 //
 // useId() pin: two simultaneous instances must have distinct element-level IDs
-// (custom-input id, hint ids) so GuidedHistory replay (Task 7.9) does not
-// produce DOM id collisions.
+// AND distinct DOM nodes (the resolved-node assertion catches the
+// duplicate-ID failure mode that string-distinctness alone would miss) so
+// GuidedHistory replay (Task 7.9) does not produce DOM id collisions.
+//
+// Focus restoration on custom-chip removal (WCAG 2.4.3): pinned by the
+// keyboard-transition tests at the bottom of this file. The convention
+// matches InspectAndConfirmTurn (Task 7.3) — refs + useEffect + firstRunRef
+// to skip initial mount. Future remove-path widgets should copy this.
 //
 // Escape branch coverage is INTENTIONALLY OUT OF SCOPE here — see the NOTE
 // in MultiSelectWithCustomTurn.tsx. Adding tests that pin the escape wire
@@ -444,7 +450,15 @@ describe("MultiSelectWithCustomTurn — DOM ID isolation (useId)", () => {
   // Regression: GuidedHistory (Task 7.9) renders past turns alongside the
   // active one; option IDs and custom-input labels recur across turns.
   // Hard-coded element IDs would collide. useId() prefixes per-instance.
-  it("two simultaneous instances with the same option ids have distinct hint IDs", () => {
+  //
+  // Each test below pins NODE distinctness (not just string distinctness).
+  // A buggy implementation that emitted two elements with the SAME id
+  // would still pass `id0 !== id1` if the IDs were assigned via different
+  // code paths, OR would silently produce duplicate IDs that
+  // getElementById resolves to the same node (both `.toBeTruthy()` pass
+  // because both queries return the same truthy node). The not.toBe()
+  // comparison on the resolved nodes catches both failure modes.
+  it("two simultaneous instances with the same option ids have distinct hint IDs and nodes", () => {
     render(
       <div>
         <MultiSelectWithCustomTurn
@@ -464,11 +478,14 @@ describe("MultiSelectWithCustomTurn — DOM ID isolation (useId)", () => {
     expect(id0).toBeTruthy();
     expect(id1).toBeTruthy();
     expect(id0).not.toBe(id1);
-    expect(document.getElementById(id0!)).toBeTruthy();
-    expect(document.getElementById(id1!)).toBeTruthy();
+    const node0 = document.getElementById(id0!);
+    const node1 = document.getElementById(id1!);
+    expect(node0).toBeTruthy();
+    expect(node1).toBeTruthy();
+    expect(node0).not.toBe(node1);
   });
 
-  it("two simultaneous instances have distinct custom-input IDs", () => {
+  it("two simultaneous instances have distinct custom-input IDs and nodes", () => {
     render(
       <div>
         <MultiSelectWithCustomTurn
@@ -486,5 +503,93 @@ describe("MultiSelectWithCustomTurn — DOM ID isolation (useId)", () => {
     expect(inputs[0].id).not.toBe(inputs[1].id);
     expect(inputs[0].id).toBeTruthy();
     expect(inputs[1].id).toBeTruthy();
+    expect(document.getElementById(inputs[0].id)).not.toBe(
+      document.getElementById(inputs[1].id),
+    );
+  });
+});
+
+describe("MultiSelectWithCustomTurn — focus restoration on custom-chip removal (WCAG 2.4.3)", () => {
+  // Removing a custom chip via the X button unmounts the focused element.
+  // Without explicit focus restoration, focus drops to <body> and the
+  // keyboard user loses their place. These tests pin the convention so
+  // future remove-path widgets (or refactors here) maintain it.
+  it("removing a non-last custom moves focus to the X button of the chip in the same slot", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+
+    await user.type(input, "alpha_custom");
+    await user.click(addBtn);
+    await user.type(input, "beta_custom");
+    await user.click(addBtn);
+
+    // Remove "alpha_custom" (the first chip). The chip that was at index 1
+    // ("beta_custom") shifts into index 0 — its X button should receive focus.
+    await user.click(
+      screen.getByRole("button", { name: /remove alpha_custom/i }),
+    );
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /remove beta_custom/i }),
+    );
+  });
+
+  it("removing the last remaining custom moves focus to the custom-input field", async () => {
+    // The input is the empty-list focus target rather than the Add button
+    // because Add is disabled while the input is empty (focusing a disabled
+    // button is a no-op). The input is always focusable and is the entry
+    // point for adding more — sensible target either way.
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+
+    await user.type(input, "lonely_custom");
+    await user.click(addBtn);
+
+    await user.click(
+      screen.getByRole("button", { name: /remove lonely_custom/i }),
+    );
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("removing the trailing chip in a list of two moves focus to the new last chip's X button", async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelectWithCustomTurn
+        payload={PAYLOAD_NO_DEFAULT_NO_ESCAPE}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /custom field/i });
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+
+    await user.type(input, "first_added");
+    await user.click(addBtn);
+    await user.type(input, "second_added");
+    await user.click(addBtn);
+
+    // Remove the chip at index 1 (the trailing one). Focus should fall back
+    // to the X button of the new last chip (now "first_added" at index 0).
+    await user.click(
+      screen.getByRole("button", { name: /remove second_added/i }),
+    );
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /remove first_added/i }),
+    );
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
@@ -65,20 +65,24 @@
 //   firstRunRef skips the initial mount so we don't steal focus from
 //   wherever the user actually was when the widget first appeared.
 //
+// SUBMIT WIRE SHAPE:
+//   handleContinue emits:
+//     { chosen: [required field names in option order],
+//       custom_inputs: [...custom field names],
+//       edited_values: null,
+//       accepted_step_index: null, edit_step_index: null, control_signal: null }
+//   The backend's _advance_step_2 reads chosen + custom_inputs and combines them
+//   with the sink plugin + options stored in GuidedSession.step_2_sink_intent
+//   (persisted by the preceding SCHEMA_FORM dispatcher) to construct
+//   SinkOutputResolved. edited_values is null — the widget does not own the
+//   plugin context. Resolved by elspeth-5e905f3c9d.
+//
 // NOTE: payload.escape_label is intentionally NOT rendered in this version.
-// The wire shape for the escape submission requires a cross-layer protocol
-// decision (frontend wire shape + backend handler branch in
-// state_machine.py:_advance_step_2 — which currently reads
-// edited_values["outputs"] unconditionally). The plan describes
-// `{edited_values: {schema_mode: "observed", required_fields: []}}` but
-// that contradicts the only backend read site, and this widget owns
-// neither the plugin name nor the options needed to construct the full
-// outputs[] array. Do NOT add the escape button to this widget without
-// resolving the contract first. The deferral is pinned by tests
+// The escape submission requires a separate protocol decision (what required_fields
+// should be when the user skips field selection). Do NOT add the escape button
+// without resolving that contract first. The deferral is pinned by tests
 // (escape-button-not-rendered for both null and non-null escape_label)
 // so a future contributor can't quietly re-add it.
-//
-// Tracker: filigree elspeth-5e905f3c9d
 
 import { useEffect, useId, useRef, useState } from "react";
 import type {

--- a/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
@@ -44,6 +44,27 @@
 //   The disable predicate is the same as the silent-no-op early-return on
 //   Enter — a single source of truth for "can this be added?".
 //
+// FOCUS MANAGEMENT ON CUSTOM-CHIP REMOVAL (WCAG 2.4.3 Focus Order):
+//   Removing a custom chip via Enter on the X button unmounts the focused
+//   element; the browser falls back to <body> and the keyboard user loses
+//   their place. We restore focus explicitly using the same ref + effect +
+//   firstRunRef pattern as InspectAndConfirmTurn (Task 7.3):
+//     - Removing chip at index i, with N customs remaining post-removal:
+//         * N > 0 and i < N  → focus the X button now at index i (the next
+//           chip in the original order takes the removed slot).
+//         * N > 0 and i == N → focus the X button at index N-1 (we removed
+//           the last chip; fall back one slot).
+//         * N == 0           → focus the custom-input field (list is now
+//           empty; the input is the entry point for adding more, and
+//           unlike the Add button it is always focusable — the Add button
+//           is disabled while the input is empty/whitespace, and focusing
+//           a disabled button is a no-op in HTML).
+//   The focus target is decided synchronously inside the click handler
+//   (BEFORE the state update fires) and stored in a ref. The effect, keyed
+//   on customs.length, reads the ref after the post-removal render commits.
+//   firstRunRef skips the initial mount so we don't steal focus from
+//   wherever the user actually was when the widget first appeared.
+//
 // NOTE: payload.escape_label is intentionally NOT rendered in this version.
 // The wire shape for the escape submission requires a cross-layer protocol
 // decision (frontend wire shape + backend handler branch in
@@ -52,12 +73,14 @@
 // `{edited_values: {schema_mode: "observed", required_fields: []}}` but
 // that contradicts the only backend read site, and this widget owns
 // neither the plugin name nor the options needed to construct the full
-// outputs[] array. Tracked as a follow-up; do NOT add the escape button
-// to this widget without resolving the contract first. The deferral is
-// pinned by tests (escape-button-not-rendered for both null and non-null
-// escape_label) so a future contributor can't quietly re-add it.
+// outputs[] array. Do NOT add the escape button to this widget without
+// resolving the contract first. The deferral is pinned by tests
+// (escape-button-not-rendered for both null and non-null escape_label)
+// so a future contributor can't quietly re-add it.
+//
+// Tracker: filigree elspeth-5e905f3c9d
 
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type {
   GuidedRespondRequest,
   MultiSelectWithCustomPayload,
@@ -91,6 +114,44 @@ export function MultiSelectWithCustomTurn({
   const reactId = useId();
   const customInputId = `${reactId}-custom-input`;
   const hintIdFor = (optionId: string) => `${reactId}-hint-${optionId}`;
+
+  // Focus-restoration refs for the custom-chip remove path (WCAG 2.4.3).
+  // The X buttons live inside .map() so we collect them into a ref-Map keyed
+  // by the custom value (which is unique within the list — the duplicate
+  // guard in canAddPending enforces it).  The custom-input ref is captured
+  // separately and used as the fallback when the list becomes empty (the
+  // Add button is disabled while pending is empty, so it can't be focused).
+  const removeBtnRefs = useRef<Map<string, HTMLButtonElement | null>>(
+    new Map(),
+  );
+  const customInputRef = useRef<HTMLInputElement | null>(null);
+
+  // After a remove, this ref holds either:
+  //   - a string (the value of the surviving chip whose X should receive focus)
+  //   - "__input__" (focus the custom-input; list is now empty)
+  //   - null        (no pending focus restoration; do nothing)
+  // The effect below consumes and clears it on each customs.length change.
+  const pendingFocusTarget = useRef<string | "__input__" | null>(null);
+
+  // Skip the first effect run: on initial widget mount the user did NOT
+  // remove anything — the widget appeared because a new turn arrived.
+  // Auto-focusing on mount would steal focus from wherever the user
+  // actually was. Same convention as InspectAndConfirmTurn (Task 7.3).
+  const firstRunRef = useRef(true);
+  useEffect(() => {
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      return;
+    }
+    const target = pendingFocusTarget.current;
+    pendingFocusTarget.current = null;
+    if (target === null) return;
+    if (target === "__input__") {
+      customInputRef.current?.focus();
+      return;
+    }
+    removeBtnRefs.current.get(target)?.focus();
+  }, [selection.customs.length]);
 
   // Stable order: option-array order. The wire-response test pins this so a
   // future "sort alphabetically" refactor would visibly fail.
@@ -132,10 +193,33 @@ export function MultiSelectWithCustomTurn({
   }
 
   function handleRemoveCustom(value: string) {
-    setSelection((prev) => ({
-      ...prev,
-      customs: prev.customs.filter((c) => c !== value),
-    }));
+    // Decide focus target BEFORE the state update fires so the decision
+    // sees the pre-removal indices. After the removal:
+    //   - If anything remains and `value` was NOT the last chip, the chip
+    //     that was at index+1 takes the removed slot — focus its X button
+    //     (look up by the value of the surviving chip at the same index).
+    //   - If `value` WAS the last chip and others remain, focus the X
+    //     button of the new last chip (one slot back).
+    //   - If nothing remains, focus the Add button.
+    setSelection((prev) => {
+      const idx = prev.customs.indexOf(value);
+      // idx === -1 should be unreachable — the X button only renders for
+      // values currently in customs, and React unmounts the button when
+      // the value disappears. If it ever happens, no-op (safer than
+      // crashing a UI thread on a stale event).
+      if (idx === -1) return prev;
+      const next = prev.customs.filter((_, i) => i !== idx);
+      if (next.length === 0) {
+        pendingFocusTarget.current = "__input__";
+      } else if (idx < next.length) {
+        // The chip formerly at idx+1 now sits at idx.
+        pendingFocusTarget.current = next[idx];
+      } else {
+        // Removed the last chip; fall back to the new last chip.
+        pendingFocusTarget.current = next[next.length - 1];
+      }
+      return { ...prev, customs: next };
+    });
   }
 
   function handleContinue() {
@@ -199,6 +283,7 @@ export function MultiSelectWithCustomTurn({
           Custom field
         </label>
         <input
+          ref={customInputRef}
           id={customInputId}
           type="text"
           className="guided-custom-input"
@@ -234,6 +319,17 @@ export function MultiSelectWithCustomTurn({
             <li key={value} className="guided-multi-custom-chip">
               <span className="guided-multi-custom-chip-label">{value}</span>
               <button
+                ref={(el) => {
+                  // Keep the ref-Map in sync with mount/unmount lifecycle.
+                  // React invokes the callback with `el` on mount and `null`
+                  // on unmount; treating null as a delete prevents stale
+                  // entries pointing at detached nodes.
+                  if (el === null) {
+                    removeBtnRefs.current.delete(value);
+                  } else {
+                    removeBtnRefs.current.set(value, el);
+                  }
+                }}
                 type="button"
                 className="guided-multi-custom-remove-btn"
                 onClick={() => handleRemoveCustom(value)}

--- a/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/MultiSelectWithCustomTurn.tsx
@@ -1,0 +1,266 @@
+// src/components/chat/guided/MultiSelectWithCustomTurn.tsx
+//
+// Guided-mode widget for the multi_select_with_custom turn type (Task 7.4).
+// Conventions inherited from SingleSelectTurn (Task 7.2 template) and
+// InspectAndConfirmTurn (Task 7.3):
+//   - Props: { payload: MultiSelectWithCustomPayload; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC — the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <fieldset>+<legend> for the chip group (per Task 7.2 SHAPE NOTE — chip-group
+//     family widgets share the structure)
+//   - <button type="button"> (never <div onClick>)
+//   - DOM IDs prefixed with React 18 useId() — multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and option IDs recur across turns
+//   - Visible labels (htmlFor / button text) ARE the accessible name; do not add
+//     redundant aria-label that overrides what sighted users see
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+//   - Reuses guided-chip-btn / guided-chip-group styles per the App.css convention
+//
+// State encoding (single nullable-free struct per Task 7.3 convention):
+//   selection: { chosen: Set<string>; customs: string[]; pending: string }
+//   - chosen: currently-pressed option IDs (initialised from payload.default_chosen)
+//   - customs: free-added custom strings, in addition order
+//   - pending: controlled value of the custom-input box
+//   The struct lives even when "empty" (no Set/list view toggle to encode);
+//   updaters return new objects to keep React's referential equality contract.
+//
+// CHIP TOGGLE PATTERN:
+//   Chips use aria-pressed (toggle-button semantics), NOT aria-selected
+//   (which is for listbox/option semantics) and NOT <input type="checkbox">
+//   styled as buttons (less consistent across screen readers). aria-pressed
+//   is the canonical accessibility pattern for two-state toggle buttons.
+//
+// CONTINUE INVARIANT:
+//   The widget enforces "user must assert at least one field" by disabling
+//   the Continue button while chosen is empty AND customs is empty. This
+//   prevents an empty submit that the backend would reject (Step 2's
+//   required-field reads cannot be satisfied by a zero-output sink). The
+//   negative branch is pinned in the test suite — clicking the disabled
+//   button does NOT fire onSubmit.
+//
+// CUSTOM-ADD DUPLICATE GUARD:
+//   The Add button is disabled when the trimmed input is empty/whitespace
+//   OR matches an existing option ID OR matches an already-added custom.
+//   The disable predicate is the same as the silent-no-op early-return on
+//   Enter — a single source of truth for "can this be added?".
+//
+// NOTE: payload.escape_label is intentionally NOT rendered in this version.
+// The wire shape for the escape submission requires a cross-layer protocol
+// decision (frontend wire shape + backend handler branch in
+// state_machine.py:_advance_step_2 — which currently reads
+// edited_values["outputs"] unconditionally). The plan describes
+// `{edited_values: {schema_mode: "observed", required_fields: []}}` but
+// that contradicts the only backend read site, and this widget owns
+// neither the plugin name nor the options needed to construct the full
+// outputs[] array. Tracked as a follow-up; do NOT add the escape button
+// to this widget without resolving the contract first. The deferral is
+// pinned by tests (escape-button-not-rendered for both null and non-null
+// escape_label) so a future contributor can't quietly re-add it.
+
+import { useId, useState } from "react";
+import type {
+  GuidedRespondRequest,
+  MultiSelectWithCustomPayload,
+} from "@/types/guided";
+
+interface MultiSelectWithCustomTurnProps {
+  payload: MultiSelectWithCustomPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+interface Selection {
+  chosen: Set<string>;
+  customs: string[];
+  pending: string;
+}
+
+export function MultiSelectWithCustomTurn({
+  payload,
+  onSubmit,
+}: MultiSelectWithCustomTurnProps) {
+  const [selection, setSelection] = useState<Selection>(() => ({
+    chosen: new Set(payload.default_chosen),
+    customs: [],
+    pending: "",
+  }));
+
+  // useId scopes DOM IDs per-instance so multiple MultiSelectWithCustomTurns
+  // rendered simultaneously (e.g. active turn + GuidedHistory replay in
+  // Task 7.9) don't produce id collisions when option IDs ("name", "price")
+  // recur across turns.
+  const reactId = useId();
+  const customInputId = `${reactId}-custom-input`;
+  const hintIdFor = (optionId: string) => `${reactId}-hint-${optionId}`;
+
+  // Stable order: option-array order. The wire-response test pins this so a
+  // future "sort alphabetically" refactor would visibly fail.
+  const chosenInOptionOrder = (chosen: Set<string>): string[] =>
+    payload.options.filter((opt) => chosen.has(opt.id)).map((opt) => opt.id);
+
+  function toggleOption(optionId: string) {
+    setSelection((prev) => {
+      const next = new Set(prev.chosen);
+      if (next.has(optionId)) {
+        next.delete(optionId);
+      } else {
+        next.add(optionId);
+      }
+      return { ...prev, chosen: next };
+    });
+  }
+
+  // Single source of truth for "can the current pending value be added?".
+  // Used both as the Add button's disabled predicate AND as the early-return
+  // guard inside handleAddCustom — they MUST agree.
+  function canAddPending(s: Selection): boolean {
+    const trimmed = s.pending.trim();
+    if (!trimmed) return false;
+    if (s.customs.includes(trimmed)) return false;
+    if (payload.options.some((opt) => opt.id === trimmed)) return false;
+    return true;
+  }
+
+  function handleAddCustom() {
+    setSelection((prev) => {
+      if (!canAddPending(prev)) return prev;
+      return {
+        ...prev,
+        customs: [...prev.customs, prev.pending.trim()],
+        pending: "",
+      };
+    });
+  }
+
+  function handleRemoveCustom(value: string) {
+    setSelection((prev) => ({
+      ...prev,
+      customs: prev.customs.filter((c) => c !== value),
+    }));
+  }
+
+  function handleContinue() {
+    // Disabled-button guard: this handler is only reachable when the Continue
+    // button is enabled, but the type system can't prove that across the
+    // render boundary. Narrow because TS doesn't see the cross-handler
+    // invariant — illegal state would be a code bug worth catching, not user
+    // data to coerce. Returning silently here matches the same predicate as
+    // the disabled attribute, deduplicated.
+    if (selection.chosen.size === 0 && selection.customs.length === 0) return;
+    onSubmit({
+      chosen: chosenInOptionOrder(selection.chosen),
+      custom_inputs: [...selection.customs],
+      edited_values: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  const continueDisabled =
+    selection.chosen.size === 0 && selection.customs.length === 0;
+  const addDisabled = !canAddPending(selection);
+
+  return (
+    <div className="guided-turn guided-multi-select">
+      <fieldset className="guided-chip-fieldset">
+        <legend className="guided-chip-legend">{payload.question}</legend>
+        {/* No role="group" on the inner div — <fieldset> already provides
+            group semantics; duplicating creates two nested groups in the
+            accessibility tree. */}
+        <div className="guided-chip-group">
+          {payload.options.map((option) => {
+            const hintId =
+              option.hint !== null ? hintIdFor(option.id) : undefined;
+            const pressed = selection.chosen.has(option.id);
+            return (
+              <div key={option.id} className="guided-chip-item">
+                <button
+                  type="button"
+                  className="guided-chip-btn"
+                  aria-pressed={pressed}
+                  aria-describedby={hintId}
+                  onClick={() => toggleOption(option.id)}
+                >
+                  {option.label}
+                </button>
+                {option.hint !== null && (
+                  <p id={hintId} className="guided-chip-hint">
+                    {option.hint}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <div className="guided-multi-custom-row">
+        <label htmlFor={customInputId} className="guided-custom-label">
+          Custom field
+        </label>
+        <input
+          id={customInputId}
+          type="text"
+          className="guided-custom-input"
+          value={selection.pending}
+          onChange={(e) =>
+            setSelection((prev) => ({ ...prev, pending: e.target.value }))
+          }
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // preventDefault so a future <form> wrapper doesn't double-submit.
+              // handleAddCustom already no-ops on a non-addable pending —
+              // disabled-button + no-op early-return are the same predicate,
+              // deduplicated.
+              e.preventDefault();
+              handleAddCustom();
+            }
+          }}
+          placeholder="Add a field name..."
+        />
+        <button
+          type="button"
+          className="guided-custom-submit-btn"
+          onClick={handleAddCustom}
+          disabled={addDisabled}
+        >
+          Add
+        </button>
+      </div>
+
+      {selection.customs.length > 0 && (
+        <ul className="guided-multi-custom-list">
+          {selection.customs.map((value) => (
+            <li key={value} className="guided-multi-custom-chip">
+              <span className="guided-multi-custom-chip-label">{value}</span>
+              <button
+                type="button"
+                className="guided-multi-custom-remove-btn"
+                onClick={() => handleRemoveCustom(value)}
+                aria-label={`Remove ${value}`}
+              >
+                {/* ASCII multiplication-style X; visible glyph for sighted
+                    users, accessible name from aria-label since the glyph
+                    alone wouldn't read meaningfully. This is the documented
+                    exception to the "no aria-label on visible-text controls"
+                    rule — there is no useful visible text. */}
+                x
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="guided-multi-actions">
+        <button
+          type="button"
+          className="guided-multi-continue-btn"
+          onClick={handleContinue}
+          disabled={continueDisabled}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.test.tsx
@@ -1,0 +1,287 @@
+// src/components/chat/guided/ProposeChainTurn.test.tsx
+//
+// Regression suite for ProposeChainTurn (Task 7.6).
+//
+// Pinned contracts:
+//   1. Card-list rendering of payload.steps — each step becomes a card showing
+//      plugin name, rationale, and a key-value options list.
+//   2. Accept-all wire-shape contract — clicking "Accept proposal" emits
+//      chosen: ["accept"] and all other fields null.  This is the ONLY submit
+//      path implemented: Edit, Reject, and Ask-advisor buttons are absent because
+//      the backend handler (routes.py:2030-2137) only processes chosen==["accept"]
+//      today.  Per-step Edit returns HTTP 400; Reject returns HTTP 501.  See
+//      observation elspeth-obs-98eab6aa67 for the Phase-5 catch-up ticket.
+//   3. payload.blockers show/hide based on emptiness — blockers list renders when
+//      non-empty; absent from DOM when blockers is [].
+//   4. DOM-ID distinctness pin — two simultaneous instances produce element IDs
+//      that are NOT the same node (per-instance useId() scoping).
+//
+// Wire-shape verification (routes.py:2030-2137):
+//   chosen: ["accept"] -> pipeline committed (success path)
+//   chosen: ["reject"] -> HTTP 501 (Phase 5 stub, not wired in widget)
+//   accepted_step_index / edit_step_index / control_signal -> not read by handler
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProposeChainTurn } from "./ProposeChainTurn";
+import { nullResponse } from "@/test/guided-fixtures";
+import type { ProposeChainPayload } from "@/types/guided";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STEP_A: ProposeChainPayload["steps"][number] = {
+  plugin: "csv_transform",
+  options: { delimiter: ",", skip_header: true },
+  rationale: "Parses CSV rows into typed records for downstream enrichment.",
+};
+
+const STEP_B: ProposeChainPayload["steps"][number] = {
+  plugin: "geo_enrich",
+  options: { api_key: "***", timeout: 5 },
+  rationale: "Adds lat/lon to each record using the geocoding API.",
+};
+
+const TWO_STEP_PAYLOAD: ProposeChainPayload = {
+  steps: [STEP_A, STEP_B],
+  why: "CSV source needs type coercion then geo enrichment before sink.",
+  blockers: [],
+};
+
+const WITH_BLOCKERS_PAYLOAD: ProposeChainPayload = {
+  steps: [STEP_A],
+  why: "Single enrichment step proposed.",
+  blockers: ["geocoding API key not yet configured", "output schema ambiguous"],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderWidget(
+  payload: ProposeChainPayload,
+  onSubmit = vi.fn(),
+) {
+  return render(<ProposeChainTurn payload={payload} onSubmit={onSubmit} />);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Card-list rendering
+// ---------------------------------------------------------------------------
+
+describe("ProposeChainTurn — card-list rendering", () => {
+  it("renders payload.why as a context paragraph", () => {
+    renderWidget(TWO_STEP_PAYLOAD);
+    expect(
+      screen.getByText(
+        "CSV source needs type coercion then geo enrichment before sink.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one card per step", () => {
+    renderWidget(TWO_STEP_PAYLOAD);
+    // Each step card has a heading with the plugin name.
+    expect(screen.getByText("csv_transform")).toBeInTheDocument();
+    expect(screen.getByText("geo_enrich")).toBeInTheDocument();
+  });
+
+  it("renders the rationale for each step", () => {
+    renderWidget(TWO_STEP_PAYLOAD);
+    expect(
+      screen.getByText(
+        "Parses CSV rows into typed records for downstream enrichment.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Adds lat/lon to each record using the geocoding API.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders option keys and values inside each step card", () => {
+    renderWidget(TWO_STEP_PAYLOAD);
+    // STEP_A options: delimiter, skip_header
+    expect(screen.getByText("delimiter")).toBeInTheDocument();
+    // STEP_B options: api_key, timeout
+    expect(screen.getByText("api_key")).toBeInTheDocument();
+  });
+
+  it("renders a single step correctly (edge case: 1-step chain)", () => {
+    const single: ProposeChainPayload = {
+      steps: [STEP_A],
+      why: "Only one transform needed.",
+      blockers: [],
+    };
+    renderWidget(single);
+    expect(screen.getByText("csv_transform")).toBeInTheDocument();
+    expect(screen.queryByText("geo_enrich")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Accept-all wire-shape contract
+// ---------------------------------------------------------------------------
+
+describe("ProposeChainTurn — accept-all submit", () => {
+  it("clicking Accept proposal fires onSubmit with chosen: ['accept'] and other fields null", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(TWO_STEP_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...nullResponse(),          // spread FIRST; overridden by explicit fields below
+        chosen: ["accept"],
+        custom_inputs: null,
+      }),
+    );
+    // Verify the full body — all 6 GuidedRespondRequest fields explicit.
+    const body = onSubmit.mock.calls[0][0];
+    expect(body).toEqual({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+    });
+  });
+
+  it("clicking Accept works when there is only one step", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const single: ProposeChainPayload = {
+      steps: [STEP_A],
+      why: "One step.",
+      blockers: [],
+    };
+    renderWidget(single, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+    });
+  });
+
+  it("clicking Accept works when blockers are present", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(WITH_BLOCKERS_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+    });
+  });
+
+  it("no widget-side state leaks between renders — second click still emits clean body", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(TWO_STEP_PAYLOAD, onSubmit);
+
+    // Click once, then click again — each call must be independent.
+    await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+    await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit.mock.calls[1][0]).toEqual({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. payload.blockers show/hide
+// ---------------------------------------------------------------------------
+
+describe("ProposeChainTurn — blockers section", () => {
+  it("renders a blockers section when blockers is non-empty", () => {
+    renderWidget(WITH_BLOCKERS_PAYLOAD);
+    expect(
+      screen.getByText("geocoding API key not yet configured"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("output schema ambiguous")).toBeInTheDocument();
+  });
+
+  it("does NOT render a blockers section when blockers is empty (negative-space pin)", () => {
+    renderWidget(TWO_STEP_PAYLOAD); // blockers: []
+    // Neither the section heading nor any blocker text should appear.
+    expect(screen.queryByText(/blocker/i)).not.toBeInTheDocument();
+  });
+
+  it("renders all individual blocker strings as list items", () => {
+    renderWidget(WITH_BLOCKERS_PAYLOAD);
+    const items = screen.getAllByRole("listitem");
+    const blockerItems = items.filter(
+      (el) =>
+        el.textContent?.includes("geocoding API key") ||
+        el.textContent?.includes("output schema ambiguous"),
+    );
+    expect(blockerItems).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. DOM-ID distinctness pin (Task 7.4 I4 convention)
+// ---------------------------------------------------------------------------
+
+describe("ProposeChainTurn — DOM-ID distinctness pin", () => {
+  it("two simultaneous instances produce distinct element nodes for the accept button", () => {
+    // Render two instances into the same document.
+    const { container: c1 } = render(
+      <ProposeChainTurn payload={TWO_STEP_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+    const { container: c2 } = render(
+      <ProposeChainTurn payload={TWO_STEP_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+
+    // Each instance's per-card IDs must be scoped by useId().
+    // Grab the first scoped element from each container.
+    const card0_id = c1.querySelector("[id]")?.id;
+    const card1_id = c2.querySelector("[id]")?.id;
+
+    // Both must exist as real DOM nodes.
+    expect(card0_id).toBeDefined();
+    expect(card1_id).toBeDefined();
+
+    // The IDs must be different strings (useId() scoping per instance).
+    expect(card0_id).not.toBe(card1_id);
+
+    // Identity check: the same string ID must not resolve to the same node.
+    // (If IDs were identical, document.getElementById would return the first one
+    // for both — the .not.toBe check would still pass; we assert both resolve.)
+    const node0 = document.getElementById(card0_id!);
+    const node1 = document.getElementById(card1_id!);
+    expect(node0).not.toBeNull();
+    expect(node1).not.toBeNull();
+    // Different IDs -> definitely different nodes.
+    expect(node0).not.toBe(node1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Focus / auto-focus (negative-space pin)
+// ---------------------------------------------------------------------------
+
+describe("ProposeChainTurn — focus management", () => {
+  it("does NOT auto-focus any element on initial render", () => {
+    // ProposeChainTurn has no view transitions or collapsible regions that
+    // would trigger focus management. The component renders fully on mount
+    // with no focus side-effects (per convention from Task 7.2 template).
+    renderWidget(TWO_STEP_PAYLOAD);
+    // document.activeElement should be body (no programmatic focus).
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.test.tsx
@@ -9,8 +9,8 @@
 //      chosen: ["accept"] and all other fields null.  This is the ONLY submit
 //      path implemented: Edit, Reject, and Ask-advisor buttons are absent because
 //      the backend handler (routes.py:2030-2137) only processes chosen==["accept"]
-//      today.  Per-step Edit returns HTTP 400; Reject returns HTTP 501.  See
-//      observation elspeth-obs-98eab6aa67 for the Phase-5 catch-up ticket.
+//      today.  Per-step Edit returns HTTP 400; Reject returns HTTP 501.
+//      Tracker: filigree elspeth-2c08408170 (Step-3 backend handler completion).
 //   3. payload.blockers show/hide based on emptiness — blockers list renders when
 //      non-empty; absent from DOM when blockers is [].
 //   4. DOM-ID distinctness pin — two simultaneous instances produce element IDs
@@ -86,6 +86,17 @@ describe("ProposeChainTurn — card-list rendering", () => {
     // Each step card has a heading with the plugin name.
     expect(screen.getByText("csv_transform")).toBeInTheDocument();
     expect(screen.getByText("geo_enrich")).toBeInTheDocument();
+  });
+
+  it("each step's plugin name is a level-3 heading for screen-reader navigation", () => {
+    // Pins the <h3> semantics so a future "simplify back to <span>" regresses
+    // the test instead of silently breaking landmark navigation. Same convention
+    // as Task 7.3 M10 (edit-mode <h3>).
+    renderWidget(TWO_STEP_PAYLOAD);
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings).toHaveLength(TWO_STEP_PAYLOAD.steps.length);
+    expect(headings[0]).toHaveTextContent(TWO_STEP_PAYLOAD.steps[0].plugin);
+    expect(headings[1]).toHaveTextContent(TWO_STEP_PAYLOAD.steps[1].plugin);
   });
 
   it("renders the rationale for each step", () => {

--- a/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.tsx
@@ -1,0 +1,177 @@
+// src/components/chat/guided/ProposeChainTurn.tsx
+//
+// Guided-mode widget for the propose_chain turn type (Task 7.6).
+// Conventions inherited from SingleSelectTurn (Task 7.2 template),
+// InspectAndConfirmTurn (Task 7.3), MultiSelectWithCustomTurn (Task 7.4),
+// and SchemaFormTurn (Task 7.5).
+//
+//   - Props: { payload: ProposeChainPayload; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC -- the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <button type="button"> (never <div onClick>)
+//   - DOM IDs prefixed with React 18 useId() -- multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and element IDs would collide without per-instance scoping
+//   - Visible labels (button text) ARE the accessible name; no redundant aria-label
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+//
+// SHAPE NOTE (differs from chip-group widgets):
+// propose_chain uses a card-list layout (per Task 7.2 SHAPE NOTE which explicitly
+// excludes propose_chain from the chip-group family).  Each step is a card.
+// No <fieldset>/<legend>.  The accept button is at the bottom of the card list.
+//
+// SCOPE -- submitted buttons (verified against routes.py:2030-2137):
+//   WIRED:   "Accept proposal" -> chosen: ["accept"] -> pipeline committed
+//   DROPPED: per-step Edit  -> backend has no handler; would HTTP 400
+//   DROPPED: Reject         -> backend returns HTTP 501 (Phase 5 stub)
+//   DROPPED: Ask advisor    -> backend has no handler; would HTTP 400
+// The three dropped paths are tracked in filigree obs elspeth-obs-98eab6aa67
+// and must be added in Phase 5 once the backend handlers are wired.
+//
+// WIRE-SHAPE (single submit path):
+//   Accept proposal: { chosen: ["accept"], custom_inputs: null, edited_values: null,
+//                      accepted_step_index: null, edit_step_index: null, control_signal: null }
+// All 6 GuidedRespondRequest fields are explicit on the one handler.
+//
+// OPTIONS RENDERING:
+//   step.options is an arbitrary mapping (Mapping[str, Any] on the wire).  Each
+//   key-value pair is rendered as a <dl> definition list: <dt> for the key,
+//   <dd> for the value.  Non-scalar values (arrays, objects) are stringified via
+//   JSON.stringify so they remain human-readable without a full JSON viewer.
+//   This is the simplest renderable shape for the demo path; a richer diff view
+//   (collapsible JSON tree etc.) is deferred to a future task.
+//
+// STATE:
+//   Zero widget-side state.  Each button click immediately constructs and emits
+//   the body literal -- no intermediate state is accumulated.  No view
+//   transitions, so the firstRunRef focus-skip pattern from InspectAndConfirmTurn
+//   and SchemaFormTurn is not needed.
+//
+// FOCUS MANAGEMENT:
+//   No programmatic focus on mount or on interaction.  All four prior widgets
+//   that use focus management do so because a view transition reveals new content
+//   (InspectAndConfirmTurn, SchemaFormTurn) or a destructive interaction removes
+//   an element (MultiSelectWithCustomTurn).  ProposeChainTurn renders statically;
+//   no equivalent trigger exists.
+
+import { useId } from "react";
+import type { GuidedRespondRequest, ProposeChainPayload } from "@/types/guided";
+
+interface ProposeChainTurnProps {
+  payload: ProposeChainPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+/**
+ * Format a single option value for display in the key-value definition list.
+ *
+ * Scalars (string, number, boolean) are coerced to string.  Null/undefined
+ * render as "null".  Arrays and objects are JSON-stringified so the user sees
+ * the structure without a full JSON editor component.
+ */
+function formatOptionValue(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function ProposeChainTurn({ payload, onSubmit }: ProposeChainTurnProps) {
+  // useId scopes DOM IDs per-instance so multiple ProposeChainTurns rendered
+  // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
+  // produce id collisions when per-card IDs recur across turns.
+  const reactId = useId();
+  const cardId = (index: number) => `${reactId}-step-${index}`;
+  const optionsId = (index: number) => `${reactId}-opts-${index}`;
+
+  function handleAccept() {
+    onSubmit({
+      chosen: ["accept"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  return (
+    <div className="guided-turn guided-propose-chain">
+      {/* Overall rationale paragraph */}
+      <p className="guided-propose-why">{payload.why}</p>
+
+      {/* Blockers list -- only rendered when non-empty (negative-space pin #3) */}
+      {payload.blockers.length > 0 && (
+        <div className="guided-propose-blockers">
+          <p className="guided-propose-blockers-heading">Blockers identified:</p>
+          <ul className="guided-propose-blockers-list">
+            {payload.blockers.map((blocker, idx) => (
+              <li key={idx} className="guided-propose-blocker-item">
+                {blocker}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Step cards -- card-list layout, one card per step */}
+      <ol className="guided-propose-steps">
+        {payload.steps.map((step, idx) => {
+          const optKeys = Object.keys(step.options as Record<string, unknown>);
+          return (
+            <li
+              key={idx}
+              id={cardId(idx)}
+              className="guided-propose-step-card"
+              aria-label={`Step ${idx + 1}: ${step.plugin}`}
+            >
+              <div className="guided-propose-step-header">
+                <span className="guided-propose-step-number">
+                  {idx + 1}
+                </span>
+                <span className="guided-propose-step-plugin">{step.plugin}</span>
+              </div>
+
+              {/* Options as a key-value definition list.
+                  <dl> is used because (key, value) pairs semantically form a
+                  description/definition relationship -- <dt> for key, <dd> for
+                  value.  A <table> would be heavier; a plain div grid would
+                  lose the semantic association between keys and their values. */}
+              {optKeys.length > 0 && (
+                <dl id={optionsId(idx)} className="guided-propose-options">
+                  {optKeys.map((key) => (
+                    <div key={key} className="guided-propose-option-row">
+                      <dt className="guided-propose-option-key">{key}</dt>
+                      <dd className="guided-propose-option-val">
+                        {formatOptionValue(
+                          (step.options as Record<string, unknown>)[key],
+                        )}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+
+              <p className="guided-propose-step-rationale">{step.rationale}</p>
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Action row -- Accept proposal only.
+          Reject, per-step Edit, and Ask advisor are deferred to Phase 5:
+          the backend returns HTTP 501 / HTTP 400 for those paths today.
+          See filigree observation elspeth-obs-98eab6aa67. */}
+      <div className="guided-propose-actions">
+        <button
+          type="button"
+          className="guided-propose-accept-btn"
+          onClick={handleAccept}
+        >
+          Accept proposal
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/ProposeChainTurn.tsx
@@ -24,8 +24,10 @@
 //   DROPPED: per-step Edit  -> backend has no handler; would HTTP 400
 //   DROPPED: Reject         -> backend returns HTTP 501 (Phase 5 stub)
 //   DROPPED: Ask advisor    -> backend has no handler; would HTTP 400
-// The three dropped paths are tracked in filigree obs elspeth-obs-98eab6aa67
-// and must be added in Phase 5 once the backend handlers are wired.
+// The three dropped paths must be added in Phase 5 once the backend handlers
+// are wired.
+//
+// Tracker: filigree elspeth-2c08408170 (Step-3 backend handler completion)
 //
 // WIRE-SHAPE (single submit path):
 //   Accept proposal: { chosen: ["accept"], custom_inputs: null, edited_values: null,
@@ -130,7 +132,13 @@ export function ProposeChainTurn({ payload, onSubmit }: ProposeChainTurnProps) {
                 <span className="guided-propose-step-number">
                   {idx + 1}
                 </span>
-                <span className="guided-propose-step-plugin">{step.plugin}</span>
+                {/* <h3> (not <span>) so screen-reader users can navigate the
+                    proposed chain by heading landmarks. The CSS rule on
+                    .guided-propose-step-plugin already pins font-size to
+                    --font-size-base, so the visual rank does not jump to the
+                    browser-default <h3> size. Same convention as Task 7.3 M10
+                    (edit-mode heading). */}
+                <h3 className="guided-propose-step-plugin">{step.plugin}</h3>
               </div>
 
               {/* Options as a key-value definition list.
@@ -162,7 +170,8 @@ export function ProposeChainTurn({ payload, onSubmit }: ProposeChainTurnProps) {
       {/* Action row -- Accept proposal only.
           Reject, per-step Edit, and Ask advisor are deferred to Phase 5:
           the backend returns HTTP 501 / HTTP 400 for those paths today.
-          See filigree observation elspeth-obs-98eab6aa67. */}
+          Tracker: filigree elspeth-2c08408170 (Step-3 backend handler
+          completion). */}
       <div className="guided-propose-actions">
         <button
           type="button"

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
@@ -112,6 +112,24 @@ const NUMERIC_UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
   ],
 };
 
+// Dedicated int-slot fixture (finding I1).  inputTypeForSlot() branches on
+// `slotType === "int" || slotType === "float"` — the "float" branch is pinned
+// by NUMERIC_UNSATISFIED_PAYLOAD above; this fixture independently pins the
+// "int" branch so a regression that drops `"int" ||` would fail.
+const INT_UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "limit-batch-size",
+  slots: { source_blob_id: "blob-int" },
+  alternatives: ["build_manually"],
+  unsatisfied_slots: [
+    {
+      name: "batch_size",
+      slot_type: "int",
+      description: "Maximum rows per batch",
+      required: true,
+    },
+  ],
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -405,6 +423,23 @@ describe("RecipeOfferTurn — unsatisfied_slots editable form", () => {
     expect(applyBtn).toBeDisabled();
   });
 
+  it("Apply button stays DISABLED when a required slot contains only whitespace", async () => {
+    // Finding I2: applyDisabled uses `value.trim() === ""` so whitespace-only
+    // input does not satisfy a required slot.  A regression to `value === ""`
+    // (dropping .trim()) would silently let "   " enable Apply.  Fill the
+    // other two required slots with real values so only the whitespace slot
+    // is the gating constraint; the trim() is therefore load-bearing.
+    const user = userEvent.setup();
+    renderWidget(UNSATISFIED_PAYLOAD);
+    const applyBtn = screen.getByRole("button", { name: /apply recipe/i });
+
+    await user.type(screen.getByLabelText(/model/i), "anthropic-claude");
+    await user.type(screen.getByLabelText(/api_key_secret/i), "OPENROUTER_API_KEY");
+    // classifier_template gets only whitespace -- must NOT enable Apply.
+    await user.type(screen.getByLabelText(/classifier_template/i), "   ");
+    expect(applyBtn).toBeDisabled();
+  });
+
   it("Apply button enables once every required slot has a non-empty value", async () => {
     const user = userEvent.setup();
     renderWidget(UNSATISFIED_PAYLOAD);
@@ -465,6 +500,16 @@ describe("RecipeOfferTurn — unsatisfied_slots editable form", () => {
     renderWidget(NUMERIC_UNSATISFIED_PAYLOAD);
     const thresholdInput = screen.getByLabelText(/threshold/i);
     expect(thresholdInput).toHaveAttribute("type", "number");
+  });
+
+  it("renders int slot inputs with type='number' (independent pin from float branch)", () => {
+    // Finding I1: inputTypeForSlot() branches on `slot_type === "int" || "float"`.
+    // The float branch is covered above; this test independently pins the int
+    // branch.  Dropping `"int" ||` from inputTypeForSlot would cause an int slot
+    // to fall through to type="text", which this assertion catches.
+    renderWidget(INT_UNSATISFIED_PAYLOAD);
+    const batchSizeInput = screen.getByLabelText(/batch_size/i);
+    expect(batchSizeInput).toHaveAttribute("type", "number");
   });
 
   it("renders str slot inputs with type='text' (NEVER type='password')", () => {

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
@@ -36,12 +36,14 @@ const BASIC_PAYLOAD: RecipeOfferPayload = {
   recipe_name: "csv_to_jsonl",
   slots: { delimiter: ",", encoding: "utf-8" },
   alternatives: ["build_manually"],
+  unsatisfied_slots: [],
 };
 
 const NO_ALTERNATIVES_PAYLOAD: RecipeOfferPayload = {
   recipe_name: "parquet_to_csv",
   slots: { compression: "snappy" },
   alternatives: [],
+  unsatisfied_slots: [],
 };
 
 const COMPLEX_SLOTS_PAYLOAD: RecipeOfferPayload = {
@@ -53,6 +55,61 @@ const COMPLEX_SLOTS_PAYLOAD: RecipeOfferPayload = {
     arr_val: ["x", "y"],
   },
   alternatives: ["build_manually"],
+  unsatisfied_slots: [],
+};
+
+// Task 10.0 / Gap 6 — classify-rows-llm-jsonl with three unsatisfied required
+// slots (classifier_template, model, api_key_secret).  Mirrors the real
+// backend wire shape after the matcher pre-fills source_blob_id /
+// output_path / label_field and surfaces the rest as editable inputs.
+const UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "classify-rows-llm-jsonl",
+  slots: {
+    source_blob_id: "abc-1234",
+    output_path: "outputs/classified.jsonl",
+    label_field: "category",
+  },
+  alternatives: ["build_manually"],
+  unsatisfied_slots: [
+    {
+      name: "classifier_template",
+      slot_type: "str",
+      description: "Jinja2 template",
+      required: true,
+    },
+    {
+      name: "model",
+      slot_type: "str",
+      description: "LLM model identifier",
+      required: true,
+    },
+    {
+      name: "api_key_secret",
+      slot_type: "str",
+      description: "Name of an inventory secret_ref",
+      required: true,
+    },
+  ],
+};
+
+const NUMERIC_UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "split-by-numeric-threshold",
+  slots: { source_blob_id: "blob-x" },
+  alternatives: ["build_manually"],
+  unsatisfied_slots: [
+    {
+      name: "field",
+      slot_type: "str",
+      description: "Field to threshold",
+      required: true,
+    },
+    {
+      name: "threshold",
+      slot_type: "float",
+      description: "Numeric threshold",
+      required: true,
+    },
+  ],
 };
 
 // ---------------------------------------------------------------------------
@@ -318,5 +375,141 @@ describe("RecipeOfferTurn — focus management", () => {
     // programmatic focus on mount (per Task 7.2 template convention).
     renderWidget(BASIC_PAYLOAD);
     expect(document.activeElement).toBe(document.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Unsatisfied-slot editable inputs (Task 10.0 / Gap 6)
+// ---------------------------------------------------------------------------
+
+describe("RecipeOfferTurn — unsatisfied_slots editable form", () => {
+  it("renders NO fieldset when unsatisfied_slots is empty", () => {
+    renderWidget(BASIC_PAYLOAD);
+    // The form fieldset only appears when there are required slots to collect.
+    expect(
+      screen.queryByText(/additional values required/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders one labelled input per unsatisfied entry", () => {
+    renderWidget(UNSATISFIED_PAYLOAD);
+    // Each slot.name becomes a <label> string that resolves the <input> via getByLabelText.
+    expect(screen.getByLabelText(/classifier_template/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/model/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/api_key_secret/i)).toBeInTheDocument();
+  });
+
+  it("Apply button starts DISABLED when any required slot is unfilled", () => {
+    renderWidget(UNSATISFIED_PAYLOAD);
+    const applyBtn = screen.getByRole("button", { name: /apply recipe/i });
+    expect(applyBtn).toBeDisabled();
+  });
+
+  it("Apply button enables once every required slot has a non-empty value", async () => {
+    const user = userEvent.setup();
+    renderWidget(UNSATISFIED_PAYLOAD);
+    const applyBtn = screen.getByRole("button", { name: /apply recipe/i });
+
+    // userEvent.type treats "{" and "[" as key-descriptor sigils; use the
+    // .keyboardOptions skip mechanism or .clear+.paste; simplest is to
+    // configure user with delay:0 and use fireEvent.change-style direct value
+    // assignment via getByLabelText + .focus + paste.  Cleaner: use
+    // userEvent.click+keyboard with escaped sequences via the documented
+    // `{{ }}` escape — but for plain alphanumeric values we don't need that.
+    await user.type(
+      screen.getByLabelText(/classifier_template/i),
+      "classify-this",
+    );
+    await user.type(screen.getByLabelText(/model/i), "anthropic-claude");
+    expect(applyBtn).toBeDisabled(); // still missing api_key_secret
+    await user.type(screen.getByLabelText(/api_key_secret/i), "openrouter-key");
+    expect(applyBtn).toBeEnabled();
+  });
+
+  it("Apply merges typed values into edited_values.slots alongside pre-filled slots", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(UNSATISFIED_PAYLOAD, onSubmit);
+
+    // Plain alphanumeric values: avoid userEvent key-descriptor sigils.
+    // Template variables ({{ row[...] }}) are exercised at the e2e layer
+    // where Playwright's fill() does not interpret sigils.
+    await user.type(screen.getByLabelText(/classifier_template/i), "classify-this");
+    await user.type(screen.getByLabelText(/model/i), "anthropic-claude");
+    await user.type(
+      screen.getByLabelText(/api_key_secret/i),
+      "OPENROUTER_API_KEY",
+    );
+
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body = onSubmit.mock.calls[0][0];
+    expect(body.chosen).toEqual(["accept"]);
+    expect(body.edited_values).toEqual({
+      recipe_name: "classify-rows-llm-jsonl",
+      slots: {
+        // Pre-filled by the resolver
+        source_blob_id: "abc-1234",
+        output_path: "outputs/classified.jsonl",
+        label_field: "category",
+        // Operator inputs
+        classifier_template: "classify-this",
+        model: "anthropic-claude",
+        api_key_secret: "OPENROUTER_API_KEY",
+      },
+    });
+  });
+
+  it("renders numeric slot inputs with type='number'", () => {
+    renderWidget(NUMERIC_UNSATISFIED_PAYLOAD);
+    const thresholdInput = screen.getByLabelText(/threshold/i);
+    expect(thresholdInput).toHaveAttribute("type", "number");
+  });
+
+  it("renders str slot inputs with type='text' (NEVER type='password')", () => {
+    // SECURITY-CRITICAL: api_key_secret carries the NAME of an inventory
+    // secret_ref, not a credential.  Using type='password' would mislead
+    // operators into pasting raw credentials, which the audit trail would
+    // then record via edited_values.  Pin both: positive (type='text') and
+    // negative (NOT type='password') so a future drift can't slip through.
+    renderWidget(UNSATISFIED_PAYLOAD);
+    const apiKeyInput = screen.getByLabelText(/api_key_secret/i);
+    expect(apiKeyInput).toHaveAttribute("type", "text");
+    expect(apiKeyInput).not.toHaveAttribute("type", "password");
+
+    // Same guarantee applies to every other str slot.
+    const templateInput = screen.getByLabelText(/classifier_template/i);
+    expect(templateInput).toHaveAttribute("type", "text");
+    const modelInput = screen.getByLabelText(/model/i);
+    expect(modelInput).toHaveAttribute("type", "text");
+  });
+
+  it("renders slot description as hint text", () => {
+    renderWidget(UNSATISFIED_PAYLOAD);
+    expect(screen.getByText(/jinja2 template/i)).toBeInTheDocument();
+    expect(screen.getByText(/llm model identifier/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/name of an inventory secret_ref/i),
+    ).toBeInTheDocument();
+  });
+
+  it("Apply with empty unsatisfied_slots keeps existing wire shape (no operator inputs to merge)", async () => {
+    // Regression pin: the empty-unsatisfied case is the common path for
+    // recipes whose resolver covers every required slot.  Apply must still
+    // echo recipe_name + payload.slots verbatim.
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+      edited_values: {
+        recipe_name: "csv_to_jsonl",
+        slots: { delimiter: ",", encoding: "utf-8" },
+      },
+    });
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
@@ -1,0 +1,322 @@
+// src/components/chat/guided/RecipeOfferTurn.test.tsx
+//
+// Regression suite for RecipeOfferTurn (Task 7.7).
+//
+// Pinned contracts:
+//   1. Recipe-name heading + slot summary + alternatives list
+//      Recipe name renders as <h3>; slots render as <dl>/<dt>/<dd>; alternatives
+//      render as a list when non-empty and are absent from the DOM when empty.
+//   2. Two-button wire-shape contracts (Apply / Build manually)
+//      "Apply recipe" sends chosen: ["accept"] + edited_values: { recipe_name, slots }.
+//      "Build manually" sends chosen: ["build_manually"] + edited_values: null.
+//      Both paths set all 6 GuidedRespondRequest fields explicitly.
+//   3. Alternatives show/hide based on emptiness
+//      Non-empty alternatives list renders; empty alternatives list is absent.
+//   4. DOM-ID distinctness pin
+//      Two simultaneous RecipeOfferTurn instances produce element-level IDs that
+//      resolve to different DOM nodes (per-instance useId() scoping).
+//
+// Wire-shape notes (routes.py:1943-2023):
+//   chosen: ["accept"]         -> backend reads edited_values.recipe_name + slots
+//   chosen: ["build_manually"] -> backend only reads chosen; advances to STEP_3
+//   Any other chosen value     -> HTTP 400
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RecipeOfferTurn } from "./RecipeOfferTurn";
+import { nullResponse } from "@/test/guided-fixtures";
+import type { RecipeOfferPayload } from "@/types/guided";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASIC_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "csv_to_jsonl",
+  slots: { delimiter: ",", encoding: "utf-8" },
+  alternatives: ["build_manually"],
+};
+
+const NO_ALTERNATIVES_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "parquet_to_csv",
+  slots: { compression: "snappy" },
+  alternatives: [],
+};
+
+const COMPLEX_SLOTS_PAYLOAD: RecipeOfferPayload = {
+  recipe_name: "enrich_geo",
+  slots: {
+    api_key: "***",
+    timeout: 5,
+    nested_obj: { a: 1, b: 2 },
+    arr_val: ["x", "y"],
+  },
+  alternatives: ["build_manually"],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderWidget(
+  payload: RecipeOfferPayload,
+  onSubmit = vi.fn(),
+) {
+  return render(<RecipeOfferTurn payload={payload} onSubmit={onSubmit} />);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Recipe-name heading + slot summary + alternatives list
+// ---------------------------------------------------------------------------
+
+describe("RecipeOfferTurn — content rendering", () => {
+  it("renders recipe_name as a level-3 heading for screen-reader navigation", () => {
+    renderWidget(BASIC_PAYLOAD);
+    // Pins <h3> semantics -- a future "simplify back to <span>" regresses here.
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading).toHaveTextContent("csv_to_jsonl");
+  });
+
+  it("renders each slot key as a <dt>", () => {
+    renderWidget(BASIC_PAYLOAD);
+    expect(screen.getByText("delimiter")).toBeInTheDocument();
+    expect(screen.getByText("encoding")).toBeInTheDocument();
+  });
+
+  it("renders each slot value as a <dd>", () => {
+    renderWidget(BASIC_PAYLOAD);
+    // Scalar string value appears directly
+    expect(screen.getByText(",")).toBeInTheDocument();
+    expect(screen.getByText("utf-8")).toBeInTheDocument();
+  });
+
+  it("JSON-stringifies non-scalar slot values (objects, arrays)", () => {
+    renderWidget(COMPLEX_SLOTS_PAYLOAD);
+    // Objects and arrays are JSON-stringified for human readability
+    expect(screen.getByText('{"a":1,"b":2}')).toBeInTheDocument();
+    expect(screen.getByText('["x","y"]')).toBeInTheDocument();
+  });
+
+  it("renders numeric slot values as strings", () => {
+    renderWidget(COMPLEX_SLOTS_PAYLOAD);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders alternatives list when alternatives is non-empty", () => {
+    renderWidget(BASIC_PAYLOAD); // alternatives: ["build_manually"]
+    expect(screen.getByText("build_manually")).toBeInTheDocument();
+  });
+
+  it("does NOT render alternatives section when alternatives is empty (negative-space pin)", () => {
+    renderWidget(NO_ALTERNATIVES_PAYLOAD); // alternatives: []
+    // The alternatives section heading must be absent.
+    expect(screen.queryByText(/alternatives/i)).not.toBeInTheDocument();
+  });
+
+  it("renders single slot correctly", () => {
+    renderWidget(NO_ALTERNATIVES_PAYLOAD);
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading).toHaveTextContent("parquet_to_csv");
+    expect(screen.getByText("compression")).toBeInTheDocument();
+    expect(screen.getByText("snappy")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Two-button wire-shape contracts
+// ---------------------------------------------------------------------------
+
+describe("RecipeOfferTurn — Apply recipe submit", () => {
+  it("clicking Apply recipe fires onSubmit with chosen: ['accept'] and echoes payload fields", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // edited_values MUST carry recipe_name and slots so the backend can reconstruct
+    // the RecipeMatch (routes.py:1965-1967). edited_values: null would cause a
+    // server-side failure ("", {}) fallback path.
+    expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(), // spread FIRST; edited_values overridden below
+      chosen: ["accept"],
+      custom_inputs: null,
+      edited_values: {
+        recipe_name: "csv_to_jsonl",
+        slots: { delimiter: ",", encoding: "utf-8" },
+      },
+    });
+  });
+
+  it("Apply recipe body contains all 6 GuidedRespondRequest fields explicitly", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+
+    const body = onSubmit.mock.calls[0][0];
+    expect(body).toEqual({
+      chosen: ["accept"],
+      edited_values: {
+        recipe_name: "csv_to_jsonl",
+        slots: { delimiter: ",", encoding: "utf-8" },
+      },
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+    // Assert all 6 explicit keys are present (toEqual checks no extra keys too).
+    const keys = Object.keys(body);
+    expect(keys).toContain("chosen");
+    expect(keys).toContain("edited_values");
+    expect(keys).toContain("custom_inputs");
+    expect(keys).toContain("accepted_step_index");
+    expect(keys).toContain("edit_step_index");
+    expect(keys).toContain("control_signal");
+  });
+
+  it("Apply recipe echoes complex slots (including nested objects) into edited_values", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(COMPLEX_SLOTS_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+
+    const body = onSubmit.mock.calls[0][0];
+    expect(body.edited_values).toEqual({
+      recipe_name: "enrich_geo",
+      slots: {
+        api_key: "***",
+        timeout: 5,
+        nested_obj: { a: 1, b: 2 },
+        arr_val: ["x", "y"],
+      },
+    });
+  });
+});
+
+describe("RecipeOfferTurn — Build manually submit", () => {
+  it("clicking Build manually fires onSubmit with chosen: ['build_manually'] and null edited_values", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /build manually/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      ...nullResponse(), // spread FIRST
+      chosen: ["build_manually"],
+      custom_inputs: null,
+    });
+  });
+
+  it("Build manually body contains all 6 GuidedRespondRequest fields explicitly", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /build manually/i }));
+
+    const body = onSubmit.mock.calls[0][0];
+    expect(body).toEqual({
+      chosen: ["build_manually"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  });
+});
+
+describe("RecipeOfferTurn — no state pollution between submits", () => {
+  it("Build manually after Apply (or vice versa) emits the correct body each time", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    // First click: Apply recipe
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+    // Second click: Build manually
+    await user.click(screen.getByRole("button", { name: /build manually/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    // First call: Apply
+    expect(onSubmit.mock.calls[0][0]).toEqual({
+      ...nullResponse(),
+      chosen: ["accept"],
+      custom_inputs: null,
+      edited_values: {
+        recipe_name: "csv_to_jsonl",
+        slots: { delimiter: ",", encoding: "utf-8" },
+      },
+    });
+    // Second call: Build manually -- no leftover state from Apply
+    expect(onSubmit.mock.calls[1][0]).toEqual({
+      ...nullResponse(),
+      chosen: ["build_manually"],
+      custom_inputs: null,
+    });
+  });
+
+  it("Apply twice emits identical bodies (zero widget state)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWidget(BASIC_PAYLOAD, onSubmit);
+
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+    await user.click(screen.getByRole("button", { name: /apply recipe/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit.mock.calls[1][0]).toEqual(onSubmit.mock.calls[0][0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. DOM-ID distinctness pin (Task 7.4 I4 convention)
+// ---------------------------------------------------------------------------
+
+describe("RecipeOfferTurn — DOM-ID distinctness pin", () => {
+  it("two simultaneous instances produce distinct element nodes", () => {
+    const { container: c1 } = render(
+      <RecipeOfferTurn payload={BASIC_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+    const { container: c2 } = render(
+      <RecipeOfferTurn payload={BASIC_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+
+    // Each instance scopes element IDs via useId().
+    const id0 = c1.querySelector("[id]")?.id;
+    const id1 = c2.querySelector("[id]")?.id;
+
+    expect(id0).toBeDefined();
+    expect(id1).toBeDefined();
+    // Different instances produce different ID strings.
+    expect(id0).not.toBe(id1);
+
+    // Resolve both IDs in the document -- must be different nodes.
+    const node0 = document.getElementById(id0!);
+    const node1 = document.getElementById(id1!);
+    expect(node0).not.toBeNull();
+    expect(node1).not.toBeNull();
+    expect(node0).not.toBe(node1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Focus / auto-focus (negative-space pin)
+// ---------------------------------------------------------------------------
+
+describe("RecipeOfferTurn — focus management", () => {
+  it("does NOT auto-focus any element on initial render", () => {
+    // RecipeOfferTurn has no view transitions or collapsible regions; no
+    // programmatic focus on mount (per Task 7.2 template convention).
+    renderWidget(BASIC_PAYLOAD);
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.test.tsx
@@ -75,19 +75,16 @@ const UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
       name: "classifier_template",
       slot_type: "str",
       description: "Jinja2 template",
-      required: true,
     },
     {
       name: "model",
       slot_type: "str",
       description: "LLM model identifier",
-      required: true,
     },
     {
       name: "api_key_secret",
       slot_type: "str",
       description: "Name of an inventory secret_ref",
-      required: true,
     },
   ],
 };
@@ -101,13 +98,11 @@ const NUMERIC_UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
       name: "field",
       slot_type: "str",
       description: "Field to threshold",
-      required: true,
     },
     {
       name: "threshold",
       slot_type: "float",
       description: "Numeric threshold",
-      required: true,
     },
   ],
 };
@@ -125,7 +120,6 @@ const INT_UNSATISFIED_PAYLOAD: RecipeOfferPayload = {
       name: "batch_size",
       slot_type: "int",
       description: "Maximum rows per batch",
-      required: true,
     },
   ],
 };

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
@@ -1,0 +1,210 @@
+// src/components/chat/guided/RecipeOfferTurn.tsx
+//
+// Guided-mode widget for the recipe_offer turn type (Task 7.7).
+// Conventions inherited from SingleSelectTurn (Task 7.2 template),
+// InspectAndConfirmTurn (Task 7.3), MultiSelectWithCustomTurn (Task 7.4),
+// SchemaFormTurn (Task 7.5), and ProposeChainTurn (Task 7.6).
+//
+//   - Props: { payload: RecipeOfferPayload; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC -- the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <button type="button"> (never <div onClick>)
+//   - DOM IDs prefixed with React 18 useId() -- multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and element IDs would collide without per-instance scoping
+//   - Visible labels (button text) ARE the accessible name; no redundant aria-label
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+//
+// SHAPE NOTE (card family):
+// recipe_offer is listed alongside single_select and multi_select_with_custom in
+// SingleSelectTurn's SHAPE NOTE as a "chip-group family" member.  However, the
+// actual layout ("single card with recipe name + slot summary + action buttons")
+// is structurally a card, not a chip group.  This widget uses the card layout.
+//
+// CARD-STYLE DECISION (a) -- Reuse guided-propose-step-card directly:
+// The .guided-propose-step-card rule (App.css:4285-4290) provides:
+//   background-color: surface-elevated, border: border-strong, border-radius: radius-lg,
+//   padding: space-md.
+// This is pure card chrome with zero step-list-specific styling.  The step-list
+// scaffolding (guided-propose-steps <ol>, guided-propose-step-header badge row)
+// is step-list-specific and is NOT applied here.  RecipeOfferTurn uses a single
+// <div class="guided-propose-step-card"> as the card shell.  New rules added
+// for this widget live in the guided-recipe-* namespace.  See App.css section
+// header at ~line 4420 for the reuse documentation.
+//
+// SCOPE -- submit paths (verified against routes.py:1943-2023 and
+//          state_machine.py:_advance_step_2_5):
+//
+//   WIRED: "Apply recipe" -> chosen: ["accept"]
+//          IMPORTANT: The backend (routes.py:1965-1967) reads edited_values to
+//          reconstruct the RecipeMatch.  This widget MUST echo payload.recipe_name
+//          and payload.slots in edited_values.  Sending edited_values: null causes
+//          the backend to fall back to RecipeMatch(recipe_name="", slots={}) and
+//          fail.  This differs from the plan-body spec which stated null -- the
+//          plan body was incomplete.
+//
+//   WIRED: "Build manually" -> chosen: ["build_manually"]
+//          Backend only reads chosen on this path; edited_values: null is correct.
+//
+//   NOT WIRED: alternatives-based alternative recipe selection.  The current
+//          backend only accepts ["accept"] or ["build_manually"]; any other chosen
+//          value returns HTTP 400.  The alternatives list is displayed for user
+//          information only.  If the user wants an alternative, Build Manually
+//          advances to Step 3 for manual construction.
+//
+// WIRE-SHAPE:
+//   Apply recipe:   { chosen: ["accept"],
+//                     edited_values: { recipe_name: payload.recipe_name,
+//                                      slots: payload.slots },
+//                     custom_inputs: null, accepted_step_index: null,
+//                     edit_step_index: null, control_signal: null }
+//   Build manually: { chosen: ["build_manually"],
+//                     edited_values: null, custom_inputs: null,
+//                     accepted_step_index: null, edit_step_index: null,
+//                     control_signal: null }
+//
+// STATE:
+//   Zero widget-side state.  Each button is a pure click -> submit; no
+//   intermediate state is accumulated.  The firstRunRef focus-skip pattern is
+//   not needed (no view transitions).
+//
+// FOCUS MANAGEMENT:
+//   No programmatic focus on mount or interaction.  No view transitions or
+//   collapsible regions that would trigger the focus management patterns used in
+//   InspectAndConfirmTurn and SchemaFormTurn.
+
+import { useId } from "react";
+import type { GuidedRespondRequest, RecipeOfferPayload } from "@/types/guided";
+
+interface RecipeOfferTurnProps {
+  payload: RecipeOfferPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+/**
+ * Format a single slot value for display in the key-value definition list.
+ *
+ * Scalars (string, number, boolean) are coerced to string.  Null/undefined
+ * render as "null".  Arrays and objects are JSON-stringified so the user sees
+ * the structure without a full JSON editor component.
+ *
+ * Mirrors formatOptionValue in ProposeChainTurn.  Not extracted to a shared
+ * helper: two call sites do not meet the rule-of-three extraction threshold.
+ */
+function formatSlotValue(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
+  // useId scopes DOM IDs per-instance so multiple RecipeOfferTurns rendered
+  // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
+  // produce id collisions when element IDs recur across turns.
+  const reactId = useId();
+  const slotsId = `${reactId}-slots`;
+  const alternativesId = `${reactId}-alts`;
+
+  function handleApply() {
+    // MUST echo recipe_name and slots in edited_values.
+    // Backend (routes.py:1965-1967) reads these to reconstruct the RecipeMatch.
+    // edited_values: null would silently produce RecipeMatch("", {}) and fail.
+    onSubmit({
+      chosen: ["accept"],
+      edited_values: {
+        recipe_name: payload.recipe_name,
+        slots: payload.slots,
+      },
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  function handleBuildManually() {
+    // Backend only reads chosen on this path (routes.py:1988-2018).
+    // edited_values: null is correct here.
+    onSubmit({
+      chosen: ["build_manually"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  const slotKeys = Object.keys(payload.slots);
+
+  return (
+    <div className="guided-turn guided-recipe-offer">
+      {/* Single card: recipe name + slot summary + alternatives + actions */}
+      <div className="guided-propose-step-card guided-recipe-card">
+        {/* Recipe name as <h3> for screen-reader landmark navigation.
+            Same convention as ProposeChainTurn's step plugin headings (Task 7.6 M3).
+            Font-size is pinned to --font-size-base via .guided-recipe-name in App.css
+            so the browser's default <h3> sizing does not bleed through. */}
+        <h3 className="guided-recipe-name">{payload.recipe_name}</h3>
+
+        {/* Slot summary as a key-value definition list.
+            <dl> is used because (key, value) pairs form a description/definition
+            relationship -- <dt> for key, <dd> for value.  Mirrors ProposeChainTurn's
+            options rendering pattern. */}
+        {slotKeys.length > 0 && (
+          <dl id={slotsId} className="guided-recipe-slots">
+            {slotKeys.map((key) => (
+              <div key={key} className="guided-recipe-slot-row">
+                <dt className="guided-recipe-slot-key">{key}</dt>
+                <dd className="guided-recipe-slot-val">
+                  {formatSlotValue(payload.slots[key])}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {/* Alternatives list -- only rendered when non-empty (negative-space pin).
+            Displayed for user information; no submit path for alternatives exists
+            in the current backend (only ["accept"] and ["build_manually"] are
+            valid).  See SCOPE NOTE in the file header. */}
+        {payload.alternatives.length > 0 && (
+          <div className="guided-recipe-alternatives">
+            <p className="guided-recipe-alternatives-heading">Alternatives:</p>
+            <ul id={alternativesId} className="guided-recipe-alternatives-list">
+              {payload.alternatives.map((alt, idx) => (
+                <li key={idx} className="guided-recipe-alternative-item">
+                  {alt}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Action row: Apply recipe + Build manually.
+            Two separate handlers; each constructs its own body literal.
+            No "construct chosen body" helper extracted: rule of three requires
+            a third widget before justifying extraction (ProposeChainTurn + this
+            widget = 2 sites). */}
+        <div className="guided-recipe-actions">
+          <button
+            type="button"
+            className="guided-recipe-apply-btn"
+            onClick={handleApply}
+          >
+            Apply recipe
+          </button>
+          <button
+            type="button"
+            className="guided-recipe-build-btn"
+            onClick={handleBuildManually}
+          >
+            Build manually
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
@@ -1,6 +1,7 @@
 // src/components/chat/guided/RecipeOfferTurn.tsx
 //
-// Guided-mode widget for the recipe_offer turn type (Task 7.7).
+// Guided-mode widget for the recipe_offer turn type (Task 7.7, extended for
+// Gap 6 / Task 10.0 — editable inputs for unsatisfied required slots).
 // Conventions inherited from SingleSelectTurn (Task 7.2 template),
 // InspectAndConfirmTurn (Task 7.3), MultiSelectWithCustomTurn (Task 7.4),
 // SchemaFormTurn (Task 7.5), and ProposeChainTurn (Task 7.6).
@@ -24,23 +25,17 @@
 // The .guided-propose-step-card rule (App.css:4285-4290) provides:
 //   background-color: surface-elevated, border: border-strong, border-radius: radius-lg,
 //   padding: space-md.
-// This is pure card chrome with zero step-list-specific styling.  The step-list
-// scaffolding (guided-propose-steps <ol>, guided-propose-step-header badge row)
-// is step-list-specific and is NOT applied here.  RecipeOfferTurn uses a single
-// <div class="guided-propose-step-card"> as the card shell.  New rules added
-// for this widget live in the guided-recipe-* namespace.  See App.css section
-// header at ~line 4420 for the reuse documentation.
+// This is pure card chrome with zero step-list-specific styling.  New rules added
+// for this widget live in the guided-recipe-* namespace.
 //
-// SCOPE -- submit paths (verified against routes.py:1943-2023 and
-//          state_machine.py:_advance_step_2_5):
+// SCOPE -- submit paths:
 //
 //   WIRED: "Apply recipe" -> chosen: ["accept"]
-//          IMPORTANT: The backend (routes.py:1965-1967) reads edited_values to
-//          reconstruct the RecipeMatch.  This widget MUST echo payload.recipe_name
-//          and payload.slots in edited_values.  Sending edited_values: null causes
-//          the backend to fall back to RecipeMatch(recipe_name="", slots={}) and
-//          fail.  This differs from the plan-body spec which stated null -- the
-//          plan body was incomplete.
+//          The backend reconstructs the RecipeMatch from edited_values; the
+//          widget MUST send the merged slot map (pre-filled + operator-supplied).
+//          Disabled until every required unsatisfied slot has a non-empty
+//          trimmed value (offensive UX: the same constraint the backend will
+//          enforce, surfaced earlier).
 //
 //   WIRED: "Build manually" -> chosen: ["build_manually"]
 //          Backend only reads chosen on this path; edited_values: null is correct.
@@ -48,13 +43,12 @@
 //   NOT WIRED: alternatives-based alternative recipe selection.  The current
 //          backend only accepts ["accept"] or ["build_manually"]; any other chosen
 //          value returns HTTP 400.  The alternatives list is displayed for user
-//          information only.  If the user wants an alternative, Build Manually
-//          advances to Step 3 for manual construction.
+//          information only.
 //
 // WIRE-SHAPE:
 //   Apply recipe:   { chosen: ["accept"],
 //                     edited_values: { recipe_name: payload.recipe_name,
-//                                      slots: payload.slots },
+//                                      slots: { ...payload.slots, ...inputs } },
 //                     custom_inputs: null, accepted_step_index: null,
 //                     edit_step_index: null, control_signal: null }
 //   Build manually: { chosen: ["build_manually"],
@@ -62,18 +56,25 @@
 //                     accepted_step_index: null, edit_step_index: null,
 //                     control_signal: null }
 //
-// STATE:
-//   Zero widget-side state.  Each button is a pure click -> submit; no
-//   intermediate state is accumulated.  The firstRunRef focus-skip pattern is
-//   not needed (no view transitions).
+// SECURITY -- api_key_secret and other slot_type="str" inputs:
+//   "api_key_secret" carries the NAME of an inventory secret_ref, not a literal
+//   credential.  All str slots render with <input type="text">.  Using
+//   type="password" would suggest pasting a raw key, which the audit trail would
+//   then record verbatim through edited_values — that is the exact thing the
+//   secret_ref indirection exists to prevent.
 //
-// FOCUS MANAGEMENT:
-//   No programmatic focus on mount or interaction.  No view transitions or
-//   collapsible regions that would trigger the focus management patterns used in
-//   InspectAndConfirmTurn and SchemaFormTurn.
+// NUMERIC slots (slot_type="int" / "float"):
+//   Rendered with <input type="number">.  The backend recipe coercion accepts
+//   string forms ("42" → 42), so the input value is submitted as the raw string;
+//   no per-type coercion in the widget.
+//
+// STATE:
+//   Local state holds one string per unsatisfied slot, keyed by slot name.
+//   Initialised to "" for each entry.  Inputs are controlled.  Typing into
+//   inputs is not a "click" for the demo SLA budget.
 
-import { useId } from "react";
-import type { GuidedRespondRequest, RecipeOfferPayload } from "@/types/guided";
+import { useId, useMemo, useState } from "react";
+import type { GuidedRespondRequest, RecipeOfferPayload, RecipeSlotInput } from "@/types/guided";
 
 interface RecipeOfferTurnProps {
   payload: RecipeOfferPayload;
@@ -86,9 +87,6 @@ interface RecipeOfferTurnProps {
  * Scalars (string, number, boolean) are coerced to string.  Null/undefined
  * render as "null".  Arrays and objects are JSON-stringified so the user sees
  * the structure without a full JSON editor component.
- *
- * Mirrors formatOptionValue in ProposeChainTurn.  Not extracted to a shared
- * helper: two call sites do not meet the rule-of-three extraction threshold.
  */
 function formatSlotValue(value: unknown): string {
   if (value === null || value === undefined) return "null";
@@ -99,6 +97,20 @@ function formatSlotValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+/**
+ * Map a slot_type to the appropriate <input type="..."> value.
+ *
+ * "str" / "blob_id" / "str_list" all render as type="text".  Critically,
+ * type="password" is NEVER returned — api_key_secret carries the NAME of an
+ * inventory secret_ref, not the credential itself; the audit trail records
+ * edited_values verbatim, so masking the input would mislead the operator
+ * into pasting raw credentials.
+ */
+function inputTypeForSlot(slotType: RecipeSlotInput["slot_type"]): "text" | "number" {
+  if (slotType === "int" || slotType === "float") return "number";
+  return "text";
+}
+
 export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
   // useId scopes DOM IDs per-instance so multiple RecipeOfferTurns rendered
   // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
@@ -106,16 +118,48 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
   const reactId = useId();
   const slotsId = `${reactId}-slots`;
   const alternativesId = `${reactId}-alts`;
+  const inputsId = `${reactId}-inputs`;
+
+  // Controlled inputs for each unsatisfied slot, keyed by slot name.
+  // Initial value is "" — the disabled-state check below treats trimmed empty
+  // as "not filled", so the Apply button stays disabled until the operator
+  // supplies every required value.
+  const initialInputs = useMemo<Record<string, string>>(() => {
+    const seed: Record<string, string> = {};
+    for (const slot of payload.unsatisfied_slots) {
+      seed[slot.name] = "";
+    }
+    return seed;
+  }, [payload.unsatisfied_slots]);
+  const [slotInputs, setSlotInputs] = useState<Record<string, string>>(initialInputs);
+
+  function setSlotInput(name: string, value: string) {
+    setSlotInputs((prev) => ({ ...prev, [name]: value }));
+  }
+
+  // Apply is disabled until every required unsatisfied slot has a non-empty
+  // trimmed value.  This mirrors the backend's validate_slots check — fail
+  // fast at the UI rather than burn a round-trip on an HTTP 400.
+  const applyDisabled = payload.unsatisfied_slots.some((slot) => {
+    if (!slot.required) return false;
+    const value = slotInputs[slot.name] ?? "";
+    return value.trim() === "";
+  });
 
   function handleApply() {
-    // MUST echo recipe_name and slots in edited_values.
-    // Backend (routes.py:1965-1967) reads these to reconstruct the RecipeMatch.
-    // edited_values: null would silently produce RecipeMatch("", {}) and fail.
+    // Merge pre-filled slots with operator inputs.  Operator inputs take
+    // precedence in collisions, though the backend resolver only writes the
+    // pre-filled slots it can derive and the unsatisfied list is by definition
+    // disjoint from those — collision is not expected in practice.
+    const mergedSlots: Record<string, unknown> = {
+      ...payload.slots,
+      ...slotInputs,
+    };
     onSubmit({
       chosen: ["accept"],
       edited_values: {
         recipe_name: payload.recipe_name,
-        slots: payload.slots,
+        slots: mergedSlots,
       },
       custom_inputs: null,
       accepted_step_index: null,
@@ -125,8 +169,6 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
   }
 
   function handleBuildManually() {
-    // Backend only reads chosen on this path (routes.py:1988-2018).
-    // edited_values: null is correct here.
     onSubmit({
       chosen: ["build_manually"],
       edited_values: null,
@@ -141,18 +183,9 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
 
   return (
     <div className="guided-turn guided-recipe-offer">
-      {/* Single card: recipe name + slot summary + alternatives + actions */}
       <div className="guided-propose-step-card guided-recipe-card">
-        {/* Recipe name as <h3> for screen-reader landmark navigation.
-            Same convention as ProposeChainTurn's step plugin headings (Task 7.6 M3).
-            Font-size is pinned to --font-size-base via .guided-recipe-name in App.css
-            so the browser's default <h3> sizing does not bleed through. */}
         <h3 className="guided-recipe-name">{payload.recipe_name}</h3>
 
-        {/* Slot summary as a key-value definition list.
-            <dl> is used because (key, value) pairs form a description/definition
-            relationship -- <dt> for key, <dd> for value.  Mirrors ProposeChainTurn's
-            options rendering pattern. */}
         {slotKeys.length > 0 && (
           <dl id={slotsId} className="guided-recipe-slots">
             {slotKeys.map((key) => (
@@ -166,10 +199,49 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
           </dl>
         )}
 
-        {/* Alternatives list -- only rendered when non-empty (negative-space pin).
-            Displayed for user information; no submit path for alternatives exists
-            in the current backend (only ["accept"] and ["build_manually"] are
-            valid).  See SCOPE NOTE in the file header. */}
+        {/* Unsatisfied required slots: inline editable form fields.
+            Rendered between the pre-filled slot summary and the action row so
+            the operator sees the partial state then fills the gaps. */}
+        {payload.unsatisfied_slots.length > 0 && (
+          <fieldset id={inputsId} className="guided-recipe-inputs">
+            <legend className="guided-recipe-inputs-legend">
+              Additional values required
+            </legend>
+            {payload.unsatisfied_slots.map((slot) => {
+              const inputId = `${reactId}-input-${slot.name}`;
+              const descriptionId = `${reactId}-desc-${slot.name}`;
+              const inputType = inputTypeForSlot(slot.slot_type);
+              return (
+                <div key={slot.name} className="guided-recipe-input-row">
+                  <label htmlFor={inputId} className="guided-recipe-input-label">
+                    {slot.name}
+                    {slot.required && (
+                      <span className="guided-recipe-input-required" aria-hidden="true">
+                        {" *"}
+                      </span>
+                    )}
+                  </label>
+                  <input
+                    id={inputId}
+                    type={inputType}
+                    className="guided-recipe-input-field"
+                    value={slotInputs[slot.name] ?? ""}
+                    onChange={(event) => setSlotInput(slot.name, event.target.value)}
+                    required={slot.required}
+                    aria-describedby={slot.description ? descriptionId : undefined}
+                    aria-required={slot.required}
+                  />
+                  {slot.description && (
+                    <p id={descriptionId} className="guided-recipe-input-hint">
+                      {slot.description}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </fieldset>
+        )}
+
         {payload.alternatives.length > 0 && (
           <div className="guided-recipe-alternatives">
             <p className="guided-recipe-alternatives-heading">Alternatives:</p>
@@ -183,16 +255,12 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
           </div>
         )}
 
-        {/* Action row: Apply recipe + Build manually.
-            Two separate handlers; each constructs its own body literal.
-            No "construct chosen body" helper extracted: rule of three requires
-            a third widget before justifying extraction (ProposeChainTurn + this
-            widget = 2 sites). */}
         <div className="guided-recipe-actions">
           <button
             type="button"
             className="guided-recipe-apply-btn"
             onClick={handleApply}
+            disabled={applyDisabled}
           >
             Apply recipe
           </button>

--- a/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/RecipeOfferTurn.tsx
@@ -137,11 +137,12 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
     setSlotInputs((prev) => ({ ...prev, [name]: value }));
   }
 
-  // Apply is disabled until every required unsatisfied slot has a non-empty
-  // trimmed value.  This mirrors the backend's validate_slots check — fail
-  // fast at the UI rather than burn a round-trip on an HTTP 400.
+  // Apply is disabled until every unsatisfied slot has a non-empty trimmed
+  // value.  RecipeSlotInput.required is absent from the wire shape because the
+  // RecipeMatch invariant guarantees every entry is required — treat all as
+  // required here.  Mirrors the backend's validate_slots check: fail fast at
+  // the UI rather than burn a round-trip on an HTTP 400.
   const applyDisabled = payload.unsatisfied_slots.some((slot) => {
-    if (!slot.required) return false;
     const value = slotInputs[slot.name] ?? "";
     return value.trim() === "";
   });
@@ -215,11 +216,11 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
                 <div key={slot.name} className="guided-recipe-input-row">
                   <label htmlFor={inputId} className="guided-recipe-input-label">
                     {slot.name}
-                    {slot.required && (
-                      <span className="guided-recipe-input-required" aria-hidden="true">
-                        {" *"}
-                      </span>
-                    )}
+                    {/* Every unsatisfied slot is required by the RecipeMatch invariant;
+                        the asterisk is always shown rather than gated on slot.required. */}
+                    <span className="guided-recipe-input-required" aria-hidden="true">
+                      {" *"}
+                    </span>
                   </label>
                   <input
                     id={inputId}
@@ -227,9 +228,9 @@ export function RecipeOfferTurn({ payload, onSubmit }: RecipeOfferTurnProps) {
                     className="guided-recipe-input-field"
                     value={slotInputs[slot.name] ?? ""}
                     onChange={(event) => setSlotInput(slot.name, event.target.value)}
-                    required={slot.required}
+                    required
                     aria-describedby={slot.description ? descriptionId : undefined}
-                    aria-required={slot.required}
+                    aria-required="true"
                   />
                   {slot.description && (
                     <p id={descriptionId} className="guided-recipe-input-hint">

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
@@ -375,13 +375,11 @@ describe("required vs advanced split", () => {
 // ── 3. Prefill-vs-default precedence ─────────────────────────────────────────
 
 describe("prefill vs default precedence", () => {
-  it("shows the prefilled value for a field present in prefilled", async () => {
-    const user = userEvent.setup();
+  it("shows the prefilled value for a field present in prefilled", () => {
     renderTurn(NUMERIC_PAYLOAD);
     // mode is required and prefilled with "read"
     const select = screen.getByRole("combobox", { name: /mode/i });
     expect((select as HTMLSelectElement).value).toBe("read");
-    void user; // prevent unused-variable lint
   });
 
   it("shows the schema default for an optional field not in prefilled", async () => {
@@ -414,7 +412,6 @@ describe("prefill vs default precedence", () => {
     const textarea = screen.getByRole("textbox", { name: /tags/i }) as HTMLTextAreaElement;
     // Prefilled is ["alpha","beta"] -- should appear as JSON
     expect(JSON.parse(textarea.value)).toEqual(["alpha", "beta"]);
-    void user;
   });
 
   it("shows parseable JSON for a $ref field with no prefill and no default", async () => {
@@ -426,7 +423,6 @@ describe("prefill vs default precedence", () => {
     const textarea = screen.getByRole("textbox", { name: /nested config/i }) as HTMLTextAreaElement;
     // Pin round-trip: whatever value appears, it must be valid JSON
     expect(() => JSON.parse(textarea.value)).not.toThrow();
-    void user;
   });
 });
 
@@ -509,6 +505,37 @@ describe("submit wire shape", () => {
     expect(edited_values).toHaveProperty("tags");
     expect((edited_values as Record<string, unknown>)["tags"]).toEqual(["alpha", "beta"]);
   });
+
+  it("optional numeric field left blank submits as null, NOT empty string", async () => {
+    // Tier 2 type contract: a numeric-typed slot must not receive a string.
+    // The widget owes the schema-declared type at the trust boundary.
+    const blankNumericPayload: SchemaFormPayload = {
+      plugin: "x",
+      schema_block: {
+        type: "object",
+        properties: {
+          name: { type: "string", title: "Name" },
+          // optional integer: no default, no prefill -> initial value ""
+          batch_size: { type: "integer", title: "Batch size" },
+        },
+        required: ["name"],
+      },
+      prefilled: {},
+    };
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={blankNumericPayload} onSubmit={onSubmit} />);
+
+    // Fill the required string and continue (leaving batch_size blank)
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "x");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0];
+    // batch_size MUST appear (every-property invariant) but as null, not ""
+    expect(edited_values).toHaveProperty("batch_size");
+    expect((edited_values as Record<string, unknown>)["batch_size"]).toBeNull();
+    expect((edited_values as Record<string, unknown>)["batch_size"]).not.toBe("");
+  });
 });
 
 // ── 5. Continue disabled invariant ────────────────────────────────────────────
@@ -557,7 +584,7 @@ describe("Continue disabled invariant", () => {
     expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
   });
 
-  it("disables Continue when all fields are optional and advanced is collapsed (all-optional schema always enabled)", () => {
+  it("all-optional schema enables Continue immediately", () => {
     // With no required fields, Continue is always enabled since there's nothing blocking
     renderTurn(ALL_OPTIONAL_PAYLOAD);
     expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
@@ -624,6 +651,57 @@ describe("focus management", () => {
     // After collapse, focus goes to the toggle button
     const showBtn = screen.getByRole("button", { name: /show advanced/i });
     expect(document.activeElement).toBe(showBtn);
+  });
+});
+
+// ── 7a. WAI-ARIA contract for the advanced-toggle expand/collapse pair ──────
+
+describe("aria-controls / aria-expanded contract", () => {
+  it("toggle button's aria-controls points to the optional-fields region after expand", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    const toggle = screen.getByRole("button", { name: /show advanced/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    // aria-expanded reflects collapsed state initially
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+    // After expand, the region with that id must exist in the DOM
+    const region = document.getElementById(controlsId!);
+    expect(region).not.toBeNull();
+    // And aria-expanded flips
+    const hideBtn = screen.getByRole("button", { name: /hide advanced/i });
+    expect(hideBtn).toHaveAttribute("aria-expanded", "true");
+    expect(hideBtn.getAttribute("aria-controls")).toBe(controlsId);
+  });
+
+  it("optional-fields region announces itself as a labelled region", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    // role=region + aria-label gives screen readers a discoverable landmark
+    const region = screen.getByRole("region", { name: /optional fields/i });
+    expect(region).toBeInTheDocument();
+  });
+});
+
+// ── 7b. aria-disabled belt-and-braces on Continue ───────────────────────────
+
+describe("aria-disabled mirrors disabled on Continue", () => {
+  it("Continue carries aria-disabled when canSubmit is false", () => {
+    renderTurn(CSV_PAYLOAD);
+    // path is required and empty -> Continue disabled
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("Continue drops aria-disabled when canSubmit becomes true", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data");
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toHaveAttribute("aria-disabled", "false");
   });
 });
 

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
@@ -417,14 +417,14 @@ describe("prefill vs default precedence", () => {
     void user;
   });
 
-  it("shows '[]' in a JSON-fallback array textarea with no prefill and no default", async () => {
+  it("shows parseable JSON for a $ref field with no prefill and no default", async () => {
     const user = userEvent.setup();
-    // REF_PAYLOAD has nested_config with $ref and no prefill
+    // REF_PAYLOAD has nested_config with $ref and no prefill; initialValueFor
+    // emits "null" (a valid JSON literal) as the sentinel for object/$ref fields
     renderTurn(REF_PAYLOAD);
     await user.click(screen.getByRole("button", { name: /show advanced/i }));
     const textarea = screen.getByRole("textbox", { name: /nested config/i }) as HTMLTextAreaElement;
-    // null prefill -> render as "null" JSON for object/$ref
-    // (any JSON-valid representation is acceptable; pin round-trip)
+    // Pin round-trip: whatever value appears, it must be valid JSON
     expect(() => JSON.parse(textarea.value)).not.toThrow();
     void user;
   });

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
@@ -657,6 +657,21 @@ describe("focus management", () => {
 // ── 7a. WAI-ARIA contract for the advanced-toggle expand/collapse pair ──────
 
 describe("aria-controls / aria-expanded contract", () => {
+  it("aria-controls id resolves to a DOM element even when collapsed (initial render)", () => {
+    // Regression pin: in the collapsed (initial) state, aria-controls on the
+    // toggle button MUST point to an element that exists in the DOM.
+    // Otherwise the relationship is a dangling reference -- a screen-reader
+    // user discovering the toggle via Tab BEFORE first expansion cannot
+    // resolve "expanded/collapsed WHAT". The container survives collapse via
+    // the `hidden` attribute (which removes it from the AT tree and hides
+    // it visually) but keeps the id resolvable.
+    renderTurn(CSV_PAYLOAD);
+    const toggle = screen.getByRole("button", { name: /show advanced/i });
+    const controlsId = toggle.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+  });
+
   it("toggle button's aria-controls points to the optional-fields region after expand", async () => {
     const user = userEvent.setup();
     renderTurn(CSV_PAYLOAD);

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
@@ -427,9 +427,17 @@ describe("prefill vs default precedence", () => {
 });
 
 // ── 4. Submit wire shape ──────────────────────────────────────────────────────
+//
+// The backend's SCHEMA_FORM dispatcher requires:
+//   { plugin, options, observed_columns, sample_rows }
+// where options contains every property from schema_block.properties.
+// The five "all-null" sibling fields on GuidedRespondRequest are also checked.
 
 describe("submit wire shape", () => {
-  it("fires onSubmit with all-null fields except edited_values on Continue", async () => {
+  it("fires onSubmit with the structured {plugin,options,observed_columns,sample_rows} shape", async () => {
+    // Core regression pin: the backend SCHEMA_FORM dispatcher at STEP_1_SOURCE
+    // requires "plugin" in edited_values. The flat-dict shape (direct field names
+    // at the top level) produces HTTP 422. This test pins the correct structure.
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
@@ -439,15 +447,34 @@ describe("submit wire shape", () => {
 
     expect(onSubmit).toHaveBeenCalledOnce();
     const body = onSubmit.mock.calls[0][0];
+    // All six GuidedRespondRequest fields must be explicitly set.
     expect(body).toEqual({
       ...nullResponse(),
       chosen: null,
       custom_inputs: null,
-      edited_values: expect.objectContaining({ path: "/data/file.csv" }),
+      edited_values: {
+        plugin: "csv",
+        options: expect.objectContaining({ path: "/data/file.csv" }),
+        observed_columns: [],
+        sample_rows: [],
+      },
     });
   });
 
-  it("includes EVERY schema property in edited_values (touched and untouched)", async () => {
+  it("includes plugin from payload.plugin regardless of form content", async () => {
+    // plugin is sourced from payload.plugin (the SINGLE_SELECT choice), never
+    // from the form fields themselves.
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={NUMERIC_PAYLOAD} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    expect(edited_values["plugin"]).toBe("database");
+  });
+
+  it("includes EVERY schema property in edited_values.options (touched and untouched)", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
@@ -455,15 +482,40 @@ describe("submit wire shape", () => {
     await user.type(screen.getByRole("textbox", { name: /path/i }), "/data/file.csv");
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    const { edited_values } = onSubmit.mock.calls[0][0];
-    // All four properties must be present; optional ones at their defaults
-    expect(edited_values).toHaveProperty("path", "/data/file.csv");
-    expect(edited_values).toHaveProperty("delimiter", ",");
-    expect(edited_values).toHaveProperty("has_header", true);
-    expect(edited_values).toHaveProperty("encoding", "utf-8");
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    const options = edited_values["options"] as Record<string, unknown>;
+    // All four properties must be present in options; optional ones at their defaults
+    expect(options).toHaveProperty("path", "/data/file.csv");
+    expect(options).toHaveProperty("delimiter", ",");
+    expect(options).toHaveProperty("has_header", true);
+    expect(options).toHaveProperty("encoding", "utf-8");
   });
 
-  it("uses prefilled value in edited_values for untouched prefilled fields", async () => {
+  it("observed_columns is always [] (backend populates after source run)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    expect(edited_values["observed_columns"]).toEqual([]);
+  });
+
+  it("sample_rows is always [] (backend populates after source run)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    expect(edited_values["sample_rows"]).toEqual([]);
+  });
+
+  it("uses prefilled value in options for untouched prefilled fields", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={NUMERIC_PAYLOAD} onSubmit={onSubmit} />);
@@ -471,14 +523,15 @@ describe("submit wire shape", () => {
     // mode is required and already prefilled -- just continue
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    const { edited_values } = onSubmit.mock.calls[0][0];
-    expect(edited_values).toHaveProperty("mode", "read");
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    const options = edited_values["options"] as Record<string, unknown>;
+    expect(options).toHaveProperty("mode", "read");
     // optional fields at their defaults
-    expect(edited_values).toHaveProperty("batch_size", 1000);
-    expect(edited_values).toHaveProperty("timeout", 30.0);
+    expect(options).toHaveProperty("batch_size", 1000);
+    expect(options).toHaveProperty("timeout", 30.0);
   });
 
-  it("emits {} edited_values and enables Continue for a schema with no fields", async () => {
+  it("emits empty options {} for a schema with no fields", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={EMPTY_SCHEMA_PAYLOAD} onSubmit={onSubmit} />);
@@ -488,10 +541,14 @@ describe("submit wire shape", () => {
     await user.click(continueBtn);
 
     expect(onSubmit).toHaveBeenCalledOnce();
-    expect(onSubmit.mock.calls[0][0].edited_values).toEqual({});
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    expect(edited_values["plugin"]).toBe("passthrough");
+    expect(edited_values["options"]).toEqual({});
+    expect(edited_values["observed_columns"]).toEqual([]);
+    expect(edited_values["sample_rows"]).toEqual([]);
   });
 
-  it("includes parsed JSON value for a JSON-fallback field in edited_values", async () => {
+  it("includes parsed JSON value for a JSON-fallback field in options", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={FALLBACK_PAYLOAD} onSubmit={onSubmit} />);
@@ -500,13 +557,14 @@ describe("submit wire shape", () => {
     await user.type(screen.getByRole("textbox", { name: /name/i }), "my-transform");
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    const { edited_values } = onSubmit.mock.calls[0][0];
-    // tags was prefilled as ["alpha","beta"] -- should appear parsed
-    expect(edited_values).toHaveProperty("tags");
-    expect((edited_values as Record<string, unknown>)["tags"]).toEqual(["alpha", "beta"]);
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    const options = edited_values["options"] as Record<string, unknown>;
+    // tags was prefilled as ["alpha","beta"] -- should appear parsed in options
+    expect(options).toHaveProperty("tags");
+    expect(options["tags"]).toEqual(["alpha", "beta"]);
   });
 
-  it("optional numeric field left blank submits as null, NOT empty string", async () => {
+  it("optional numeric field left blank submits as null in options, NOT empty string", async () => {
     // Tier 2 type contract: a numeric-typed slot must not receive a string.
     // The widget owes the schema-declared type at the trust boundary.
     const blankNumericPayload: SchemaFormPayload = {
@@ -530,11 +588,12 @@ describe("submit wire shape", () => {
     await user.type(screen.getByRole("textbox", { name: /name/i }), "x");
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    const { edited_values } = onSubmit.mock.calls[0][0];
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    const options = edited_values["options"] as Record<string, unknown>;
     // batch_size MUST appear (every-property invariant) but as null, not ""
-    expect(edited_values).toHaveProperty("batch_size");
-    expect((edited_values as Record<string, unknown>)["batch_size"]).toBeNull();
-    expect((edited_values as Record<string, unknown>)["batch_size"]).not.toBe("");
+    expect(options).toHaveProperty("batch_size");
+    expect(options["batch_size"]).toBeNull();
+    expect(options["batch_size"]).not.toBe("");
   });
 });
 
@@ -787,7 +846,7 @@ describe("edge cases", () => {
     expect(btn.textContent).toMatch(/3/);
   });
 
-  it("parses valid JSON in a fallback textarea and includes it in submit", async () => {
+  it("parses valid JSON in a fallback textarea and includes it in options", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<SchemaFormTurn payload={FALLBACK_PAYLOAD} onSubmit={onSubmit} />);
@@ -800,7 +859,8 @@ describe("edge cases", () => {
     fireEvent.change(tagsTextarea, { target: { value: '["x","y"]' } });
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    const { edited_values } = onSubmit.mock.calls[0][0];
-    expect((edited_values as Record<string, unknown>)["tags"]).toEqual(["x", "y"]);
+    const { edited_values } = onSubmit.mock.calls[0][0] as { edited_values: Record<string, unknown> };
+    const options = edited_values["options"] as Record<string, unknown>;
+    expect(options["tags"]).toEqual(["x", "y"]);
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.test.tsx
@@ -1,0 +1,713 @@
+// ============================================================================
+// SchemaFormTurn -- wire-response and rendering contract regression coverage.
+//
+// Pins SIX contracts (see implementation header for full rationale):
+//   1. Field-type-to-control mapping:
+//        string (no enum)     -> <input type="text">
+//        string with enum     -> <select> + <option> per enum value
+//        integer              -> <input type="number" step="1">
+//        number               -> <input type="number" step="any">
+//        boolean              -> <input type="checkbox">
+//        array / object / $ref / anyOf -> <textarea> JSON fallback
+//   2. Required-vs-advanced split:
+//        Fields listed in schema_block.required appear unconditionally.
+//        Fields absent from required are hidden until "Show advanced" is clicked.
+//        Toggle is reversible. No toggle button when there are no optional fields.
+//   3. Prefill-vs-default precedence:
+//        prefilled[name] beats schema default beats empty.
+//   4. Submit wire shape (all-properties inclusion):
+//        edited_values contains EVERY property from the schema, using the
+//        user's current input value -- or the prefilled/default for untouched
+//        fields. Other five GuidedRespondRequest fields are explicitly null.
+//   5. JSON-fallback behaviour:
+//        Fallback fields show stringified initial value; invalid JSON shows an
+//        inline error and disables Continue.
+//   6. Focus management on advanced toggle:
+//        No auto-focus on initial mount; first advanced field gets focus on
+//        Show-advanced click; re-collapsing focuses the toggle button.
+//
+// Source of truth:
+//   - protocol.py:53-56 (SchemaFormPayload wire shape)
+//   - schema_block = Pydantic ConfigModel.model_json_schema() output
+//   - state_machine.py:_advance_step_1 confirms schema_form is currently an
+//     intra-step turn (returns early without consuming edited_values), but
+//     the full edited_values dict is pre-wired for when the intra-step flow
+//     is connected (Tasks 2.2+).
+// ============================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SchemaFormTurn } from "./SchemaFormTurn";
+import { nullResponse } from "@/test/guided-fixtures";
+import type { GuidedRespondRequest, SchemaFormPayload } from "@/types/guided";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// Realistic Pydantic model_json_schema() output for a CsvSourceSettings model.
+// path is required; delimiter/has_header/encoding are optional with defaults.
+const CSV_PAYLOAD: SchemaFormPayload = {
+  plugin: "csv",
+  schema_block: {
+    title: "CsvSourceSettings",
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        title: "Path",
+        description: "Filesystem path to the CSV file",
+      },
+      delimiter: {
+        type: "string",
+        title: "Delimiter",
+        default: ",",
+      },
+      has_header: {
+        type: "boolean",
+        title: "Has header",
+        default: true,
+      },
+      encoding: {
+        type: "string",
+        title: "Encoding",
+        default: "utf-8",
+      },
+    },
+    required: ["path"],
+  },
+  prefilled: {},
+};
+
+// Schema with an enum string field (required) and integer / number fields (optional).
+const NUMERIC_PAYLOAD: SchemaFormPayload = {
+  plugin: "database",
+  schema_block: {
+    title: "DatabaseSourceSettings",
+    type: "object",
+    properties: {
+      mode: {
+        type: "string",
+        enum: ["read", "write", "append"],
+        title: "Mode",
+      },
+      batch_size: {
+        type: "integer",
+        title: "Batch size",
+        default: 1000,
+      },
+      timeout: {
+        type: "number",
+        title: "Timeout",
+        default: 30.0,
+      },
+    },
+    required: ["mode"],
+  },
+  prefilled: { mode: "read" },
+};
+
+// Schema with an array field (JSON fallback) and an object field (JSON fallback).
+const FALLBACK_PAYLOAD: SchemaFormPayload = {
+  plugin: "transform",
+  schema_block: {
+    title: "TransformSettings",
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        title: "Name",
+      },
+      tags: {
+        type: "array",
+        title: "Tags",
+        items: { type: "string" },
+      },
+      metadata: {
+        type: "object",
+        title: "Metadata",
+      },
+    },
+    required: ["name"],
+  },
+  prefilled: { tags: ["alpha", "beta"], metadata: { version: 1 } },
+};
+
+// Schema with a $ref field (JSON fallback).
+const REF_PAYLOAD: SchemaFormPayload = {
+  plugin: "sink",
+  schema_block: {
+    title: "SinkSettings",
+    type: "object",
+    properties: {
+      target: {
+        type: "string",
+        title: "Target",
+      },
+      nested_config: {
+        $ref: "#/$defs/NestedConfig",
+        title: "Nested config",
+      },
+    },
+    $defs: {
+      NestedConfig: {
+        type: "object",
+        properties: { key: { type: "string" } },
+      },
+    },
+    required: ["target"],
+  },
+  prefilled: {},
+};
+
+// Schema with anyOf field (JSON fallback -- Optional[str] pattern from Pydantic).
+const ANY_OF_PAYLOAD: SchemaFormPayload = {
+  plugin: "filter",
+  schema_block: {
+    title: "FilterSettings",
+    type: "object",
+    properties: {
+      name: { type: "string", title: "Name" },
+      label: {
+        anyOf: [{ type: "string" }, { type: "null" }],
+        title: "Label",
+        default: null,
+      },
+    },
+    required: ["name"],
+  },
+  prefilled: {},
+};
+
+// Schema with NO optional fields -- no "Show advanced" toggle expected.
+const NO_ADVANCED_PAYLOAD: SchemaFormPayload = {
+  plugin: "csv",
+  schema_block: {
+    title: "MinimalSettings",
+    type: "object",
+    properties: {
+      path: { type: "string", title: "Path" },
+    },
+    required: ["path"],
+  },
+  prefilled: {},
+};
+
+// Schema with NO fields at all -- empty form, Continue always enabled.
+const EMPTY_SCHEMA_PAYLOAD: SchemaFormPayload = {
+  plugin: "passthrough",
+  schema_block: {
+    title: "PassthroughSettings",
+    type: "object",
+    properties: {},
+  },
+  prefilled: {},
+};
+
+// Schema with ALL optional fields (no required array at all).
+const ALL_OPTIONAL_PAYLOAD: SchemaFormPayload = {
+  plugin: "sink",
+  schema_block: {
+    title: "SinkSettings",
+    type: "object",
+    properties: {
+      format: { type: "string", title: "Format", default: "json" },
+      compress: { type: "boolean", title: "Compress", default: false },
+    },
+  },
+  prefilled: {},
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderTurn(
+  payload: SchemaFormPayload,
+  onSubmit?: (body: GuidedRespondRequest) => void,
+) {
+  const handler = onSubmit ?? vi.fn();
+  render(<SchemaFormTurn payload={payload} onSubmit={handler} />);
+  return handler;
+}
+
+// ── 1. Field-type rendering ───────────────────────────────────────────────────
+
+describe("field-type rendering", () => {
+  it("renders a string field as <input type='text'>", () => {
+    renderTurn(CSV_PAYLOAD);
+    const input = screen.getByRole("textbox", { name: /path/i });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("wires description to hint text via aria-describedby", () => {
+    renderTurn(CSV_PAYLOAD);
+    const input = screen.getByRole("textbox", { name: /path/i });
+    const describedById = input.getAttribute("aria-describedby");
+    expect(describedById).toBeTruthy();
+    const hint = document.getElementById(describedById!);
+    expect(hint).toHaveTextContent("Filesystem path to the CSV file");
+  });
+
+  it("does NOT wire aria-describedby when description is absent", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    // delimiter has no description
+    const input = screen.getByRole("textbox", { name: /delimiter/i });
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("renders an enum string field as <select>", () => {
+    renderTurn(NUMERIC_PAYLOAD);
+    const select = screen.getByRole("combobox", { name: /mode/i });
+    expect(select.tagName).toBe("SELECT");
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("read");
+    expect(options[1]).toHaveTextContent("write");
+    expect(options[2]).toHaveTextContent("append");
+  });
+
+  it("renders an integer field as <input type='number' step='1'>", async () => {
+    const user = userEvent.setup();
+    renderTurn(NUMERIC_PAYLOAD);
+    // Show advanced first since batch_size is optional
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const input = screen.getByRole("spinbutton", { name: /batch size/i });
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("step", "1");
+  });
+
+  it("renders a number field as <input type='number' step='any'>", async () => {
+    const user = userEvent.setup();
+    renderTurn(NUMERIC_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const input = screen.getByRole("spinbutton", { name: /timeout/i });
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("step", "any");
+  });
+
+  it("renders a boolean field as <input type='checkbox'>", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const checkbox = screen.getByRole("checkbox", { name: /has header/i });
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  it("renders an array field as a <textarea> JSON fallback", async () => {
+    const user = userEvent.setup();
+    renderTurn(FALLBACK_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /tags/i });
+    expect(textarea.tagName).toBe("TEXTAREA");
+  });
+
+  it("renders an object field as a <textarea> JSON fallback", async () => {
+    const user = userEvent.setup();
+    renderTurn(FALLBACK_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /metadata/i });
+    expect(textarea.tagName).toBe("TEXTAREA");
+  });
+
+  it("renders a $ref field as a <textarea> JSON fallback", async () => {
+    const user = userEvent.setup();
+    renderTurn(REF_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /nested config/i });
+    expect(textarea.tagName).toBe("TEXTAREA");
+  });
+
+  it("renders an anyOf field as a <textarea> JSON fallback", async () => {
+    const user = userEvent.setup();
+    renderTurn(ANY_OF_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /label/i });
+    expect(textarea.tagName).toBe("TEXTAREA");
+  });
+});
+
+// ── 2. Required vs advanced split ─────────────────────────────────────────────
+
+describe("required vs advanced split", () => {
+  it("shows required fields without clicking Show advanced", () => {
+    renderTurn(CSV_PAYLOAD);
+    expect(screen.getByRole("textbox", { name: /path/i })).toBeInTheDocument();
+  });
+
+  it("hides optional fields initially", () => {
+    renderTurn(CSV_PAYLOAD);
+    expect(screen.queryByRole("textbox", { name: /delimiter/i })).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: /has header/i })).toBeNull();
+    expect(screen.queryByRole("textbox", { name: /encoding/i })).toBeNull();
+  });
+
+  it("reveals optional fields after clicking Show advanced", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    expect(screen.getByRole("textbox", { name: /delimiter/i })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /has header/i })).toBeInTheDocument();
+  });
+
+  it("hides optional fields again when toggle is clicked a second time", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    await user.click(screen.getByRole("button", { name: /hide advanced/i }));
+    expect(screen.queryByRole("textbox", { name: /delimiter/i })).toBeNull();
+  });
+
+  it("does NOT render the Show advanced button when there are no optional fields", () => {
+    renderTurn(NO_ADVANCED_PAYLOAD);
+    expect(screen.queryByRole("button", { name: /show advanced/i })).toBeNull();
+  });
+
+  it("renders Show advanced when all fields are optional (no required array)", async () => {
+    const user = userEvent.setup();
+    renderTurn(ALL_OPTIONAL_PAYLOAD);
+    const btn = screen.getByRole("button", { name: /show advanced/i });
+    await user.click(btn);
+    expect(screen.getByRole("textbox", { name: /format/i })).toBeInTheDocument();
+  });
+});
+
+// ── 3. Prefill-vs-default precedence ─────────────────────────────────────────
+
+describe("prefill vs default precedence", () => {
+  it("shows the prefilled value for a field present in prefilled", async () => {
+    const user = userEvent.setup();
+    renderTurn(NUMERIC_PAYLOAD);
+    // mode is required and prefilled with "read"
+    const select = screen.getByRole("combobox", { name: /mode/i });
+    expect((select as HTMLSelectElement).value).toBe("read");
+    void user; // prevent unused-variable lint
+  });
+
+  it("shows the schema default for an optional field not in prefilled", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    // delimiter has default "," and is not in CSV_PAYLOAD.prefilled
+    const input = screen.getByRole("textbox", { name: /delimiter/i }) as HTMLInputElement;
+    expect(input.value).toBe(",");
+  });
+
+  it("shows the schema boolean default for a checkbox", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const checkbox = screen.getByRole("checkbox", { name: /has header/i }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("shows empty for a required field with no prefill and no schema default", () => {
+    renderTurn(CSV_PAYLOAD);
+    const input = screen.getByRole("textbox", { name: /path/i }) as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("shows JSON-stringified prefilled value in a JSON-fallback textarea", async () => {
+    const user = userEvent.setup();
+    renderTurn(FALLBACK_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /tags/i }) as HTMLTextAreaElement;
+    // Prefilled is ["alpha","beta"] -- should appear as JSON
+    expect(JSON.parse(textarea.value)).toEqual(["alpha", "beta"]);
+    void user;
+  });
+
+  it("shows '[]' in a JSON-fallback array textarea with no prefill and no default", async () => {
+    const user = userEvent.setup();
+    // REF_PAYLOAD has nested_config with $ref and no prefill
+    renderTurn(REF_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const textarea = screen.getByRole("textbox", { name: /nested config/i }) as HTMLTextAreaElement;
+    // null prefill -> render as "null" JSON for object/$ref
+    // (any JSON-valid representation is acceptable; pin round-trip)
+    expect(() => JSON.parse(textarea.value)).not.toThrow();
+    void user;
+  });
+});
+
+// ── 4. Submit wire shape ──────────────────────────────────────────────────────
+
+describe("submit wire shape", () => {
+  it("fires onSubmit with all-null fields except edited_values on Continue", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data/file.csv");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    const body = onSubmit.mock.calls[0][0];
+    expect(body).toEqual({
+      ...nullResponse(),
+      chosen: null,
+      custom_inputs: null,
+      edited_values: expect.objectContaining({ path: "/data/file.csv" }),
+    });
+  });
+
+  it("includes EVERY schema property in edited_values (touched and untouched)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data/file.csv");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0];
+    // All four properties must be present; optional ones at their defaults
+    expect(edited_values).toHaveProperty("path", "/data/file.csv");
+    expect(edited_values).toHaveProperty("delimiter", ",");
+    expect(edited_values).toHaveProperty("has_header", true);
+    expect(edited_values).toHaveProperty("encoding", "utf-8");
+  });
+
+  it("uses prefilled value in edited_values for untouched prefilled fields", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={NUMERIC_PAYLOAD} onSubmit={onSubmit} />);
+
+    // mode is required and already prefilled -- just continue
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0];
+    expect(edited_values).toHaveProperty("mode", "read");
+    // optional fields at their defaults
+    expect(edited_values).toHaveProperty("batch_size", 1000);
+    expect(edited_values).toHaveProperty("timeout", 30.0);
+  });
+
+  it("emits {} edited_values and enables Continue for a schema with no fields", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={EMPTY_SCHEMA_PAYLOAD} onSubmit={onSubmit} />);
+
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).not.toBeDisabled();
+    await user.click(continueBtn);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit.mock.calls[0][0].edited_values).toEqual({});
+  });
+
+  it("includes parsed JSON value for a JSON-fallback field in edited_values", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={FALLBACK_PAYLOAD} onSubmit={onSubmit} />);
+
+    // name is required
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "my-transform");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0];
+    // tags was prefilled as ["alpha","beta"] -- should appear parsed
+    expect(edited_values).toHaveProperty("tags");
+    expect((edited_values as Record<string, unknown>)["tags"]).toEqual(["alpha", "beta"]);
+  });
+});
+
+// ── 5. Continue disabled invariant ────────────────────────────────────────────
+
+describe("Continue disabled invariant", () => {
+  it("disables Continue when a required string field is empty", () => {
+    renderTurn(CSV_PAYLOAD);
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it("enables Continue once the required string field has a value", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.type(screen.getByRole("textbox", { name: /path/i }), "/data");
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+
+  it("clicking disabled Continue does NOT fire onSubmit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={onSubmit} />);
+    // path is empty, Continue is disabled
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("enables Continue when the required field is a prefilled enum select", () => {
+    // NUMERIC_PAYLOAD prefills mode="read" -- Continue should be enabled immediately
+    renderTurn(NUMERIC_PAYLOAD);
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+
+  it("a required boolean checkbox always satisfies the required check", () => {
+    const boolRequiredPayload: SchemaFormPayload = {
+      plugin: "x",
+      schema_block: {
+        type: "object",
+        properties: { enabled: { type: "boolean", title: "Enabled" } },
+        required: ["enabled"],
+      },
+      prefilled: {},
+    };
+    renderTurn(boolRequiredPayload);
+    // boolean is always present (true or false) -- should be enabled
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+
+  it("disables Continue when all fields are optional and advanced is collapsed (all-optional schema always enabled)", () => {
+    // With no required fields, Continue is always enabled since there's nothing blocking
+    renderTurn(ALL_OPTIONAL_PAYLOAD);
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+
+  it("disables Continue when a JSON-fallback field has a parse error", async () => {
+    const user = userEvent.setup();
+    renderTurn(FALLBACK_PAYLOAD);
+
+    // name is required -- fill it
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "x");
+
+    // tags textarea shows prefilled JSON -- set it to invalid JSON via fireEvent
+    // (userEvent.type interprets { and " as special key descriptors; fireEvent.change
+    // sets the value directly without key-descriptor parsing)
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const tagsTextarea = screen.getByRole("textbox", { name: /tags/i });
+    fireEvent.change(tagsTextarea, { target: { value: "not valid json {" } });
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    // An inline error message should be visible
+    expect(screen.getByText(/invalid json/i)).toBeInTheDocument();
+  });
+
+  it("re-enables Continue after fixing a JSON parse error", async () => {
+    const user = userEvent.setup();
+    renderTurn(FALLBACK_PAYLOAD);
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "x");
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+
+    const tagsTextarea = screen.getByRole("textbox", { name: /tags/i });
+    fireEvent.change(tagsTextarea, { target: { value: "not valid json {" } });
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.change(tagsTextarea, { target: { value: '["fixed"]' } });
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+});
+
+// ── 6. Focus management ───────────────────────────────────────────────────────
+
+describe("focus management", () => {
+  it("does NOT auto-focus any input on initial mount", () => {
+    renderTurn(CSV_PAYLOAD);
+    const path = screen.getByRole("textbox", { name: /path/i });
+    expect(document.activeElement).not.toBe(path);
+  });
+
+  it("focuses the first newly-revealed advanced field on Show advanced click", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    // First advanced field for CSV_PAYLOAD is "delimiter"
+    const delimiter = screen.getByRole("textbox", { name: /delimiter/i });
+    expect(document.activeElement).toBe(delimiter);
+  });
+
+  it("focuses the toggle button after re-collapsing advanced", async () => {
+    const user = userEvent.setup();
+    renderTurn(CSV_PAYLOAD);
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+    const hideBtn = screen.getByRole("button", { name: /hide advanced/i });
+    await user.click(hideBtn);
+    // After collapse, focus goes to the toggle button
+    const showBtn = screen.getByRole("button", { name: /show advanced/i });
+    expect(document.activeElement).toBe(showBtn);
+  });
+});
+
+// ── 7. Distinctness pin (useId) ───────────────────────────────────────────────
+
+describe("useId distinctness", () => {
+  it("two simultaneous instances have distinct DOM nodes for label targets", async () => {
+    const user = userEvent.setup();
+    const { container: c1 } = render(
+      <SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+    const { container: c2 } = render(
+      <SchemaFormTurn payload={CSV_PAYLOAD} onSubmit={vi.fn()} />,
+    );
+
+    // Expand advanced in both so all inputs are present
+    const showBtns = screen.getAllByRole("button", { name: /show advanced/i });
+    for (const btn of showBtns) {
+      await user.click(btn);
+    }
+
+    // Get path inputs from each container -- they must be distinct DOM nodes
+    const pathInputs = screen.getAllByRole("textbox", { name: /path/i });
+    expect(pathInputs.length).toBeGreaterThanOrEqual(2);
+    expect(pathInputs[0]).not.toBe(pathInputs[1]);
+
+    // IDs must be distinct strings
+    const id1 = pathInputs[0].id;
+    const id2 = pathInputs[1].id;
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id1).not.toBe(id2);
+
+    void c1;
+    void c2;
+  });
+});
+
+// ── 8. Edge cases ─────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("renders gracefully with no properties (empty form, Continue enabled)", () => {
+    renderTurn(EMPTY_SCHEMA_PAYLOAD);
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+    expect(screen.queryByRole("button", { name: /show advanced/i })).toBeNull();
+  });
+
+  it("title falls back to property name when title is absent", () => {
+    const noTitlePayload: SchemaFormPayload = {
+      plugin: "x",
+      schema_block: {
+        type: "object",
+        properties: {
+          my_field: { type: "string" },
+        },
+        required: ["my_field"],
+      },
+      prefilled: {},
+    };
+    renderTurn(noTitlePayload);
+    // Should render with label derived from property name
+    expect(screen.getByRole("textbox", { name: /my_field/i })).toBeInTheDocument();
+  });
+
+  it("renders Show advanced (N) with count of optional fields", () => {
+    renderTurn(CSV_PAYLOAD); // 3 optional fields
+    const btn = screen.getByRole("button", { name: /show advanced/i });
+    expect(btn.textContent).toMatch(/3/);
+  });
+
+  it("parses valid JSON in a fallback textarea and includes it in submit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SchemaFormTurn payload={FALLBACK_PAYLOAD} onSubmit={onSubmit} />);
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "t");
+    await user.click(screen.getByRole("button", { name: /show advanced/i }));
+
+    // Use fireEvent.change for JSON content to avoid userEvent key-descriptor
+    // parsing of special characters like "[", '"', and "]".
+    const tagsTextarea = screen.getByRole("textbox", { name: /tags/i });
+    fireEvent.change(tagsTextarea, { target: { value: '["x","y"]' } });
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    const { edited_values } = onSubmit.mock.calls[0][0];
+    expect((edited_values as Record<string, unknown>)["tags"]).toEqual(["x", "y"]);
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
@@ -220,10 +220,12 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
   // Derive the ordered list of properties from the schema once.
   // schema_block.properties is a plain object; we preserve declaration order
   // (JS spec guarantees string-keyed insertion order on plain objects).
-  const properties = (payload.schema_block["properties"] ?? {}) as Record<
-    string,
-    PropSchema
-  >;
+  // Pydantic always emits the "properties" key -- even for models with no fields
+  // it emits `"properties": {}`. We do NOT defensively ?? {} here: if the wire
+  // somehow omits "properties", Object.keys(undefined) crashes loudly and
+  // attributably (per CLAUDE.md offensive programming). The EMPTY_SCHEMA_PAYLOAD
+  // test covers the legitimate `properties: {}` case.
+  const properties = payload.schema_block["properties"] as Record<string, PropSchema>;
   const propertyNames = Object.keys(properties);
 
   // Required fields: those listed in schema_block.required (may be absent).
@@ -409,7 +411,7 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
     const description = typeof prop["description"] === "string" ? prop["description"] : null;
     const inputId = fieldInputId(name);
     const hintId = description !== null ? fieldHintId(name) : undefined;
-    const errorId = fieldHintId(name) !== undefined ? fieldErrorId(name) : fieldErrorId(name);
+    const errorId = fieldErrorId(name);
     const hasError = (formState.errors[name] ?? "") !== "";
     const val = formState.values[name];
 

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
@@ -597,18 +597,23 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
               ? "Hide advanced"
               : `Show advanced (${optionalNames.length})`}
           </button>
-          {advancedExpanded && (
-            <div
-              id={optionalSectionId}
-              role="region"
-              aria-label="Optional fields"
-              className="guided-schema-optional-section"
-            >
-              {optionalNames.map((name, idx) =>
-                renderField(name, idx === 0),
-              )}
-            </div>
-          )}
+          {/* Container is rendered UNCONDITIONALLY so the toggle's
+              aria-controls reference resolves on initial render (before first
+              expansion). When collapsed, the `hidden` attribute removes it
+              from the accessibility tree AND hides it visually
+              (`[hidden] { display: none; }` is the browser default). The
+              CHILDREN are still gated on `advancedExpanded` so optional
+              fields don't run their ref callbacks until the user opts in. */}
+          <div
+            id={optionalSectionId}
+            role="region"
+            aria-label="Optional fields"
+            className="guided-schema-optional-section"
+            hidden={!advancedExpanded}
+          >
+            {advancedExpanded &&
+              optionalNames.map((name, idx) => renderField(name, idx === 0))}
+          </div>
         </>
       )}
 

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
@@ -52,6 +52,13 @@
 //   "single source of truth" convention -- the same error set drives both the inline
 //   error message and the continue-disabled predicate.
 //
+// EMPTY OPTIONAL NUMERIC:
+//   Submitted as null per the Tier 2 type contract -- an empty string in a numeric
+//   slot would violate the schema-declared type at the trust boundary. Null preserves
+//   the "edited_values includes EVERY property" invariant while letting the server
+//   distinguish "user explicitly cleared" from "field was never offered." Required
+//   numeric fields are blocked by canSubmit so they never reach this branch.
+//
 // STATE SPLIT:
 //   formState: { values, errors } -- owned by the form; submitted on Continue.
 //   advancedExpanded: boolean     -- owned separately; orthogonal to form values.
@@ -258,6 +265,12 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
   const fieldInputId = (name: string) => `${reactId}-field-${name}`;
   const fieldHintId = (name: string) => `${reactId}-hint-${name}`;
   const fieldErrorId = (name: string) => `${reactId}-error-${name}`;
+  // Optional-fields region id: paired with the toggle button's aria-controls so
+  // assistive tech announces "expanded/collapsed <Optional fields>" not just
+  // "expanded/collapsed". Convention-setting for Task 7.9 (GuidedHistory) which
+  // is also a collapsible region -- both widgets land the WAI-ARIA pattern
+  // together rather than copying a gap.
+  const optionalSectionId = `${reactId}-optional-section`;
 
   // Partition properties into required / optional based on schema.required.
   const requiredNames = propertyNames.filter((n) => requiredFields.has(n));
@@ -370,6 +383,15 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
     // JSON-fallback fields are re-parsed here; any parse error would have
     // already been caught by hasParseErrors and canSubmit would be false, so
     // this parse is guaranteed to succeed at submit time.
+    //
+    // EMPTY OPTIONAL NUMERIC: an empty string in a number-int / number-float
+    // field is submitted as null, NOT as "" (which would violate the Tier 2
+    // type contract -- the schema declares int/float and the widget owes the
+    // declared type at the trust boundary). Required-empty numerics are
+    // already blocked by canSubmit and never reach this branch.
+    // Rationale: null preserves the "edited_values includes EVERY property"
+    // invariant documented in the file header, while letting the server
+    // distinguish "user explicitly cleared" from "field was never offered."
     const edited_values: Record<string, unknown> = {};
     for (const name of propertyNames) {
       const ft = inferFieldType(properties[name]);
@@ -378,12 +400,21 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
         // raw is the textarea string; parse it back to the structured value.
         // canSubmit guarantees no parse errors here.
         edited_values[name] = JSON.parse(raw as string);
-      } else if (ft === "number-int") {
-        const n = parseInt(raw as string, 10);
-        edited_values[name] = isNaN(n) ? raw : n;
-      } else if (ft === "number-float") {
-        const n = parseFloat(raw as string);
-        edited_values[name] = isNaN(n) ? raw : n;
+      } else if (ft === "number-int" || ft === "number-float") {
+        // Empty -> null (Tier 2 type contract). Otherwise parse to number.
+        // canSubmit guarantees required numerics are non-empty.
+        if ((raw as string) === "") {
+          edited_values[name] = null;
+        } else {
+          const n =
+            ft === "number-int"
+              ? parseInt(raw as string, 10)
+              : parseFloat(raw as string);
+          // NaN means the user typed something the input accepted but isn't a
+          // number (e.g. "1e" mid-typing). Submit null to honour the type
+          // contract -- an unparseable string would corrupt the audit trail.
+          edited_values[name] = isNaN(n) ? null : n;
+        }
       } else if (ft === "checkbox") {
         edited_values[name] = raw as boolean;
       } else {
@@ -560,13 +591,19 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
             className="guided-schema-advanced-toggle"
             onClick={() => setAdvancedExpanded((prev) => !prev)}
             aria-expanded={advancedExpanded}
+            aria-controls={optionalSectionId}
           >
             {advancedExpanded
               ? "Hide advanced"
               : `Show advanced (${optionalNames.length})`}
           </button>
           {advancedExpanded && (
-            <div className="guided-schema-optional-section">
+            <div
+              id={optionalSectionId}
+              role="region"
+              aria-label="Optional fields"
+              className="guided-schema-optional-section"
+            >
               {optionalNames.map((name, idx) =>
                 renderField(name, idx === 0),
               )}
@@ -575,13 +612,17 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
         </>
       )}
 
-      {/* Continue action */}
+      {/* Continue action.
+          aria-disabled mirrors disabled because some screen readers skip
+          disabled buttons entirely; aria-disabled keeps the announcement in
+          the AT tree while still preventing click activation. */}
       <div className="guided-schema-actions">
         <button
           type="button"
           className="guided-schema-continue-btn"
           onClick={handleContinue}
           disabled={!canSubmit}
+          aria-disabled={!canSubmit}
         >
           Continue
         </button>

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
@@ -1,0 +1,589 @@
+// src/components/chat/guided/SchemaFormTurn.tsx
+//
+// Guided-mode widget for the schema_form turn type (Task 7.5).
+// Conventions inherited from SingleSelectTurn (Task 7.2 template),
+// InspectAndConfirmTurn (Task 7.3), and MultiSelectWithCustomTurn (Task 7.4):
+//   - Props: { payload: SchemaFormPayload; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC -- the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <button type="button"> (never <div onClick>)
+//   - DOM IDs prefixed with React 18 useId() -- multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and element IDs would collide without per-instance scoping
+//   - Visible labels (htmlFor / button text) ARE the accessible name; do not add
+//     redundant aria-label that overrides what sighted users see
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+//
+// SHAPE NOTE (differs from chip-group widgets):
+// This widget does NOT use <fieldset>+<legend> or chip buttons (per the Task 7.2
+// SHAPE NOTE: "schema_form establishes its own structure"). It uses form semantics:
+//   - One <label>+control row per schema property
+//   - A "Show advanced (N)" toggle button for optional fields
+//   - A Continue button at the bottom
+//
+// SCOPE -- supported JSON Schema subset (MVP, Task 7.5):
+//   SUPPORTED: string (no enum) -> text input
+//              string + enum    -> select dropdown
+//              integer          -> number input (step="1")
+//              number           -> number input (step="any")
+//              boolean          -> checkbox
+//   FALLBACK:  array / object / $ref / anyOf / allOf / oneOf -> JSON textarea
+//              User types/edits JSON literal; parse errors show inline and
+//              disable Continue until fixed.
+//
+// The JSON-textarea fallback is a deliberate MVP scope choice -- not a contract
+// conflict. Full JSON Schema support (e.g. Optional[str] detection for anyOf,
+// nested object flattening) is deferred and does NOT have a Filigree issue.
+// Source of truth: protocol.py:53-56 (SchemaFormPayload wire shape).
+//
+// CONTINUE INVARIANT:
+//   Disabled when any required field's value is "empty":
+//     - text/number: empty string
+//     - boolean:     NEVER empty (always true/false -- a required bool is
+//                    always satisfied regardless of its current value)
+//     - enum select: empty string (no option selected)
+//     - JSON fallback: empty string OR parse error present
+//   Continue fires with edited_values = EVERY property from schema_block.properties,
+//   using the user's current input or the prefilled/default for untouched fields.
+//
+// JSON-FALLBACK PARSE CHOICE:
+//   Continue is disabled when any JSON-fallback field has a parse error. The per-field
+//   error string is stored in formState.errors (keyed by property name). This matches
+//   the "disabled = invariant violated" pattern from Task 7.4 (canAddPending) and the
+//   "single source of truth" convention -- the same error set drives both the inline
+//   error message and the continue-disabled predicate.
+//
+// STATE SPLIT:
+//   formState: { values, errors } -- owned by the form; submitted on Continue.
+//   advancedExpanded: boolean     -- owned separately; orthogonal to form values.
+//   Keeping them separate is correct here (unlike InspectAndConfirmTurn's nullable
+//   struct, which encoded mode + data together because the two views hold DIFFERENT
+//   data). Toggle state does not affect what gets submitted; merging would be
+//   misleading.
+//
+// FOCUS MANAGEMENT:
+//   firstRunRef: skips initial-mount effect so we don't steal focus on widget appear.
+//   Show-advanced click: focuses the first revealed field after the re-render.
+//   Hide-advanced click: focuses the toggle button after the re-render.
+//   Same pattern as InspectAndConfirmTurn (Task 7.3).
+//
+// Wire-response shape:
+//   Continue: { chosen: null, custom_inputs: null, edited_values: <full dict>,
+//               accepted_step_index: null, edit_step_index: null, control_signal: null }
+//   edited_values is a flat dict with every property from schema_block.properties.
+//   Server (state_machine.py:_advance_step_1) currently treats schema_form as an
+//   intra-step turn and returns early without consuming edited_values -- the full
+//   dict is pre-wired for when the intra-step flow is connected (Tasks 2.2+).
+
+import { useEffect, useId, useRef, useState } from "react";
+import type { GuidedRespondRequest, SchemaFormPayload } from "@/types/guided";
+
+// ── JSON Schema sub-types used for rendering decisions ────────────────────────
+
+// A single property definition from schema_block.properties. We use unknown
+// and narrow explicitly rather than typing the full JSON Schema spec.
+type PropSchema = Record<string, unknown>;
+
+// The field type we dispatch to a control. Single source of truth for
+// inferFieldType() -- no duplicated if/else ladders in JSX.
+type FieldType = "text" | "number-int" | "number-float" | "checkbox" | "enum" | "json-fallback";
+
+// ── Helper functions ───────────────────────────────────────────────────────────
+
+/**
+ * Returns the JSON Schema type string for a property schema, or null if absent.
+ * Reads schema["type"] only if it is a string.
+ */
+function schemaType(prop: PropSchema): string | null {
+  const t = prop["type"];
+  return typeof t === "string" ? t : null;
+}
+
+/**
+ * Returns the enum values if the property is a string enum, or null otherwise.
+ */
+function schemaEnum(prop: PropSchema): string[] | null {
+  const e = prop["enum"];
+  if (!Array.isArray(e)) return null;
+  // Narrow: each element must be a string (Pydantic always emits string enums
+  // for StrEnum fields; if a non-string slips through, fall back to json-fallback).
+  if (!e.every((v) => typeof v === "string")) return null;
+  return e as string[];
+}
+
+/**
+ * Derives the FieldType for a single property schema.
+ *
+ * Rules (in order):
+ *   1. anyOf / allOf / oneOf present            -> json-fallback
+ *   2. $ref present                             -> json-fallback
+ *   3. type === "array" or type === "object"    -> json-fallback
+ *   4. type === "boolean"                       -> checkbox
+ *   5. type === "integer"                       -> number-int
+ *   6. type === "number"                        -> number-float
+ *   7. type === "string" AND enum present       -> enum
+ *   8. type === "string"                        -> text
+ *   9. anything else (missing / exotic type)    -> json-fallback
+ */
+export function inferFieldType(prop: PropSchema): FieldType {
+  // Rule 1: composite types always fall back
+  if ("anyOf" in prop || "allOf" in prop || "oneOf" in prop) return "json-fallback";
+  // Rule 2: $ref
+  if ("$ref" in prop) return "json-fallback";
+
+  const t = schemaType(prop);
+  // Rule 3: container types
+  if (t === "array" || t === "object") return "json-fallback";
+  // Rule 4: boolean
+  if (t === "boolean") return "checkbox";
+  // Rule 5: integer
+  if (t === "integer") return "number-int";
+  // Rule 6: number (float)
+  if (t === "number") return "number-float";
+  // Rules 7-8: string
+  if (t === "string") {
+    return schemaEnum(prop) !== null ? "enum" : "text";
+  }
+  // Rule 9: fallback for missing or exotic type
+  return "json-fallback";
+}
+
+/**
+ * Derives the initial display value for a form field, applying precedence:
+ *   prefilled[name] > schema default > empty (type-appropriate sentinel).
+ *
+ * For JSON-fallback fields, the return value is the JSON string representation
+ * so it can be placed directly in the textarea.
+ */
+function initialValueFor(
+  name: string,
+  prop: PropSchema,
+  prefilled: Record<string, unknown>,
+  fieldType: FieldType,
+): string | boolean {
+  // Prefilled takes priority
+  if (Object.prototype.hasOwnProperty.call(prefilled, name)) {
+    const v = prefilled[name];
+    if (fieldType === "checkbox") return Boolean(v);
+    if (fieldType === "json-fallback") return JSON.stringify(v, null, 2);
+    // text, enum, number-int, number-float: coerce to string for input state
+    return String(v);
+  }
+
+  // Schema default next
+  const def = prop["default"];
+  if (def !== undefined) {
+    if (fieldType === "checkbox") return Boolean(def);
+    if (fieldType === "json-fallback") return JSON.stringify(def, null, 2);
+    return String(def);
+  }
+
+  // Empty sentinel
+  if (fieldType === "checkbox") return false;
+  // For json-fallback array fields, the natural empty state is "[]" --
+  // for object/$ref/anyOf we use "null" (a valid JSON null literal) so the
+  // textarea has a parseable initial value rather than an empty string
+  // that would immediately trigger a parse error.
+  if (fieldType === "json-fallback") {
+    const t = schemaType(prop);
+    if (t === "array") return "[]";
+    return "null";
+  }
+  return "";
+}
+
+/**
+ * Returns the label text for a property: title if present, else the property
+ * name itself (fallback for schemas where Pydantic omits title).
+ */
+function labelFor(name: string, prop: PropSchema): string {
+  const t = prop["title"];
+  return typeof t === "string" && t.length > 0 ? t : name;
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface SchemaFormTurnProps {
+  payload: SchemaFormPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+// Form state holds current field values (string or boolean) and per-field
+// JSON parse error messages (only set for json-fallback fields with invalid JSON).
+interface FormState {
+  values: Record<string, string | boolean>;
+  errors: Record<string, string>;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
+  // Derive the ordered list of properties from the schema once.
+  // schema_block.properties is a plain object; we preserve declaration order
+  // (JS spec guarantees string-keyed insertion order on plain objects).
+  const properties = (payload.schema_block["properties"] ?? {}) as Record<
+    string,
+    PropSchema
+  >;
+  const propertyNames = Object.keys(properties);
+
+  // Required fields: those listed in schema_block.required (may be absent).
+  // We derive this once here rather than scattering ?? [] throughout the JSX.
+  const requiredRaw = payload.schema_block["required"];
+  const requiredFields: ReadonlySet<string> = new Set(
+    Array.isArray(requiredRaw) ? (requiredRaw as string[]) : [],
+  );
+
+  // Derive initial form state from schema defaults and prefilled values.
+  const initialFormState = (): FormState => {
+    const values: Record<string, string | boolean> = {};
+    for (const name of propertyNames) {
+      const prop = properties[name];
+      const ft = inferFieldType(prop);
+      values[name] = initialValueFor(name, prop, payload.prefilled, ft);
+    }
+    return { values, errors: {} };
+  };
+
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+
+  // advancedExpanded is orthogonal to form state (see STATE SPLIT note above).
+  const [advancedExpanded, setAdvancedExpanded] = useState(false);
+
+  // useId scopes DOM IDs per-instance so multiple SchemaFormTurns rendered
+  // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9)
+  // don't produce id collisions when field names recur across turns.
+  const reactId = useId();
+  const fieldInputId = (name: string) => `${reactId}-field-${name}`;
+  const fieldHintId = (name: string) => `${reactId}-hint-${name}`;
+  const fieldErrorId = (name: string) => `${reactId}-error-${name}`;
+
+  // Partition properties into required / optional based on schema.required.
+  const requiredNames = propertyNames.filter((n) => requiredFields.has(n));
+  const optionalNames = propertyNames.filter((n) => !requiredFields.has(n));
+
+  // ── Focus management ──────────────────────────────────────────────────────
+
+  // Refs for the first advanced (optional) field and the toggle button.
+  // Set via ref callbacks in JSX so they track whatever control is first.
+  const firstAdvancedRef = useRef<
+    HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null
+  >(null);
+  const toggleBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  // Skip the first effect run: on initial widget mount the user did NOT toggle
+  // the view. Auto-focusing on mount would steal focus from wherever the user
+  // actually was. Same convention as InspectAndConfirmTurn (Task 7.3).
+  const firstRunRef = useRef(true);
+  useEffect(() => {
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      return;
+    }
+    if (advancedExpanded) {
+      firstAdvancedRef.current?.focus();
+    } else {
+      toggleBtnRef.current?.focus();
+    }
+  }, [advancedExpanded]);
+
+  // ── Field value updaters ──────────────────────────────────────────────────
+
+  function handleTextChange(name: string, value: string) {
+    setFormState((prev) => ({
+      ...prev,
+      values: { ...prev.values, [name]: value },
+    }));
+  }
+
+  function handleCheckboxChange(name: string, checked: boolean) {
+    setFormState((prev) => ({
+      ...prev,
+      values: { ...prev.values, [name]: checked },
+    }));
+  }
+
+  function handleJsonChange(name: string, raw: string) {
+    // Attempt to parse immediately so errors show inline as the user types.
+    // The parsed value is not stored in state -- on submit we re-parse from
+    // the raw string. This keeps the state type simple (string) and avoids
+    // a separate "parsed value" slot that would need synchronizing.
+    let error = "";
+    try {
+      JSON.parse(raw);
+    } catch {
+      error = "Invalid JSON";
+    }
+    setFormState((prev) => ({
+      values: { ...prev.values, [name]: raw },
+      errors: { ...prev.errors, [name]: error },
+    }));
+  }
+
+  // ── Submit predicate ──────────────────────────────────────────────────────
+
+  // A required field is "empty" when:
+  //   - text/enum: its string value is "" (trimmed for text, exact for enum)
+  //   - number-int/number-float: its string value is ""
+  //   - boolean: NEVER empty (required bool is always satisfied)
+  //   - json-fallback: value is "" OR there is a parse error
+  //
+  // Optional fields never block Continue regardless of their value.
+  //
+  // Additionally, ANY json-fallback field with a parse error blocks Continue,
+  // even optional ones -- bad JSON in an optional field would corrupt the
+  // edited_values dict sent to the server.
+  function isFieldEmpty(name: string, fieldType: FieldType): boolean {
+    const val = formState.values[name];
+    if (fieldType === "checkbox") return false; // boolean always satisfied
+    if (typeof val === "string") {
+      if (fieldType === "text" || fieldType === "number-int" || fieldType === "number-float") {
+        return val.trim() === "";
+      }
+      if (fieldType === "enum") return val === "";
+      if (fieldType === "json-fallback") return val.trim() === "";
+    }
+    return false;
+  }
+
+  const hasParseErrors = Object.values(formState.errors).some((e) => e !== "");
+
+  const canSubmit = (() => {
+    if (hasParseErrors) return false;
+    for (const name of requiredNames) {
+      const ft = inferFieldType(properties[name]);
+      if (isFieldEmpty(name, ft)) return false;
+    }
+    return true;
+  })();
+
+  // ── Submit handler ────────────────────────────────────────────────────────
+
+  function handleContinue() {
+    // Narrow because TS doesn't see the cross-handler invariant: canSubmit is
+    // the disabled predicate and this guard -- same predicate, deduped, not
+    // defensive programming.
+    if (!canSubmit) return;
+
+    // Build edited_values: EVERY property, using current state for the value.
+    // JSON-fallback fields are re-parsed here; any parse error would have
+    // already been caught by hasParseErrors and canSubmit would be false, so
+    // this parse is guaranteed to succeed at submit time.
+    const edited_values: Record<string, unknown> = {};
+    for (const name of propertyNames) {
+      const ft = inferFieldType(properties[name]);
+      const raw = formState.values[name];
+      if (ft === "json-fallback") {
+        // raw is the textarea string; parse it back to the structured value.
+        // canSubmit guarantees no parse errors here.
+        edited_values[name] = JSON.parse(raw as string);
+      } else if (ft === "number-int") {
+        const n = parseInt(raw as string, 10);
+        edited_values[name] = isNaN(n) ? raw : n;
+      } else if (ft === "number-float") {
+        const n = parseFloat(raw as string);
+        edited_values[name] = isNaN(n) ? raw : n;
+      } else if (ft === "checkbox") {
+        edited_values[name] = raw as boolean;
+      } else {
+        // text / enum
+        edited_values[name] = raw as string;
+      }
+    }
+
+    onSubmit({
+      chosen: null,
+      edited_values,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  // ── Field rendering helper ────────────────────────────────────────────────
+
+  function renderField(name: string, isFirst: boolean) {
+    const prop = properties[name];
+    const fieldType = inferFieldType(prop);
+    const label = labelFor(name, prop);
+    const description = typeof prop["description"] === "string" ? prop["description"] : null;
+    const inputId = fieldInputId(name);
+    const hintId = description !== null ? fieldHintId(name) : undefined;
+    const errorId = fieldHintId(name) !== undefined ? fieldErrorId(name) : fieldErrorId(name);
+    const hasError = (formState.errors[name] ?? "") !== "";
+    const val = formState.values[name];
+
+    // Build ref callback for focus restoration: the first optional field gets
+    // the ref so Show-advanced click can focus it.
+    const firstAdvancedCallback = (
+      el: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null,
+    ) => {
+      if (isFirst) firstAdvancedRef.current = el;
+    };
+
+    // aria-describedby: wire hint, error, or both -- only wire IDs that exist
+    const describedByParts: string[] = [];
+    if (hintId) describedByParts.push(hintId);
+    if (hasError) describedByParts.push(errorId);
+    const describedBy =
+      describedByParts.length > 0 ? describedByParts.join(" ") : undefined;
+
+    return (
+      <div key={name} className="guided-schema-field-row">
+        {fieldType === "checkbox" ? (
+          // Checkbox: label wraps the input for larger click target. We still use
+          // htmlFor so the accessible name is always the visible text.
+          <>
+            <div className="guided-schema-checkbox-row">
+              <input
+                id={inputId}
+                ref={isFirst ? firstAdvancedCallback : undefined}
+                type="checkbox"
+                className="guided-schema-checkbox"
+                checked={val as boolean}
+                aria-describedby={describedBy}
+                onChange={(e) => handleCheckboxChange(name, e.target.checked)}
+              />
+              <label htmlFor={inputId} className="guided-schema-label">
+                {label}
+              </label>
+            </div>
+            {description !== null && (
+              <p id={hintId} className="guided-schema-hint">
+                {description}
+              </p>
+            )}
+          </>
+        ) : fieldType === "enum" ? (
+          <>
+            <label htmlFor={inputId} className="guided-schema-label">
+              {label}
+            </label>
+            <select
+              id={inputId}
+              ref={isFirst ? firstAdvancedCallback as (el: HTMLSelectElement | null) => void : undefined}
+              className="guided-schema-select"
+              value={val as string}
+              aria-describedby={describedBy}
+              onChange={(e) => handleTextChange(name, e.target.value)}
+            >
+              {(schemaEnum(prop) ?? []).map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+            {description !== null && (
+              <p id={hintId} className="guided-schema-hint">
+                {description}
+              </p>
+            )}
+          </>
+        ) : fieldType === "json-fallback" ? (
+          <>
+            <label htmlFor={inputId} className="guided-schema-label">
+              {label}
+            </label>
+            <textarea
+              id={inputId}
+              ref={isFirst ? firstAdvancedCallback as (el: HTMLTextAreaElement | null) => void : undefined}
+              className={`guided-schema-textarea${hasError ? " guided-schema-textarea--error" : ""}`}
+              value={val as string}
+              aria-describedby={describedBy}
+              onChange={(e) => handleJsonChange(name, e.target.value)}
+              rows={4}
+              spellCheck={false}
+            />
+            {description !== null && (
+              <p id={hintId} className="guided-schema-hint">
+                {description}
+              </p>
+            )}
+            {hasError && (
+              <p id={errorId} className="guided-schema-error" role="alert">
+                {formState.errors[name]}
+              </p>
+            )}
+          </>
+        ) : (
+          // text / number-int / number-float
+          <>
+            <label htmlFor={inputId} className="guided-schema-label">
+              {label}
+            </label>
+            <input
+              id={inputId}
+              ref={isFirst ? firstAdvancedCallback as (el: HTMLInputElement | null) => void : undefined}
+              type={fieldType === "text" ? "text" : "number"}
+              step={
+                fieldType === "number-int"
+                  ? "1"
+                  : fieldType === "number-float"
+                    ? "any"
+                    : undefined
+              }
+              className="guided-schema-input"
+              value={val as string}
+              aria-describedby={describedBy}
+              onChange={(e) => handleTextChange(name, e.target.value)}
+            />
+            {description !== null && (
+              <p id={hintId} className="guided-schema-hint">
+                {description}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="guided-turn guided-schema-form">
+      {/* Required fields -- always visible */}
+      {requiredNames.length > 0 && (
+        <div className="guided-schema-required-section">
+          {requiredNames.map((name) => renderField(name, false))}
+        </div>
+      )}
+
+      {/* Optional fields -- collapsed until user clicks toggle */}
+      {optionalNames.length > 0 && (
+        <>
+          <button
+            ref={toggleBtnRef}
+            type="button"
+            className="guided-schema-advanced-toggle"
+            onClick={() => setAdvancedExpanded((prev) => !prev)}
+            aria-expanded={advancedExpanded}
+          >
+            {advancedExpanded
+              ? "Hide advanced"
+              : `Show advanced (${optionalNames.length})`}
+          </button>
+          {advancedExpanded && (
+            <div className="guided-schema-optional-section">
+              {optionalNames.map((name, idx) =>
+                renderField(name, idx === 0),
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Continue action */}
+      <div className="guided-schema-actions">
+        <button
+          type="button"
+          className="guided-schema-continue-btn"
+          onClick={handleContinue}
+          disabled={!canSubmit}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SchemaFormTurn.tsx
@@ -74,12 +74,18 @@
 //   Same pattern as InspectAndConfirmTurn (Task 7.3).
 //
 // Wire-response shape:
-//   Continue: { chosen: null, custom_inputs: null, edited_values: <full dict>,
+//   Continue: { chosen: null, custom_inputs: null, edited_values: <structured dict>,
 //               accepted_step_index: null, edit_step_index: null, control_signal: null }
-//   edited_values is a flat dict with every property from schema_block.properties.
-//   Server (state_machine.py:_advance_step_1) currently treats schema_form as an
-//   intra-step turn and returns early without consuming edited_values -- the full
-//   dict is pre-wired for when the intra-step flow is connected (Tasks 2.2+).
+//   edited_values has the shape { plugin, options, observed_columns, sample_rows }:
+//     - plugin: payload.plugin (the plugin name chosen in the preceding SINGLE_SELECT)
+//     - options: { ...allFormValues } — every property from schema_block.properties
+//     - observed_columns: [] (empty at source step; populated by backend after run)
+//     - sample_rows: [] (empty at source step; populated by backend after run)
+//   The backend's SCHEMA_FORM dispatcher (_dispatch_guided_respond, SCHEMA_FORM branch
+//   at STEP_1_SOURCE) requires "plugin" in edited_values to construct SourceResolved.
+//   The backend's SCHEMA_FORM dispatcher at STEP_2_SINK currently ignores edited_values
+//   (it just emits MULTI_SELECT_WITH_CUSTOM), but the same wire shape is used for
+//   shape conformance and future compatibility.
 
 import { useEffect, useId, useRef, useState } from "react";
 import type { GuidedRespondRequest, SchemaFormPayload } from "@/types/guided";
@@ -379,7 +385,8 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
     // defensive programming.
     if (!canSubmit) return;
 
-    // Build edited_values: EVERY property, using current state for the value.
+    // Build the options dict: EVERY property from the schema, using the
+    // current field state (prefilled value, schema default, or user input).
     // JSON-fallback fields are re-parsed here; any parse error would have
     // already been caught by hasParseErrors and canSubmit would be false, so
     // this parse is guaranteed to succeed at submit time.
@@ -389,22 +396,19 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
     // type contract -- the schema declares int/float and the widget owes the
     // declared type at the trust boundary). Required-empty numerics are
     // already blocked by canSubmit and never reach this branch.
-    // Rationale: null preserves the "edited_values includes EVERY property"
-    // invariant documented in the file header, while letting the server
-    // distinguish "user explicitly cleared" from "field was never offered."
-    const edited_values: Record<string, unknown> = {};
+    const options: Record<string, unknown> = {};
     for (const name of propertyNames) {
       const ft = inferFieldType(properties[name]);
       const raw = formState.values[name];
       if (ft === "json-fallback") {
         // raw is the textarea string; parse it back to the structured value.
         // canSubmit guarantees no parse errors here.
-        edited_values[name] = JSON.parse(raw as string);
+        options[name] = JSON.parse(raw as string);
       } else if (ft === "number-int" || ft === "number-float") {
         // Empty -> null (Tier 2 type contract). Otherwise parse to number.
         // canSubmit guarantees required numerics are non-empty.
         if ((raw as string) === "") {
-          edited_values[name] = null;
+          options[name] = null;
         } else {
           const n =
             ft === "number-int"
@@ -413,19 +417,30 @@ export function SchemaFormTurn({ payload, onSubmit }: SchemaFormTurnProps) {
           // NaN means the user typed something the input accepted but isn't a
           // number (e.g. "1e" mid-typing). Submit null to honour the type
           // contract -- an unparseable string would corrupt the audit trail.
-          edited_values[name] = isNaN(n) ? null : n;
+          options[name] = isNaN(n) ? null : n;
         }
       } else if (ft === "checkbox") {
-        edited_values[name] = raw as boolean;
+        options[name] = raw as boolean;
       } else {
         // text / enum
-        edited_values[name] = raw as string;
+        options[name] = raw as string;
       }
     }
 
+    // The backend's SCHEMA_FORM dispatcher requires the structured shape:
+    // { plugin, options, observed_columns, sample_rows }. "plugin" is the key
+    // the backend uses to resolve the plugin and construct SourceResolved (or
+    // SinkResolved). observed_columns and sample_rows are populated by the
+    // backend after the source runs; this widget submits empty lists as
+    // shape-conformant placeholders.
     onSubmit({
       chosen: null,
-      edited_values,
+      edited_values: {
+        plugin: payload.plugin,
+        options,
+        observed_columns: [],
+        sample_rows: [],
+      },
       custom_inputs: null,
       accepted_step_index: null,
       edit_step_index: null,

--- a/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.test.tsx
@@ -1,0 +1,156 @@
+// ============================================================================
+// SingleSelectTurn — wire-response contract regression coverage.
+//
+// Pins SingleSelectTurn's wire-response contract:
+//   option click   → chosen=[id], custom_inputs=null, all-other-fields null
+//   custom-input submit → custom_inputs=[text], chosen=null, all-other-fields null
+//   never both populated, never neither
+//   hint text → rendered + aria-describedby wired; no hint → no aria-describedby
+//   allow_custom=false → no custom-input control rendered
+//
+// The GuidedRespondRequest shape is the unit under test; these tests will
+// catch any future refactor that silently drops a null field or swaps chosen
+// and custom_inputs.  Tasks 7.3-7.7 will replicate this regression-intent
+// structure with their own wire contracts.
+// ============================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SingleSelectTurn } from "./SingleSelectTurn";
+import type { SingleSelectPayload } from "@/types/guided";
+import type { GuidedRespondRequest } from "@/types/guided";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PAYLOAD_NO_CUSTOM: SingleSelectPayload = {
+  question: "Which data source do you want?",
+  options: [
+    { id: "csv", label: "CSV File", hint: null },
+    { id: "api", label: "REST API", hint: "Fetches data from an HTTP endpoint" },
+  ],
+  allow_custom: false,
+};
+
+const PAYLOAD_WITH_CUSTOM: SingleSelectPayload = {
+  question: "Which transform should we use?",
+  options: [{ id: "llm_classify", label: "LLM Classifier", hint: null }],
+  allow_custom: true,
+};
+
+// Helper to make the null-field assertion concise
+function nullResponse(): Pick<
+  GuidedRespondRequest,
+  "edited_values" | "accepted_step_index" | "edit_step_index" | "control_signal"
+> {
+  return {
+    edited_values: null,
+    accepted_step_index: null,
+    edit_step_index: null,
+    control_signal: null,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("SingleSelectTurn — option click", () => {
+  it("renders the question text and one button per option", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
+
+    expect(screen.getByText("Which data source do you want?")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "CSV File" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "REST API" })).toBeTruthy();
+  });
+
+  it("clicking an option fires onSubmit with chosen=[id] and all other fields null", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "CSV File" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      chosen: ["csv"],
+      custom_inputs: null,
+      ...nullResponse(),
+    });
+  });
+
+  it("option click with allow_custom=true still produces chosen=[id], custom_inputs=null (mutual exclusion)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "LLM Classifier" }));
+
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body.chosen).toEqual(["llm_classify"]);
+    expect(body.custom_inputs).toBeNull();
+  });
+});
+
+describe("SingleSelectTurn — allow_custom=false", () => {
+  it("does not render a custom-input control when allow_custom is false", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
+    // The custom input row should be absent
+    expect(screen.queryByPlaceholderText(/custom/i)).toBeNull();
+    expect(screen.queryByLabelText(/custom/i)).toBeNull();
+  });
+});
+
+describe("SingleSelectTurn — allow_custom=true", () => {
+  it("renders a custom-input control when allow_custom is true", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={vi.fn()} />);
+    expect(screen.getByRole("textbox", { name: /custom/i })).toBeTruthy();
+  });
+
+  it("submit button is disabled while custom input is empty", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={vi.fn()} />);
+    const submitBtn = screen.getByRole("button", { name: /submit custom/i });
+    expect(submitBtn).toHaveProperty("disabled", true);
+  });
+
+  it("submitting custom text fires onSubmit with custom_inputs=[text] and chosen=null", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={onSubmit} />);
+
+    const input = screen.getByRole("textbox", { name: /custom/i });
+    await user.type(input, "my custom transform");
+    await user.click(screen.getByRole("button", { name: /submit custom/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const body: GuidedRespondRequest = onSubmit.mock.calls[0][0];
+    expect(body).toEqual<GuidedRespondRequest>({
+      chosen: null,
+      custom_inputs: ["my custom transform"],
+      ...nullResponse(),
+    });
+  });
+});
+
+describe("SingleSelectTurn — hint rendering", () => {
+  it("renders hint text for options that have a non-null hint", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
+    expect(screen.getByText("Fetches data from an HTTP endpoint")).toBeTruthy();
+  });
+
+  it("option with non-null hint has aria-describedby pointing to hint element", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
+    const apiBtn = screen.getByRole("button", { name: "REST API" });
+    const describedBy = apiBtn.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    // The ID must resolve to the hint element in the DOM
+    const hintEl = document.getElementById(describedBy!);
+    expect(hintEl).toBeTruthy();
+    expect(hintEl!.textContent).toBe("Fetches data from an HTTP endpoint");
+  });
+
+  it("option with null hint has no aria-describedby", () => {
+    render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
+    const csvBtn = screen.getByRole("button", { name: "CSV File" });
+    expect(csvBtn.getAttribute("aria-describedby")).toBeNull();
+  });
+});

--- a/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.test.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.test.tsx
@@ -18,6 +18,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SingleSelectTurn } from "./SingleSelectTurn";
+import { nullResponse } from "@/test/guided-fixtures";
 import type { SingleSelectPayload } from "@/types/guided";
 import type { GuidedRespondRequest } from "@/types/guided";
 
@@ -37,19 +38,6 @@ const PAYLOAD_WITH_CUSTOM: SingleSelectPayload = {
   options: [{ id: "llm_classify", label: "LLM Classifier", hint: null }],
   allow_custom: true,
 };
-
-// Helper to make the null-field assertion concise
-function nullResponse(): Pick<
-  GuidedRespondRequest,
-  "edited_values" | "accepted_step_index" | "edit_step_index" | "control_signal"
-> {
-  return {
-    edited_values: null,
-    accepted_step_index: null,
-    edit_step_index: null,
-    control_signal: null,
-  };
-}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -152,5 +140,49 @@ describe("SingleSelectTurn — hint rendering", () => {
     render(<SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />);
     const csvBtn = screen.getByRole("button", { name: "CSV File" });
     expect(csvBtn.getAttribute("aria-describedby")).toBeNull();
+  });
+});
+
+describe("SingleSelectTurn — DOM ID isolation (useId)", () => {
+  // Regression: GuidedHistory (Task 7.9) renders past turns alongside the
+  // active one; option IDs ("csv", "api") recur across turns. Hard-coded
+  // hint IDs (e.g. "hint-api") would collide. useId() prefixes per-instance.
+  it("two simultaneous instances with the same option ids have distinct hint IDs", () => {
+    render(
+      <div>
+        <SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />
+        <SingleSelectTurn payload={PAYLOAD_NO_CUSTOM} onSubmit={vi.fn()} />
+      </div>,
+    );
+
+    const restBtns = screen.getAllByRole("button", { name: "REST API" });
+    expect(restBtns).toHaveLength(2);
+    const id0 = restBtns[0].getAttribute("aria-describedby");
+    const id1 = restBtns[1].getAttribute("aria-describedby");
+    expect(id0).toBeTruthy();
+    expect(id1).toBeTruthy();
+    expect(id0).not.toBe(id1);
+
+    // Both IDs must resolve to a unique hint element in the DOM.
+    expect(document.getElementById(id0!)).toBeTruthy();
+    expect(document.getElementById(id1!)).toBeTruthy();
+  });
+
+  it("two simultaneous instances with allow_custom have distinct input IDs", () => {
+    render(
+      <div>
+        <SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={vi.fn()} />
+        <SingleSelectTurn payload={PAYLOAD_WITH_CUSTOM} onSubmit={vi.fn()} />
+      </div>,
+    );
+
+    const inputs = screen.getAllByRole("textbox", { name: /custom/i });
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].id).not.toBe(inputs[1].id);
+    // The <label htmlFor> must point to its own input, not the sibling's
+    // — this is what makes the per-label getByRole queries above work
+    // correctly across multiple instances.
+    expect(inputs[0].id).toBeTruthy();
+    expect(inputs[1].id).toBeTruthy();
   });
 });

--- a/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.tsx
@@ -7,9 +7,19 @@
 //   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
 //   - <fieldset>+<legend> for chip groups; <button type="button"> (never <div onClick>)
 //   - aria-describedby only wired when hint is non-null (no dangling IDs)
+//   - DOM IDs prefixed with React 18 useId() — multiple turn instances coexist in
+//     GuidedHistory (Task 7.9) and option IDs recur across turns; document-global
+//     IDs would collide
+//   - Visible labels (htmlFor / button text) ARE the accessible name; do not add
+//     redundant aria-label that overrides what sighted users see
 //   - CSS via App.css class names with design tokens; no hardcoded colours
+//
+// SHAPE NOTE for Tasks 7.3-7.7:
+// The chip-group structure (<fieldset>+<legend>+chip-button-group) applies to
+// single_select, multi_select_with_custom, and recipe_offer. schema_form and
+// propose_chain establish their own structures — do not blindly copy this layout.
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import type { GuidedRespondRequest, SingleSelectPayload } from "@/types/guided";
 
 interface SingleSelectTurnProps {
@@ -19,6 +29,13 @@ interface SingleSelectTurnProps {
 
 export function SingleSelectTurn({ payload, onSubmit }: SingleSelectTurnProps) {
   const [customText, setCustomText] = useState("");
+
+  // useId scopes DOM IDs per-instance so multiple SingleSelectTurns rendered
+  // simultaneously (e.g. active turn + GuidedHistory replay in Task 7.9) don't
+  // produce id collisions when option IDs ("csv", "api") recur across turns.
+  const reactId = useId();
+  const customInputId = `${reactId}-custom-input`;
+  const hintIdFor = (optionId: string) => `${reactId}-hint-${optionId}`;
 
   function handleOptionClick(optionId: string) {
     onSubmit({
@@ -48,10 +65,13 @@ export function SingleSelectTurn({ payload, onSubmit }: SingleSelectTurnProps) {
     <div className="guided-turn guided-single-select">
       <fieldset className="guided-chip-fieldset">
         <legend className="guided-chip-legend">{payload.question}</legend>
-        <div className="guided-chip-group" role="group">
+        {/* No role="group" on the inner div — <fieldset> already provides
+            group semantics; duplicating creates two nested groups in the
+            accessibility tree. */}
+        <div className="guided-chip-group">
           {payload.options.map((option) => {
             const hintId =
-              option.hint !== null ? `hint-${option.id}` : undefined;
+              option.hint !== null ? hintIdFor(option.id) : undefined;
             return (
               <div key={option.id} className="guided-chip-item">
                 <button
@@ -75,27 +95,30 @@ export function SingleSelectTurn({ payload, onSubmit }: SingleSelectTurnProps) {
 
       {payload.allow_custom && (
         <div className="guided-custom-row">
-          <label htmlFor="guided-custom-input" className="guided-custom-label">
+          <label htmlFor={customInputId} className="guided-custom-label">
             Custom
           </label>
           <input
-            id="guided-custom-input"
+            id={customInputId}
             type="text"
-            aria-label="Custom option"
             className="guided-custom-input"
             value={customText}
             onChange={(e) => setCustomText(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && customText.trim()) {
+              if (e.key === "Enter") {
+                // preventDefault so a future <form> wrapper (e.g. SchemaFormTurn
+                // composition) doesn't double-submit. handleCustomSubmit
+                // already no-ops on empty — disabled-button + no-op
+                // early-return are the same predicate, deduplicated.
+                e.preventDefault();
                 handleCustomSubmit();
               }
             }}
-            placeholder="Describe your custom option…"
+            placeholder="Describe your custom option..."
           />
           <button
             type="button"
             className="guided-custom-submit-btn"
-            aria-label="Submit custom option"
             onClick={handleCustomSubmit}
             disabled={!customText.trim()}
           >

--- a/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.tsx
+++ b/src/elspeth/web/frontend/src/components/chat/guided/SingleSelectTurn.tsx
@@ -1,0 +1,108 @@
+// src/components/chat/guided/SingleSelectTurn.tsx
+//
+// Template widget for the guided-mode protocol (Task 7.2).
+// Conventions established here will be replicated by Tasks 7.3-7.7:
+//   - Props: { payload: <WidgetPayload>; onSubmit: (body: GuidedRespondRequest) => void }
+//   - onSubmit is SYNC — the widget constructs the body; the store awaits the round-trip
+//   - All 6 GuidedRespondRequest fields set explicitly; unused ones = null (no omission)
+//   - <fieldset>+<legend> for chip groups; <button type="button"> (never <div onClick>)
+//   - aria-describedby only wired when hint is non-null (no dangling IDs)
+//   - CSS via App.css class names with design tokens; no hardcoded colours
+
+import { useState } from "react";
+import type { GuidedRespondRequest, SingleSelectPayload } from "@/types/guided";
+
+interface SingleSelectTurnProps {
+  payload: SingleSelectPayload;
+  onSubmit: (body: GuidedRespondRequest) => void;
+}
+
+export function SingleSelectTurn({ payload, onSubmit }: SingleSelectTurnProps) {
+  const [customText, setCustomText] = useState("");
+
+  function handleOptionClick(optionId: string) {
+    onSubmit({
+      chosen: [optionId],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  function handleCustomSubmit() {
+    const trimmed = customText.trim();
+    if (!trimmed) return;
+    onSubmit({
+      chosen: null,
+      edited_values: null,
+      custom_inputs: [trimmed],
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+  }
+
+  return (
+    <div className="guided-turn guided-single-select">
+      <fieldset className="guided-chip-fieldset">
+        <legend className="guided-chip-legend">{payload.question}</legend>
+        <div className="guided-chip-group" role="group">
+          {payload.options.map((option) => {
+            const hintId =
+              option.hint !== null ? `hint-${option.id}` : undefined;
+            return (
+              <div key={option.id} className="guided-chip-item">
+                <button
+                  type="button"
+                  className="guided-chip-btn"
+                  onClick={() => handleOptionClick(option.id)}
+                  aria-describedby={hintId}
+                >
+                  {option.label}
+                </button>
+                {option.hint !== null && (
+                  <p id={hintId} className="guided-chip-hint">
+                    {option.hint}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {payload.allow_custom && (
+        <div className="guided-custom-row">
+          <label htmlFor="guided-custom-input" className="guided-custom-label">
+            Custom
+          </label>
+          <input
+            id="guided-custom-input"
+            type="text"
+            aria-label="Custom option"
+            className="guided-custom-input"
+            value={customText}
+            onChange={(e) => setCustomText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && customText.trim()) {
+                handleCustomSubmit();
+              }
+            }}
+            placeholder="Describe your custom option…"
+          />
+          <button
+            type="button"
+            className="guided-custom-submit-btn"
+            aria-label="Submit custom option"
+            onClick={handleCustomSubmit}
+            disabled={!customText.trim()}
+          >
+            Submit custom
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/elspeth/web/frontend/src/hooks/useFocusTrap.ts
+++ b/src/elspeth/web/frontend/src/hooks/useFocusTrap.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 
-const FOCUSABLE_SELECTOR =
-  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+export const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Traps keyboard focus within a container element.

--- a/src/elspeth/web/frontend/src/stores/sessionStore.guided.test.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.guided.test.ts
@@ -1,0 +1,251 @@
+// src/stores/sessionStore.guided.test.ts
+//
+// Tests for guided-mode state fields and actions on useSessionStore.
+// TDD pass: these import types/actions that don't exist yet. First run
+// expected to fail on missing fields/actions.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useSessionStore } from "./sessionStore";
+import { resetStore } from "@/test/store-helpers";
+import type { GuidedSession, TurnPayload, TerminalState, GetGuidedResponse, GuidedRespondResponse } from "@/types/guided";
+
+// Mock the API client — store tests verify state logic, not HTTP calls.
+// Must include all exports used by sessionStore (not just guided ones).
+vi.mock("@/api/client", () => ({
+  fetchSessions: vi.fn(),
+  createSession: vi.fn(),
+  fetchMessages: vi.fn(),
+  fetchCompositionState: vi.fn(),
+  fetchComposerProgress: vi.fn(),
+  sendMessage: vi.fn(),
+  recompose: vi.fn(),
+  forkFromMessage: vi.fn(),
+  revertToVersion: vi.fn(),
+  fetchStateVersions: vi.fn(),
+  archiveSession: vi.fn(),
+  getGuided: vi.fn(),
+  respondGuided: vi.fn(),
+}));
+
+// Mock the execution store dependency (selectSession calls clearValidation)
+vi.mock("./executionStore", () => ({
+  useExecutionStore: {
+    getState: () => ({ clearValidation: vi.fn() }),
+  },
+}));
+
+// Mock blobStore — selectSession calls useBlobStore.getState().loadBlobs() fire-and-forget.
+// Without this, the real blobStore makes HTTP calls against jsdom.
+vi.mock("./blobStore", () => ({
+  useBlobStore: {
+    getState: () => ({ loadBlobs: vi.fn() }),
+  },
+}));
+
+// ── Sample fixtures ───────────────────────────────────────────────────────────
+
+const sampleGuidedSession: GuidedSession = {
+  step: "step_1_source",
+  history: [],
+  terminal: null,
+};
+
+const sampleNextTurn: TurnPayload = {
+  type: "single_select",
+  step_index: 0,
+  payload: { options: ["csv", "jsonl"] },
+};
+
+const sampleTerminal: TerminalState = {
+  kind: "completed",
+  reason: null,
+  pipeline_yaml: "source:\n  plugin: csv\n",
+};
+
+const sampleCompositionState = {
+  id: "state-1",
+  version: 1,
+  nodes: [],
+  edges: [],
+  source: null,
+  outputs: [],
+  metadata: { name: null, description: null },
+};
+
+const sampleGetGuidedResponse: GetGuidedResponse = {
+  guided_session: sampleGuidedSession,
+  next_turn: sampleNextTurn,
+  terminal: null,
+  composition_state: sampleCompositionState,
+};
+
+const sampleRespondResponse: GuidedRespondResponse = {
+  guided_session: { ...sampleGuidedSession, step: "step_2_sink" },
+  next_turn: { type: "single_select", step_index: 1, payload: {} },
+  terminal: null,
+  composition_state: { ...sampleCompositionState, version: 2 },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("sessionStore — guided-mode fields and actions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetStore(useSessionStore);
+  });
+
+  // ── Test 1: Initial state ─────────────────────────────────────────────────
+
+  it("initial state: guidedSession, guidedNextTurn, guidedTerminal all null", () => {
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+  });
+
+  // ── Test 2: startGuided happy path ────────────────────────────────────────
+
+  it("startGuided: populates all 4 wire fields atomically on success", async () => {
+    const { getGuided } = await import("@/api/client");
+    (getGuided as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      sampleGetGuidedResponse,
+    );
+
+    await useSessionStore.getState().startGuided("sess-1");
+
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toEqual(sampleGetGuidedResponse.guided_session);
+    expect(state.guidedNextTurn).toEqual(sampleGetGuidedResponse.next_turn);
+    expect(state.guidedTerminal).toEqual(sampleGetGuidedResponse.terminal);
+    expect(state.compositionState).toEqual(
+      sampleGetGuidedResponse.composition_state,
+    );
+  });
+
+  // ── Test 3: startGuided failure ───────────────────────────────────────────
+
+  it("startGuided: sets error string and leaves guided state alone on failure", async () => {
+    const { getGuided } = await import("@/api/client");
+    (getGuided as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("network error"),
+    );
+
+    // Pre-seed: if previously loaded guided state exists it should be
+    // preserved on error (same convention as selectSession lines 207-209:
+    // set error, don't clobber fields that already loaded).
+    useSessionStore.setState({ guidedSession: sampleGuidedSession });
+
+    await useSessionStore.getState().startGuided("sess-1");
+
+    const state = useSessionStore.getState();
+    // Error must be set to a non-empty string
+    expect(state.error).toBeTruthy();
+    expect(typeof state.error).toBe("string");
+    // Pre-seeded guided state is preserved (error path doesn't clear it)
+    expect(state.guidedSession).toEqual(sampleGuidedSession);
+  });
+
+  // ── Test 4: respondGuided happy path ─────────────────────────────────────
+
+  it("respondGuided: atomically replaces all 4 wire fields on success", async () => {
+    const { respondGuided } = await import("@/api/client");
+    (respondGuided as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      sampleRespondResponse,
+    );
+
+    // Pre-seed active session
+    useSessionStore.setState({ activeSessionId: "sess-1" });
+
+    await useSessionStore.getState().respondGuided({
+      chosen: ["csv"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toEqual(sampleRespondResponse.guided_session);
+    expect(state.guidedNextTurn).toEqual(sampleRespondResponse.next_turn);
+    expect(state.guidedTerminal).toEqual(sampleRespondResponse.terminal);
+    expect(state.compositionState).toEqual(
+      sampleRespondResponse.composition_state,
+    );
+  });
+
+  // ── Test 5: respondGuided invariant violation ─────────────────────────────
+
+  it("respondGuided: throws when activeSessionId is null (offensive guard)", async () => {
+    // activeSessionId is null from resetStore
+    await expect(
+      useSessionStore.getState().respondGuided({
+        chosen: null,
+        edited_values: null,
+        custom_inputs: null,
+        accepted_step_index: null,
+        edit_step_index: null,
+        control_signal: null,
+      }),
+    ).rejects.toThrow("respondGuided called without active session");
+  });
+
+  // ── Test 6: exitToFreeform ────────────────────────────────────────────────
+
+  it("exitToFreeform: delegates to respondGuided with control_signal=exit_to_freeform", async () => {
+    const { respondGuided } = await import("@/api/client");
+    (respondGuided as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      sampleRespondResponse,
+    );
+
+    useSessionStore.setState({ activeSessionId: "sess-1" });
+    await useSessionStore.getState().exitToFreeform();
+
+    expect(respondGuided).toHaveBeenCalledWith(
+      "sess-1",
+      expect.objectContaining({ control_signal: "exit_to_freeform" }),
+    );
+  });
+
+  // ── Test 7: session switch clears guided state (leak regression) ──────────
+
+  it("selectSession: clears guidedSession, guidedNextTurn, guidedTerminal on session switch", async () => {
+    const { fetchMessages, fetchCompositionState } = await import("@/api/client");
+    (fetchMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    (fetchCompositionState as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    // Pre-seed non-null guided state from a previous session
+    useSessionStore.setState({
+      activeSessionId: "sess-1",
+      guidedSession: sampleGuidedSession,
+      guidedNextTurn: sampleNextTurn,
+      guidedTerminal: sampleTerminal,
+    });
+
+    // Switch to a different session — guided state must be cleared immediately
+    // (the synchronous set() at the top of selectSession, before Promise.all)
+    await useSessionStore.getState().selectSession("sess-2");
+
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+  });
+
+  // ── Test 8: reset() clears guided state ──────────────────────────────────
+
+  it("reset: clears guidedSession, guidedNextTurn, guidedTerminal", () => {
+    useSessionStore.setState({
+      guidedSession: sampleGuidedSession,
+      guidedNextTurn: sampleNextTurn,
+      guidedTerminal: sampleTerminal,
+    });
+
+    useSessionStore.getState().reset();
+
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+  });
+});

--- a/src/elspeth/web/frontend/src/stores/sessionStore.guided.test.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.guided.test.ts
@@ -111,6 +111,14 @@ describe("sessionStore — guided-mode fields and actions", () => {
       sampleGetGuidedResponse,
     );
 
+    // Pre-seed activeSessionId to match the requested session.  The stale-fetch
+    // guard (Codex #3) requires activeSessionId === requestedSessionId after the
+    // await; without this pre-seed the guard would drop the response and the
+    // assertions below would fail.  Real callers (createSession, selectSession,
+    // forkFromMessage) always set activeSessionId synchronously before firing
+    // startGuided, so this invariant holds in production.
+    useSessionStore.setState({ activeSessionId: "sess-1" });
+
     await useSessionStore.getState().startGuided("sess-1");
 
     const state = useSessionStore.getState();
@@ -247,5 +255,154 @@ describe("sessionStore — guided-mode fields and actions", () => {
     expect(state.guidedSession).toBeNull();
     expect(state.guidedNextTurn).toBeNull();
     expect(state.guidedTerminal).toBeNull();
+  });
+
+  // ── Test 9: startGuided stale-fetch guard (Codex #3) ─────────────────────
+  //
+  // If the user switches to a different session while getGuided is in flight
+  // for sess-A, the resolved response must be dropped and the new session's
+  // guided state must remain null.
+
+  it("startGuided: drops response when active session changes before resolution", async () => {
+    const { getGuided } = await import("@/api/client");
+
+    // Controllable promise — we resolve it manually after simulating a session switch.
+    let resolveGuided!: (v: GetGuidedResponse) => void;
+    (getGuided as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<GetGuidedResponse>((resolve) => {
+        resolveGuided = resolve;
+      }),
+    );
+
+    // The caller always sets activeSessionId before firing startGuided.
+    useSessionStore.setState({ activeSessionId: "sess-A" });
+    const startPromise = useSessionStore.getState().startGuided("sess-A");
+
+    // Simulate a session switch happening while the request is in flight.
+    useSessionStore.setState({ activeSessionId: "sess-B" });
+
+    // Now let the request resolve with sess-A's data.
+    resolveGuided(sampleGetGuidedResponse);
+    await startPromise;
+
+    // The stale response must have been dropped — sess-B's guided state
+    // must remain null.
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+    expect(state.compositionState).toBeNull();
+  });
+
+  // ── Test 10: respondGuided stale-fetch guard (Codex #4) ──────────────────
+  //
+  // If the user switches sessions while respondGuided's API call is in flight,
+  // the resolved response must be dropped and the new session's state unchanged.
+
+  it("respondGuided: drops response when active session changes before resolution", async () => {
+    const { respondGuided } = await import("@/api/client");
+
+    // Controllable promise — we resolve it manually after simulating a session switch.
+    let resolveRespond!: (v: GuidedRespondResponse) => void;
+    (respondGuided as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<GuidedRespondResponse>((resolve) => {
+        resolveRespond = resolve;
+      }),
+    );
+
+    // Pre-seed: sess-A has existing guided state before the respond call.
+    useSessionStore.setState({
+      activeSessionId: "sess-A",
+      guidedSession: sampleGuidedSession,
+      guidedNextTurn: sampleNextTurn,
+      guidedTerminal: null,
+    });
+
+    const respondPromise = useSessionStore.getState().respondGuided({
+      chosen: ["csv"],
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    });
+
+    // Simulate a session switch before the response arrives.
+    useSessionStore.setState({
+      activeSessionId: "sess-B",
+      guidedSession: null,
+      guidedNextTurn: null,
+      guidedTerminal: null,
+    });
+
+    // Let sess-A's response arrive.
+    resolveRespond(sampleRespondResponse);
+    await respondPromise;
+
+    // The stale response must have been dropped — sess-B's guided state
+    // must remain null (not overwritten by sess-A's respond result).
+    const state = useSessionStore.getState();
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+  });
+
+  // ── Test 11: forkFromMessage clears guided state and reloads (Codex #6) ──
+  //
+  // After a successful fork:
+  // 1. The fork's guided state must start null (synchronous clear).
+  // 2. startGuided must be called for the new fork session.
+
+  it("forkFromMessage: clears guided state and fires startGuided for fork", async () => {
+    const { forkFromMessage, getGuided } = await import("@/api/client");
+
+    const forkResult = {
+      session: { id: "sess-fork", title: "Fork", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" },
+      messages: [],
+      composition_state: null,
+    };
+
+    (forkFromMessage as ReturnType<typeof vi.fn>).mockResolvedValueOnce(forkResult);
+
+    // Controllable promise for startGuided so we can verify it was called
+    // without letting it resolve (keeps test deterministic).
+    let resolveGuided!: (v: GetGuidedResponse) => void;
+    (getGuided as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<GetGuidedResponse>((resolve) => {
+        resolveGuided = resolve;
+      }),
+    );
+
+    // Pre-seed: parent session has guided state that must NOT bleed into fork.
+    useSessionStore.setState({
+      activeSessionId: "sess-parent",
+      sessions: [{ id: "sess-parent", title: "Parent", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" }],
+      guidedSession: sampleGuidedSession,
+      guidedNextTurn: sampleNextTurn,
+      guidedTerminal: null,
+    });
+
+    // Start the fork — this triggers the async forkFromMessage path.
+    const forkPromise = useSessionStore.getState().forkFromMessage("msg-1", "new content");
+    await forkPromise;
+
+    // Guided state must be null immediately after the set() (synchronous clear).
+    const state = useSessionStore.getState();
+    expect(state.activeSessionId).toBe("sess-fork");
+    expect(state.guidedSession).toBeNull();
+    expect(state.guidedNextTurn).toBeNull();
+    expect(state.guidedTerminal).toBeNull();
+
+    // startGuided must have been invoked for the fork session.
+    expect(getGuided).toHaveBeenCalledWith("sess-fork");
+
+    // Let startGuided resolve — must write into the fork's guided state
+    // since activeSessionId is still "sess-fork".
+    resolveGuided(sampleGetGuidedResponse);
+    // Give microtask queue a tick to drain.
+    await Promise.resolve();
+
+    const stateAfterReload = useSessionStore.getState();
+    expect(stateAfterReload.guidedSession).toEqual(sampleGetGuidedResponse.guided_session);
   });
 });

--- a/src/elspeth/web/frontend/src/stores/sessionStore.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.ts
@@ -9,6 +9,12 @@ import type {
   ApiError,
   ValidationResult,
 } from "@/types/api";
+import type {
+  GuidedSession,
+  TurnPayload,
+  TerminalState,
+  GuidedRespondRequest,
+} from "@/types/guided";
 import * as api from "@/api/client";
 import { COMPOSE_TIMEOUT_MS } from "@/config/composer";
 import { useBlobStore } from "./blobStore";
@@ -83,6 +89,12 @@ interface SessionState {
 
   // Shared selection state for cross-component sync (GraphView <-> SpecView)
   selectedNodeId: string | null;
+
+  // Guided-mode protocol state — all three are null when not in a guided session
+  guidedSession: GuidedSession | null;
+  guidedNextTurn: TurnPayload | null;
+  guidedTerminal: TerminalState | null;
+
   selectNode: (nodeId: string | null) => void;
 
   loadSessions: () => Promise<void>;
@@ -99,6 +111,10 @@ interface SessionState {
   loadStateVersions: () => Promise<void>;
   isLoadingVersions: boolean;
   revertToVersion: (stateId: string) => Promise<void>;
+  // Guided-mode actions
+  startGuided: (sessionId: string) => Promise<void>;
+  respondGuided: (body: GuidedRespondRequest) => Promise<void>;
+  exitToFreeform: () => Promise<void>;
   clearError: () => void;
   injectSystemMessage: (content: string, stableId?: string) => void;
   reset: () => void;
@@ -115,6 +131,9 @@ const initialState = {
   isLoadingVersions: false,
   error: null as string | null,
   selectedNodeId: null as string | null,
+  guidedSession: null as GuidedSession | null,
+  guidedNextTurn: null as TurnPayload | null,
+  guidedTerminal: null as TerminalState | null,
 };
 
 export const useSessionStore = create<SessionState>((set, get) => ({
@@ -142,6 +161,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         stateVersions: [],
         error: null,
         selectedNodeId: null, // Clear selection for new session
+        guidedSession: null,
+        guidedNextTurn: null,
+        guidedTerminal: null,
       }));
     } catch {
       set({ error: "Failed to create session. Please try again." });
@@ -169,6 +191,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
                 stateVersions: [],
                 isComposing: false,
                 selectedNodeId: null,
+                guidedSession: null,
+                guidedNextTurn: null,
+                guidedTerminal: null,
               }
             : {}),
         };
@@ -193,6 +218,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       isComposing: false,
       error: null,
       selectedNodeId: null, // Clear selection when switching sessions
+      guidedSession: null,
+      guidedNextTurn: null,
+      guidedTerminal: null,
     });
 
     try {
@@ -498,6 +526,65 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         error: "Failed to fork conversation. Please try again.",
       });
     }
+  },
+
+  async startGuided(sessionId: string) {
+    try {
+      const response = await api.getGuided(sessionId);
+      // Atomically replace all 4 wire fields — server is authoritative (spec §7.3)
+      set({
+        guidedSession: response.guided_session,
+        guidedNextTurn: response.next_turn,
+        guidedTerminal: response.terminal,
+        compositionState: response.composition_state,
+      });
+    } catch {
+      // Error path: set error string, leave existing guided state alone.
+      // Mirrors selectSession lines 207-209: set error, don't clobber fields
+      // that were already loaded. The caller can inspect error to decide whether
+      // to surface a retry prompt.
+      set({ error: "Failed to load guided session. Please try again." });
+    }
+  },
+
+  async respondGuided(body: GuidedRespondRequest) {
+    const { activeSessionId } = get();
+    // Offensive guard — caller must not invoke this without an active session.
+    // Per CLAUDE.md: "Proactively detect invalid states and throw meaningful
+    // exceptions." Using ?. to silently skip would mask a programmer error.
+    if (activeSessionId === null) {
+      throw new Error("respondGuided called without active session");
+    }
+    try {
+      const response = await api.respondGuided(activeSessionId, body);
+      // Atomically replace all 4 wire fields — no optimistic updates (spec §7.3)
+      set({
+        guidedSession: response.guided_session,
+        guidedNextTurn: response.next_turn,
+        guidedTerminal: response.terminal,
+        compositionState: response.composition_state,
+      });
+    } catch (err) {
+      // Re-throw the invariant violation from the guard above — that's not a
+      // network error and must propagate to the caller unchanged.
+      if (err instanceof Error && err.message === "respondGuided called without active session") {
+        throw err;
+      }
+      set({ error: "Failed to submit guided response. Please try again." });
+    }
+  },
+
+  async exitToFreeform() {
+    // Sugar over respondGuided — sets control_signal and nulls all choice fields.
+    // All state mutation is handled by respondGuided.
+    await get().respondGuided({
+      chosen: null,
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: "exit_to_freeform",
+    });
   },
 
   async loadStateVersions() {

--- a/src/elspeth/web/frontend/src/stores/sessionStore.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.ts
@@ -164,6 +164,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         guidedNextTurn: null,
         guidedTerminal: null,
       }));
+      // Auto-start guided mode.  New sessions are created with
+      // GuidedSession.initial() already attached by the backend (spec §5.2,
+      // errata C7).  startGuided's own catch block handles failures without
+      // clobbering the session we just set above.
+      void get().startGuided(session.id);
     } catch {
       set({ error: "Failed to create session. Please try again." });
     }
@@ -228,6 +233,21 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         api.fetchCompositionState(id),
       ]);
       set({ messages, compositionState });
+
+      // Auto-start guided mode for the selected session.
+      //
+      // Per spec §5.2 and errata C7: new sessions are created with
+      // GuidedSession.initial() already attached by the backend.  The
+      // GET /guided endpoint auto-initialises on first call and returns the
+      // current step (or terminal state for sessions that have already
+      // exited to freeform).
+      //
+      // startGuided is fire-and-forget here: its own catch block sets the
+      // error field without clobbering the session/messages/compositionState
+      // we just loaded.  ChatPanel's guided-mode discriminator falls through
+      // to the freeform surface when guidedSession is null (startup race) or
+      // when terminal.kind === "exited_to_freeform" — both safe.
+      void get().startGuided(id);
 
       // Fire-and-forget: refresh blob list for the newly selected session
       useBlobStore.getState().loadBlobs(id);

--- a/src/elspeth/web/frontend/src/stores/sessionStore.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.ts
@@ -89,12 +89,6 @@ interface SessionState {
 
   // Shared selection state for cross-component sync (GraphView <-> SpecView)
   selectedNodeId: string | null;
-
-  // Guided-mode protocol state — all three are null when not in a guided session
-  guidedSession: GuidedSession | null;
-  guidedNextTurn: TurnPayload | null;
-  guidedTerminal: TerminalState | null;
-
   selectNode: (nodeId: string | null) => void;
 
   loadSessions: () => Promise<void>;
@@ -111,6 +105,11 @@ interface SessionState {
   loadStateVersions: () => Promise<void>;
   isLoadingVersions: boolean;
   revertToVersion: (stateId: string) => Promise<void>;
+
+  // Guided-mode protocol state — all three are null when not in a guided session
+  guidedSession: GuidedSession | null;
+  guidedNextTurn: TurnPayload | null;
+  guidedTerminal: TerminalState | null;
   // Guided-mode actions
   startGuided: (sessionId: string) => Promise<void>;
   respondGuided: (body: GuidedRespondRequest) => Promise<void>;
@@ -528,6 +527,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }
   },
 
+  // Guided-mode actions
   async startGuided(sessionId: string) {
     try {
       const response = await api.getGuided(sessionId);
@@ -564,12 +564,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         guidedTerminal: response.terminal,
         compositionState: response.composition_state,
       });
-    } catch (err) {
-      // Re-throw the invariant violation from the guard above — that's not a
-      // network error and must propagate to the caller unchanged.
-      if (err instanceof Error && err.message === "respondGuided called without active session") {
-        throw err;
-      }
+    } catch {
       set({ error: "Failed to submit guided response. Please try again." });
     }
   },

--- a/src/elspeth/web/frontend/src/stores/sessionStore.ts
+++ b/src/elspeth/web/frontend/src/stores/sessionStore.ts
@@ -534,10 +534,23 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         stateVersions: [],
         isComposing: false,
         selectedNodeId: null, // Clear selection for forked session
+        // Clear guided state synchronously — the fork is a new session context;
+        // the parent's guidedSession must not bleed into the fork's UI before
+        // startGuided resolves.  Mirrors selectSession lines 225-228.
+        guidedSession: null,
+        guidedNextTurn: null,
+        guidedTerminal: null,
       }));
 
       // Fire-and-forget: refresh blob list for the NEW forked session
       useBlobStore.getState().loadBlobs(result.session.id);
+
+      // Auto-start guided mode for the forked session — same pattern as
+      // selectSession and createSession.  The backend initialises a fresh
+      // GuidedSession on the first GET /guided call (spec §5.2, errata C7).
+      // The stale-fetch guard inside startGuided ensures the response is
+      // dropped if the user switches away again before it resolves.
+      void get().startGuided(result.session.id);
     } catch {
       set({
         isComposing: false,
@@ -549,8 +562,19 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   // Guided-mode actions
   async startGuided(sessionId: string) {
+    // Capture which session this fetch belongs to before the await.
+    // Mirrors the active-session guard in loadComposerProgress (lines 367-372):
+    // if the user switches sessions while the request is in flight, the
+    // stale response is silently dropped rather than overwriting the newly
+    // active session's guided state.
+    const requestedSessionId = sessionId;
     try {
       const response = await api.getGuided(sessionId);
+      // Stale-fetch guard (Codex #3): drop the response if the active session
+      // changed while the request was in flight.
+      if (get().activeSessionId !== requestedSessionId) {
+        return;
+      }
       // Atomically replace all 4 wire fields — server is authoritative (spec §7.3)
       set({
         guidedSession: response.guided_session,
@@ -575,8 +599,16 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     if (activeSessionId === null) {
       throw new Error("respondGuided called without active session");
     }
+    // Capture the session identity before the await (Codex #4 stale-fetch guard).
+    // Mirrors the active-session guard in loadComposerProgress (lines 367-372).
+    const requestedSessionId = activeSessionId;
     try {
       const response = await api.respondGuided(activeSessionId, body);
+      // Stale-fetch guard (Codex #4): drop the response if the active session
+      // changed while the request was in flight.
+      if (get().activeSessionId !== requestedSessionId) {
+        return;
+      }
       // Atomically replace all 4 wire fields — no optimistic updates (spec §7.3)
       set({
         guidedSession: response.guided_session,

--- a/src/elspeth/web/frontend/src/test/guided-fixtures.ts
+++ b/src/elspeth/web/frontend/src/test/guided-fixtures.ts
@@ -1,0 +1,31 @@
+// ============================================================================
+// Guided-mode test fixtures — shared helpers for SingleSelectTurn,
+// MultiSelectWithCustomTurn, SchemaFormTurn, ProposeChainTurn, RecipeOfferTurn,
+// InspectAndConfirmTurn (Tasks 7.2-7.7).
+//
+// Convention: anything that pins the GuidedRespondRequest wire shape lives
+// here, not inside individual widget tests. The whole point of these tests is
+// to detect drift in the wire contract — if a 7th GuidedRespondRequest field
+// lands one day, only THIS file should need updating, not 6 widget tests.
+// ============================================================================
+
+import type { GuidedRespondRequest } from "@/types/guided";
+
+/**
+ * The four GuidedRespondRequest fields that none of the chip-group / form
+ * widgets ever set (only `chosen` and `custom_inputs` vary across them).
+ *
+ * Spread into an `expect(...).toEqual({...})` body to assert the unused
+ * fields are explicitly null on the wire (not `undefined`, not omitted).
+ */
+export function nullResponse(): Pick<
+  GuidedRespondRequest,
+  "edited_values" | "accepted_step_index" | "edit_step_index" | "control_signal"
+> {
+  return {
+    edited_values: null,
+    accepted_step_index: null,
+    edit_step_index: null,
+    control_signal: null,
+  };
+}

--- a/src/elspeth/web/frontend/src/test/guided-fixtures.ts
+++ b/src/elspeth/web/frontend/src/test/guided-fixtures.ts
@@ -17,6 +17,28 @@ import type { GuidedRespondRequest } from "@/types/guided";
  *
  * Spread into an `expect(...).toEqual({...})` body to assert the unused
  * fields are explicitly null on the wire (not `undefined`, not omitted).
+ *
+ * USAGE: spread FIRST in the toEqual literal so explicitly-set fields override.
+ *
+ *   // CORRECT — explicit edited_values wins over nullResponse's edited_values=null
+ *   expect(body).toEqual({
+ *     ...nullResponse(),                  // <-- first
+ *     chosen: null,
+ *     custom_inputs: null,
+ *     edited_values: { columns, samples, warnings },  // <-- overrides
+ *   });
+ *
+ *   // WRONG — spreading last re-nulls edited_values; the test silently asserts null
+ *   expect(body).toEqual({
+ *     chosen: null,
+ *     edited_values: { columns, samples, warnings },
+ *     ...nullResponse(),                  // <-- clobbers edited_values
+ *   });
+ *
+ * InspectAndConfirmTurn (Task 7.3) sets `edited_values` on both submit paths
+ * and tripped this exact bug during initial development. Widgets in 7.4-7.7
+ * that set fields beyond `chosen` / `custom_inputs` MUST observe the same
+ * spread order.
  */
 export function nullResponse(): Pick<
   GuidedRespondRequest,

--- a/src/elspeth/web/frontend/src/types/guided.test.ts
+++ b/src/elspeth/web/frontend/src/types/guided.test.ts
@@ -66,25 +66,24 @@ describe("guided protocol types", () => {
     // attempt to assign it would be a TS compile error.
   });
 
-  it("TurnPayload.step_index is number", () => {
+  it("TurnPayload.step_index is number (compile-time) and 0-based ordinal", () => {
     const payload: TurnPayload = {
       type: "single_select",
       step_index: 0,
       payload: {},
     };
-    expect(typeof payload.step_index).toBe("number");
     expect(payload.step_index).toBe(0);
   });
 
-  it("GuidedSession has exactly step, history, terminal", () => {
-    // Exhaustiveness at compile time: the array type forces Keys to be
-    // constrained to keyof GuidedSession.
-    type Keys = keyof GuidedSession;
-    const expected: Keys[] = ["step", "history", "terminal"];
-    expect(expected).toHaveLength(3);
+  it("GuidedSession has exactly step, history, terminal — exhaustive", () => {
+    type Equals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+    // Compile-time mutual-extends: adding/removing a key in GuidedSession
+    // makes this assignment fail tsc.
+    const _exact: Equals<keyof GuidedSession, "step" | "history" | "terminal"> = true;
+    expect(_exact).toBe(true);
   });
 
-  it("TurnRecord compiles with a well-formed sample", () => {
+  it("TurnRecord nullable response_hash is honoured", () => {
     const rec: TurnRecord = {
       step: "step_1_source",
       turn_type: "inspect_and_confirm",
@@ -92,7 +91,7 @@ describe("guided protocol types", () => {
       response_hash: null,
       emitter: "server",
     };
-    expect(rec.payload_hash).toBe("abc123");
+    expect(rec.response_hash).toBeNull();
   });
 
   it("GuidedRespondRequest compiles with all-null body", () => {

--- a/src/elspeth/web/frontend/src/types/guided.test.ts
+++ b/src/elspeth/web/frontend/src/types/guided.test.ts
@@ -1,0 +1,119 @@
+// Tests for guided.ts — type-assertion style.
+// Vitest compile failures ARE the test: if the union drifts, the array literal
+// above it stops compiling.
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ControlSignal,
+  GuidedRespondRequest,
+  GuidedRespondResponse,
+  GuidedSession,
+  GuidedStep,
+  GetGuidedResponse,
+  TerminalKind,
+  TerminalReason,
+  TurnPayload,
+  TurnRecord,
+  TurnType,
+} from "./guided";
+
+describe("guided protocol types", () => {
+  it("TurnType union has 6 values", () => {
+    const all: TurnType[] = [
+      "inspect_and_confirm",
+      "single_select",
+      "multi_select_with_custom",
+      "schema_form",
+      "propose_chain",
+      "recipe_offer",
+    ];
+    expect(all).toHaveLength(6);
+  });
+
+  it("ControlSignal union has 3 values", () => {
+    const all: ControlSignal[] = [
+      "exit_to_freeform",
+      "request_advisor",
+      "reject",
+    ];
+    expect(all).toHaveLength(3);
+  });
+
+  it("GuidedStep union has 4 values", () => {
+    const all: GuidedStep[] = [
+      "step_1_source",
+      "step_2_sink",
+      "step_2_5_recipe_match",
+      "step_3_transforms",
+    ];
+    expect(all).toHaveLength(4);
+  });
+
+  it("TerminalKind union has 2 values", () => {
+    const all: TerminalKind[] = ["completed", "exited_to_freeform"];
+    expect(all).toHaveLength(2);
+  });
+
+  it("TerminalReason union has 3 values (no completed_pipeline)", () => {
+    const all: TerminalReason[] = [
+      "user_pressed_exit",
+      "protocol_violation",
+      "solver_exhausted",
+    ];
+    expect(all).toHaveLength(3);
+    // Type-level negative: "completed_pipeline" is not in the union — any
+    // attempt to assign it would be a TS compile error.
+  });
+
+  it("TurnPayload.step_index is number", () => {
+    const payload: TurnPayload = {
+      type: "single_select",
+      step_index: 0,
+      payload: {},
+    };
+    expect(typeof payload.step_index).toBe("number");
+    expect(payload.step_index).toBe(0);
+  });
+
+  it("GuidedSession has exactly step, history, terminal", () => {
+    // Exhaustiveness at compile time: the array type forces Keys to be
+    // constrained to keyof GuidedSession.
+    type Keys = keyof GuidedSession;
+    const expected: Keys[] = ["step", "history", "terminal"];
+    expect(expected).toHaveLength(3);
+  });
+
+  it("TurnRecord compiles with a well-formed sample", () => {
+    const rec: TurnRecord = {
+      step: "step_1_source",
+      turn_type: "inspect_and_confirm",
+      payload_hash: "abc123",
+      response_hash: null,
+      emitter: "server",
+    };
+    expect(rec.payload_hash).toBe("abc123");
+  });
+
+  it("GuidedRespondRequest compiles with all-null body", () => {
+    const req: GuidedRespondRequest = {
+      chosen: null,
+      edited_values: null,
+      custom_inputs: null,
+      accepted_step_index: null,
+      edit_step_index: null,
+      control_signal: null,
+    };
+    expect(req.chosen).toBeNull();
+  });
+
+  it("GetGuidedResponse and GuidedRespondResponse include composition_state", () => {
+    // Type-level check: if composition_state were absent the assignment below
+    // would be a TS error.
+    const check = (r: GetGuidedResponse | GuidedRespondResponse) => {
+      return r.composition_state;
+    };
+    // Runtime: just confirm the type guard compiles; value is irrelevant.
+    expect(check).toBeTypeOf("function");
+  });
+});

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -102,3 +102,21 @@ export interface GuidedRespondResponse {
   terminal: TerminalState | null;
   composition_state: CompositionState | null;
 }
+
+// ── Per-turn payload shapes ───────────────────────────────────────────────────
+// Each widget owns its payload type; add yours when you implement the widget.
+// Field names use snake_case to mirror the wire (GuidedRespondRequest does too).
+//
+// SHARED across single_select / multi_select_with_custom / recipe_offer:
+export interface Option {
+  id: string;
+  label: string;
+  hint: string | null; // null, not optional — wire always sends the key
+}
+
+/** Wire: SingleSelectPayload (protocol.py:40-43). */
+export interface SingleSelectPayload {
+  question: string;
+  options: Option[];
+  allow_custom: boolean;
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -157,3 +157,21 @@ export interface Observed {
 export interface InspectAndConfirmPayload {
   observed: Observed;
 }
+
+/**
+ * Wire: SchemaFormPayload (protocol.py:53-56).
+ *
+ * schema_block is the output of Pydantic ConfigModel.model_json_schema().
+ * The TS type uses Record<string, unknown> because the full JSON Schema spec
+ * is not reflected here -- only the subset handled by SchemaFormTurn is consumed
+ * (see SchemaFormTurn.tsx SCOPE NOTE for the supported field types).
+ *
+ * prefilled contains initial field values keyed by property name.
+ * Top-level keys in prefilled always correspond to top-level keys in
+ * schema_block.properties.
+ */
+export interface SchemaFormPayload {
+  plugin: string;
+  schema_block: Record<string, unknown>;
+  prefilled: Record<string, unknown>;
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -213,12 +213,16 @@ export interface ProposeChainPayload {
  *
  * The frontend renders an editable input keyed by ``name`` and merges the
  * typed value into ``edited_values.slots`` before submitting.
+ *
+ * ``required`` is intentionally absent: the RecipeMatch invariant
+ * (protocol.py:_RecipeSlotInput docstring, commit 83b17ca6) guarantees every
+ * entry in unsatisfied_slots is required. All inputs rendered from this type
+ * should be treated as required without reading a flag.
  */
 export interface RecipeSlotInput {
   name: string;
   slot_type: "blob_id" | "str" | "float" | "int" | "str_list";
   description: string;
-  required: boolean;
 }
 
 /**

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -198,7 +198,8 @@ export interface ProposedStep {
  * Submit shape (verified against routes.py:2030-2137):
  *   Accept all: { chosen: ["accept"], ... all other fields null }
  *   Reject / per-step Edit / Ask advisor: NOT wired in Phase 4.
- *   See observation elspeth-obs-98eab6aa67 for Phase 5 catch-up tracking.
+ *
+ * Tracker: filigree elspeth-2c08408170 (Step-3 backend handler completion).
  */
 export interface ProposeChainPayload {
   steps: ProposedStep[];

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -120,3 +120,15 @@ export interface SingleSelectPayload {
   options: Option[];
   allow_custom: boolean;
 }
+
+/** Wire: _Observed (protocol.py:30-33). Nested inside InspectAndConfirmPayload. */
+export interface Observed {
+  columns: string[];
+  samples: Record<string, unknown>[];
+  warnings: string[];
+}
+
+/** Wire: InspectAndConfirmPayload (protocol.py:36-37). */
+export interface InspectAndConfirmPayload {
+  observed: Observed;
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -121,6 +121,29 @@ export interface SingleSelectPayload {
   allow_custom: boolean;
 }
 
+/** Wire: MultiSelectWithCustomPayload (protocol.py:46-50). */
+export interface MultiSelectWithCustomPayload {
+  question: string;
+  options: Option[];
+  /** Option IDs initially checked; subset of `options[].id`. */
+  default_chosen: string[];
+  /**
+   * Server-emitted label for the "let source decide" escape button, or null.
+   *
+   * NOTE: As of Task 7.4 this field is INTENTIONALLY NOT consumed by
+   * MultiSelectWithCustomTurn. The wire shape for the escape submission
+   * requires a cross-layer protocol decision: the plan describes
+   * `{edited_values: {schema_mode: "observed", required_fields: []}}`
+   * (no `outputs` wrapper, no plugin/options) but the only backend read
+   * site (state_machine.py:_advance_step_2 lines 476-483) unconditionally
+   * reads `edited_values["outputs"]` as a list of full output dicts. The
+   * widget owns neither the plugin nor the options needed to construct
+   * that array. Tracked as a follow-up; the field stays here because the
+   * backend still emits it (do not remove).
+   */
+  escape_label: string | null;
+}
+
 /** Wire: _Observed (protocol.py:30-33). Nested inside InspectAndConfirmPayload. */
 export interface Observed {
   columns: string[];

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -46,8 +46,8 @@ export interface TurnRecord {
   turn_type: TurnType;
   payload_hash: string;
   response_hash: string | null;
-  /** "server" or "llm" — enum not yet closed in spec §5; bare string for now. */
-  emitter: string;
+  /** Closed value domain (state_machine.py:75-82): server-emitted or LLM-emitted. */
+  emitter: "server" | "llm";
 }
 
 /** Wire: TerminalStateResponse (schemas.py:223-228). */

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -175,3 +175,33 @@ export interface SchemaFormPayload {
   schema_block: Record<string, unknown>;
   prefilled: Record<string, unknown>;
 }
+
+/**
+ * Wire: _ProposedStep (protocol.py:59-62). One step in a proposed chain.
+ *
+ * options is an arbitrary plugin options dict (Mapping[str, Any] on the wire);
+ * typed as Record<string, unknown> -- callers must not assume any specific shape.
+ */
+export interface ProposedStep {
+  plugin: string;
+  options: Record<string, unknown>;
+  rationale: string;
+}
+
+/**
+ * Wire: ProposeChainPayload (protocol.py:64-68).
+ *
+ * steps    -- ordered list of proposed transforms.
+ * why      -- LLM's overall rationale for the proposal.
+ * blockers -- obstacles identified by the LLM (may be empty).
+ *
+ * Submit shape (verified against routes.py:2030-2137):
+ *   Accept all: { chosen: ["accept"], ... all other fields null }
+ *   Reject / per-step Edit / Ask advisor: NOT wired in Phase 4.
+ *   See observation elspeth-obs-98eab6aa67 for Phase 5 catch-up tracking.
+ */
+export interface ProposeChainPayload {
+  steps: ProposedStep[];
+  why: string;
+  blockers: string[];
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -1,0 +1,104 @@
+// ============================================================================
+// Guided-mode protocol types
+//
+// TypeScript mirrors of the pydantic wire schemas for the guided composer
+// protocol.  Source of truth:
+//   src/elspeth/web/composer/guided/protocol.py   — TurnType, ControlSignal, GuidedStep
+//   src/elspeth/web/composer/guided/state_machine.py — TerminalKind, TerminalReason
+//   src/elspeth/web/sessions/schemas.py:213-296   — wire response/request shapes
+// ============================================================================
+
+import type { CompositionState } from "./index";
+
+// ── Enums ────────────────────────────────────────────────────────────────────
+
+export type TurnType =
+  | "inspect_and_confirm"
+  | "single_select"
+  | "multi_select_with_custom"
+  | "schema_form"
+  | "propose_chain"
+  | "recipe_offer";
+
+export type ControlSignal =
+  | "exit_to_freeform"
+  | "request_advisor"
+  | "reject";
+
+export type GuidedStep =
+  | "step_1_source"
+  | "step_2_sink"
+  | "step_2_5_recipe_match"
+  | "step_3_transforms";
+
+export type TerminalKind = "completed" | "exited_to_freeform";
+
+export type TerminalReason =
+  | "user_pressed_exit"
+  | "protocol_violation"
+  | "solver_exhausted";
+
+// ── Domain shapes ─────────────────────────────────────────────────────────────
+
+/** Wire: TurnRecordResponse (schemas.py:213-220). Mirrors a single history entry. */
+export interface TurnRecord {
+  step: GuidedStep;
+  turn_type: TurnType;
+  payload_hash: string;
+  response_hash: string | null;
+  /** "server" or "llm" — enum not yet closed in spec §5; bare string for now. */
+  emitter: string;
+}
+
+/** Wire: TerminalStateResponse (schemas.py:223-228). */
+export interface TerminalState {
+  kind: TerminalKind;
+  reason: TerminalReason | null;
+  pipeline_yaml: string | null;
+}
+
+/**
+ * Wire: GuidedSessionResponse (schemas.py:231-236).
+ * Exactly three wire fields — internal step results never cross the wire.
+ */
+export interface GuidedSession {
+  step: GuidedStep;
+  history: TurnRecord[];
+  terminal: TerminalState | null;
+}
+
+/** Wire: TurnPayloadResponse (schemas.py:239-252). step_index is 0-based ordinal (number). */
+export interface TurnPayload {
+  type: TurnType;
+  step_index: number;
+  payload: unknown;
+}
+
+// ── Endpoint envelopes ───────────────────────────────────────────────────────
+
+/** Response for GET /api/sessions/{id}/guided (schemas.py:255-261). */
+export interface GetGuidedResponse {
+  guided_session: GuidedSession;
+  next_turn: TurnPayload | null;
+  terminal: TerminalState | null;
+  composition_state: CompositionState | null;
+}
+
+/** Request body for POST /api/sessions/{id}/guided/respond (schemas.py:264-283). */
+export interface GuidedRespondRequest {
+  chosen: string[] | null;
+  edited_values: Record<string, unknown> | null;
+  custom_inputs: string[] | null;
+  accepted_step_index: number | null;
+  edit_step_index: number | null;
+  /** Typed as closed enum client-side; server validates and accepts str for graceful stale-client failure. */
+  control_signal: ControlSignal | null;
+}
+
+/** Response for POST /api/sessions/{id}/guided/respond (schemas.py:286-296). */
+export interface GuidedRespondResponse {
+  guided_session: GuidedSession;
+  next_turn: TurnPayload | null;
+  terminal: TerminalState | null;
+  composition_state: CompositionState | null;
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -208,22 +208,44 @@ export interface ProposeChainPayload {
 }
 
 /**
- * Wire: RecipeOfferPayload (protocol.py:71-74).
+ * Wire: one unsatisfied required slot input for a recipe_offer turn
+ * (protocol.py:_RecipeSlotInput).
  *
- * recipe_name  -- matched recipe identifier.
- * slots        -- already-resolved slot values (Mapping[str, Any] on the wire).
- *                 Typed as Record<string, unknown> — callers must not assume
- *                 any specific value shape.
- * alternatives -- alternative recipe names or control signals the server may
- *                 suggest.  In the current backend (emitters.py:226), this is
- *                 always ["build_manually"].  Display when non-empty; the
- *                 "Build manually" button already acts on that signal, so
- *                 rendering it here is advisory only (informs the user other
- *                 paths exist — or may exist once the recipe catalogue grows).
+ * The frontend renders an editable input keyed by ``name`` and merges the
+ * typed value into ``edited_values.slots`` before submitting.
+ */
+export interface RecipeSlotInput {
+  name: string;
+  slot_type: "blob_id" | "str" | "float" | "int" | "str_list";
+  description: string;
+  required: boolean;
+}
+
+/**
+ * Wire: RecipeOfferPayload (protocol.py:RecipeOfferPayload).
  *
- * Submit shapes (verified against routes.py:1943-2023):
+ * recipe_name       -- matched recipe identifier.
+ * slots             -- already-resolved slot values (Mapping[str, Any] on the
+ *                      wire).  Typed as Record<string, unknown> — callers must
+ *                      not assume any specific value shape.
+ * alternatives      -- alternative recipe names or control signals the server
+ *                      may suggest.  In the current backend (emitters.py), this
+ *                      is always ["build_manually"].  Display when non-empty;
+ *                      the "Build manually" button already acts on that signal,
+ *                      so rendering it here is advisory only (informs the user
+ *                      other paths exist — or may exist once the recipe
+ *                      catalogue grows).
+ * unsatisfied_slots -- the schema for required slots the resolver could NOT
+ *                      pre-fill.  The widget renders an editable input per
+ *                      entry; the typed values are merged into
+ *                      ``edited_values.slots`` on Apply.  Empty when the
+ *                      resolver covered every required slot.
+ *
+ * Submit shapes (verified against routes.py STEP_2_5_RECIPE_MATCH handler):
  *   Apply recipe:   { chosen: ["accept"],
- *                     edited_values: { recipe_name, slots },  ← ECHO REQUIRED
+ *                     edited_values: { recipe_name,
+ *                                      slots: { ...payload.slots,
+ *                                               ...operator_inputs } },
  *                     custom_inputs: null, accepted_step_index: null,
  *                     edit_step_index: null, control_signal: null }
  *   Build manually: { chosen: ["build_manually"],
@@ -232,13 +254,13 @@ export interface ProposeChainPayload {
  *                     control_signal: null }
  *
  * NOTE: The "Apply recipe" path MUST send edited_values with recipe_name and
- * slots.  The backend (routes.py:1965-1967) reads edited_values to reconstruct
- * the RecipeMatch; if edited_values is null it falls back to ("", {}) which
- * causes handle_step_2_5_recipe_apply to fail.  This differs from the plan-body
- * description which stated edited_values: null -- the plan body was incomplete.
+ * the merged slots (pre-filled + operator inputs).  The backend reconstructs
+ * the RecipeMatch from edited_values and feeds slots to validate_slots; a
+ * missing required slot produces a RecipeValidationError → HTTP 400.
  */
 export interface RecipeOfferPayload {
   recipe_name: string;
   slots: Record<string, unknown>;
   alternatives: string[];
+  unsatisfied_slots: RecipeSlotInput[];
 }

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -206,3 +206,39 @@ export interface ProposeChainPayload {
   why: string;
   blockers: string[];
 }
+
+/**
+ * Wire: RecipeOfferPayload (protocol.py:71-74).
+ *
+ * recipe_name  -- matched recipe identifier.
+ * slots        -- already-resolved slot values (Mapping[str, Any] on the wire).
+ *                 Typed as Record<string, unknown> — callers must not assume
+ *                 any specific value shape.
+ * alternatives -- alternative recipe names or control signals the server may
+ *                 suggest.  In the current backend (emitters.py:226), this is
+ *                 always ["build_manually"].  Display when non-empty; the
+ *                 "Build manually" button already acts on that signal, so
+ *                 rendering it here is advisory only (informs the user other
+ *                 paths exist — or may exist once the recipe catalogue grows).
+ *
+ * Submit shapes (verified against routes.py:1943-2023):
+ *   Apply recipe:   { chosen: ["accept"],
+ *                     edited_values: { recipe_name, slots },  ← ECHO REQUIRED
+ *                     custom_inputs: null, accepted_step_index: null,
+ *                     edit_step_index: null, control_signal: null }
+ *   Build manually: { chosen: ["build_manually"],
+ *                     edited_values: null, custom_inputs: null,
+ *                     accepted_step_index: null, edit_step_index: null,
+ *                     control_signal: null }
+ *
+ * NOTE: The "Apply recipe" path MUST send edited_values with recipe_name and
+ * slots.  The backend (routes.py:1965-1967) reads edited_values to reconstruct
+ * the RecipeMatch; if edited_values is null it falls back to ("", {}) which
+ * causes handle_step_2_5_recipe_apply to fail.  This differs from the plan-body
+ * description which stated edited_values: null -- the plan body was incomplete.
+ */
+export interface RecipeOfferPayload {
+  recipe_name: string;
+  slots: Record<string, unknown>;
+  alternatives: string[];
+}

--- a/src/elspeth/web/frontend/src/types/guided.ts
+++ b/src/elspeth/web/frontend/src/types/guided.ts
@@ -138,8 +138,10 @@ export interface MultiSelectWithCustomPayload {
    * site (state_machine.py:_advance_step_2 lines 476-483) unconditionally
    * reads `edited_values["outputs"]` as a list of full output dicts. The
    * widget owns neither the plugin nor the options needed to construct
-   * that array. Tracked as a follow-up; the field stays here because the
-   * backend still emits it (do not remove).
+   * that array. The field stays here because the backend still emits it
+   * (do not remove).
+   *
+   * Tracker: filigree elspeth-5e905f3c9d
    */
   escape_label: string | null;
 }

--- a/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
+++ b/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
@@ -5,35 +5,49 @@
 //   ≤9 user clicks to reach CompletionSummary via the recipe-match path.
 //   <30s wall-clock (recipe match is deterministic — zero LLM calls).
 //
-// ── FIXME — BLOCKED (Phase 9, 2026-05-12) ───────────────────────────────────
+// ── Gap 5 fixed (2026-05-12, commit 74ea68eb) ────────────────────────────────
 //
-// This spec was run against the live backend during Phase 9 Task 9.1 and
-// verified step-by-step using Playwright traces and server logs. The wizard
-// UI advances correctly through csv→SCHEMA_FORM→json→SCHEMA_FORM→
-// MULTI_SELECT_WITH_CUSTOM, but the RECIPE_OFFER "Apply recipe" step returns
-// HTTP 400.
+// This spec was previously blocked by Gap 5 (recipe-match path unreachable via
+// SchemaForm).  The fix uses a combined approach (options a + b):
 //
-// Root cause (Gap 5 below): the guided wizard's Step 1 SchemaForm path writes
-// the source via _execute_set_source (handle_step_1_source in steps.py:83),
-// which stores options={path, schema, on_validation_failure} with NO blob_id
-// key.  The recipe slot resolver _classify_slot_resolver (recipe_match.py:133)
-// reads `source.options.get("blob_id", "")` → returns "".  The recipe builder
-// _build_classify_recipe (recipes.py:250) puts `"blob_id": ""` into the source
-// args.  _execute_set_pipeline then calls _resolve_source_blob(blob_id=""),
-// which fails: "Blob '' not found." → HTTP 400.
+//   (a) recipe_match.py: _classify_slot_resolver / _split_threshold_slot_resolver
+//       now read source.options["blob_ref"] (composer-canonical) instead of
+//       source.options.get("blob_id", ""). Missing blob_ref → offensive crash
+//       (state-machine invariant: resolver is only reached for blob-backed sources).
 //
-// The recipe-match path is structurally unreachable when the source is set via
-// SchemaForm.  Fixing it requires one of:
-//   (a) _classify_slot_resolver also checks source.options["blob_ref"] (set by
-//       _execute_set_source_from_blob but not by _execute_set_source);
-//   (b) handle_step_1_source detects blob-storage paths and writes blob_ref
-//       alongside path;
-//   (c) _build_classify_recipe treats blob_id="" as None and falls back to the
-//       already-committed source path in state.source.options.
-// All three options require backend design review. Filed as observation for
-// triage (see below).
+//   (b) steps.py / tools.py: handle_step_1_source now accepts session_engine +
+//       session_id, looks up the blob by storage_path after _execute_set_source
+//       commits, and injects blob_ref into SourceResolved.options when found.
+//       This lets the guided SchemaForm path (where the user types the blob's
+//       file path) populate blob_ref without switching to set_source_from_blob.
 //
-// Gaps discovered (in order encountered during the Phase 9 run):
+// Gap 5 VERIFIED FIXED: Playwright page snapshot after clicking "Apply recipe"
+// shows source_blob_id: f2852ea6-9e19-4db1-a03d-4dba2b92b9da (real UUID) in
+// the recipe_offer card. Steps 1–5 now return HTTP 200. The 400 is downstream.
+//
+// ── Gap 6 — recipe_offer missing unsatisfied-slot UX (blocks Apply recipe) ───
+//
+// The recipe_offer step still returns HTTP 400 at Apply recipe time.  This is a
+// NEW blocker revealed after Gap 5 was fixed.
+//
+// Root cause: RecipeOfferPayload.slots carries only the pre-filled slots
+// {source_blob_id, output_path, label_field}.  The RecipeOfferTurn widget echoes
+// payload.slots unchanged in edited_values when "Apply recipe" is clicked.  But
+// classify-rows-llm-jsonl declares three required slots without defaults:
+//   - classifier_template (str)
+//   - model (str)
+//   - api_key_secret (str)
+// validate_slots raises RecipeValidationError for each missing required slot →
+// _execute_apply_pipeline_recipe returns failure → HTTP 400.
+//
+// The RecipeOfferPayload type (guided.ts:240-244) carries no slot-schema, so the
+// frontend cannot know which slots need user input.  Both layers need changes:
+//   (a) backend: include the recipe's slot specs (type, required, description) in
+//       RecipeOfferPayload so the frontend can distinguish pre-filled from empty.
+//   (b) frontend: RecipeOfferTurn renders editable form fields for unsatisfied
+//       required slots (using payload.slot_specs[name].required + value absent).
+//
+// Gaps discovered during Phase 9 Task 9.1 (in order encountered):
 //
 //   Gap 1 — startGuided not wired to any UI entry point:
 //     sessionStore.createSession and selectSession both set guidedSession: null.
@@ -41,7 +55,7 @@
 //     component. ChatPanel's guided-mode discriminator never fires. Fix applied
 //     in sessionStore.ts (both createSession and selectSession now call
 //     void get().startGuided(id)) — this is the minimum needed for the wizard
-//     to render. See observation filed as elspeth-obs-PLACEHOLDER-gap1.
+//     to render. See observation filed as elspeth-obs-d3d0d7fa70.
 //
 //   Gap 2 — S2 path allowlist blocks raw /tmp paths:
 //     _validate_source_path (tools.py:2086) rejects paths outside data_dir/blobs/.
@@ -62,29 +76,28 @@
 //     must expand the section and set "auto_increment".  Adds 1 to click budget.
 //
 //   Gap 5 — recipe-match structurally unreachable (blocks Apply recipe → 400):
-//     See root cause above.  THIS IS THE HARD BLOCKER.  No in-test workaround
-//     exists without modifying the backend.
+//     FIXED in commit 74ea68eb (Phase 9 dispatch).
+//
+//   Gap 6 — recipe_offer missing unsatisfied-slot UX (blocks Apply recipe → 400):
+//     See root cause above.  THIS IS THE CURRENT HARD BLOCKER.
+//     Filed as elspeth-obs-<gap6-id> (see Observations section).
 //
 // ── Observations filed ───────────────────────────────────────────────────────
 //
-// Observations will be filed by the Phase 9 controller after reviewing this
-// spec.  Placeholder IDs below; update when observation IDs are assigned.
-//
-//   elspeth-obs-PLACEHOLDER-gap1: startGuided not wired to UI entry point
-//   elspeth-obs-PLACEHOLDER-gap5: recipe-match unreachable via SchemaForm path
-//     (source_blob_id always "" for SCHEMA_FORM-set sources)
+//   elspeth-obs-d3d0d7fa70: startGuided not wired to UI entry point (Gap 1)
+//     Fixed in sessionStore.ts (createSession + selectSession now call startGuided).
+//   elspeth-obs-a8a9bc010a: recipe-match unreachable via SchemaForm path (Gap 5)
+//     Fixed in 74ea68eb (this Phase 9 dispatch).
+//   elspeth-obs-f626607b13: RecipeOfferTurn missing editable form for
+//     unsatisfied required slots; RecipeOfferPayload missing slot-schema (Gap 6).
 //
 // ── What the spec verifies today ─────────────────────────────────────────────
 //
-// The smoke spec (smoke.spec.ts) already verifies session CRUD and auth.
-// The guided spec WOULD verify the full recipe-match flow once Gap 5 is fixed.
-//
-// The partial steps 1-4 (csv chip → source schema → json chip → sink schema)
-// were verified to work correctly during Phase 9 testing:
-//   POST /guided/respond 200 OK ×4 (one per step)
-//   POST /guided/respond 400 Bad Request (Apply recipe fails, Gap 5)
-// The test is written as fixme so that the step-by-step logic and commentary
-// are preserved for the developer who fixes Gap 5.
+// Steps 1–5 (csv chip → source schema → json chip → sink schema → required
+// fields → recipe_offer render) now return HTTP 200 (verified in this dispatch).
+// The test is marked fixme because Apply recipe still returns HTTP 400 (Gap 6).
+// All step-by-step logic is preserved so whoever fixes Gap 6 can un-fixme in
+// one step without reconstructing the test.
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -127,11 +140,16 @@ const SINK_OUTPUT_PATH = resolve(E2E_DATA_DIR, "outputs", "playwright-guided-out
 test.describe("composer-guided — recipe-match happy path", () => {
   test.fixme(
     true,
-    "BLOCKED: recipe-match path unreachable (Gap 5) — source set via SchemaForm " +
-    "has no blob_id in options; _classify_slot_resolver returns source_blob_id=''; " +
-    "_resolve_source_blob fails 'Blob not found' → HTTP 400 on Apply recipe. " +
-    "Backend fix required (steps.py / recipe_match.py / recipes.py). " +
-    "Full blocker analysis in spec file header.",
+    "BLOCKED: Apply recipe → HTTP 400 (Gap 6) — recipe_offer payload contains " +
+    "only the pre-filled slots {source_blob_id, output_path, label_field}; the " +
+    "RecipeOfferTurn widget echoes payload.slots unchanged; missing required slots " +
+    "classifier_template / model / api_key_secret cause RecipeValidationError at " +
+    "apply time.  Gap 5 (blob_ref lookup) is VERIFIED FIXED (page snapshot shows " +
+    "source_blob_id: f2852ea6-...) — the recipe_offer now renders correctly. " +
+    "Fix requires: (a) backend to include slot-schema in RecipeOfferPayload so the " +
+    "frontend knows which slots need user input, and (b) RecipeOfferTurn editable " +
+    "form fields for unsatisfied required slots. " +
+    "Full analysis in spec file header."
   );
 
   test(
@@ -232,8 +250,11 @@ test.describe("composer-guided — recipe-match happy path", () => {
         clicks++;
 
         // ── Step 2.5 RECIPE_OFFER — Apply recipe ──────────────────────────
-        // Blocked by Gap 5: Apply recipe → HTTP 400 (source_blob_id = "").
-        // This assertion is expected to fail until Gap 5 is fixed.
+        // Gap 5 FIXED: recipe_offer now renders with correct source_blob_id.
+        // Apply recipe still returns HTTP 400 (Gap 6): required slots
+        // classifier_template / model / api_key_secret are not pre-filled and
+        // the RecipeOfferTurn widget has no editable form to supply them.
+        // This assertion is expected to fail until Gap 6 is fixed.
         await expect(
           page.getByRole("button", { name: "Apply recipe", exact: true }),
         ).toBeVisible();

--- a/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
+++ b/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
@@ -1,0 +1,262 @@
+// E2E spec: guided-mode wizard recipe-match happy path.
+//
+// Targets the demo SLA defined in §10.3 of the implementation plan
+// (2026-05-11-composer-guided-mode.md:4619-4621, corrected at df5306cf):
+//   ≤9 user clicks to reach CompletionSummary via the recipe-match path.
+//   <30s wall-clock (recipe match is deterministic — zero LLM calls).
+//
+// ── FIXME — BLOCKED (Phase 9, 2026-05-12) ───────────────────────────────────
+//
+// This spec was run against the live backend during Phase 9 Task 9.1 and
+// verified step-by-step using Playwright traces and server logs. The wizard
+// UI advances correctly through csv→SCHEMA_FORM→json→SCHEMA_FORM→
+// MULTI_SELECT_WITH_CUSTOM, but the RECIPE_OFFER "Apply recipe" step returns
+// HTTP 400.
+//
+// Root cause (Gap 5 below): the guided wizard's Step 1 SchemaForm path writes
+// the source via _execute_set_source (handle_step_1_source in steps.py:83),
+// which stores options={path, schema, on_validation_failure} with NO blob_id
+// key.  The recipe slot resolver _classify_slot_resolver (recipe_match.py:133)
+// reads `source.options.get("blob_id", "")` → returns "".  The recipe builder
+// _build_classify_recipe (recipes.py:250) puts `"blob_id": ""` into the source
+// args.  _execute_set_pipeline then calls _resolve_source_blob(blob_id=""),
+// which fails: "Blob '' not found." → HTTP 400.
+//
+// The recipe-match path is structurally unreachable when the source is set via
+// SchemaForm.  Fixing it requires one of:
+//   (a) _classify_slot_resolver also checks source.options["blob_ref"] (set by
+//       _execute_set_source_from_blob but not by _execute_set_source);
+//   (b) handle_step_1_source detects blob-storage paths and writes blob_ref
+//       alongside path;
+//   (c) _build_classify_recipe treats blob_id="" as None and falls back to the
+//       already-committed source path in state.source.options.
+// All three options require backend design review. Filed as observation for
+// triage (see below).
+//
+// Gaps discovered (in order encountered during the Phase 9 run):
+//
+//   Gap 1 — startGuided not wired to any UI entry point:
+//     sessionStore.createSession and selectSession both set guidedSession: null.
+//     startGuided() is implemented in the store but never called from any
+//     component. ChatPanel's guided-mode discriminator never fires. Fix applied
+//     in sessionStore.ts (both createSession and selectSession now call
+//     void get().startGuided(id)) — this is the minimum needed for the wizard
+//     to render. See observation filed as elspeth-obs-PLACEHOLDER-gap1.
+//
+//   Gap 2 — S2 path allowlist blocks raw /tmp paths:
+//     _validate_source_path (tools.py:2086) rejects paths outside data_dir/blobs/.
+//     Test must use the blob's storage path (service.py:207-211 format:
+//     data_dir/blobs/{session_id}/{blob_id}_{filename}).  Worked around in spec
+//     by constructing the path from known session_id and blob.id.
+//
+//   Gap 3 — on_validation_failure is required in source SchemaForm:
+//     SourceDataConfig.on_validation_failure (config_base.py:358) has no default
+//     and appears in the REQUIRED section of the SchemaForm.  The test must fill
+//     it with "discard" to enable Continue.
+//
+//   Gap 4 — collision_policy required in composer mode but hidden behind
+//     Show advanced:
+//     validate_composer_file_sink_collision_policy (tools.py:2317) rejects null
+//     collision_policy when data_dir is not None.  The field is optional in the
+//     JSON schema (default null) and rendered behind "Show advanced".  The test
+//     must expand the section and set "auto_increment".  Adds 1 to click budget.
+//
+//   Gap 5 — recipe-match structurally unreachable (blocks Apply recipe → 400):
+//     See root cause above.  THIS IS THE HARD BLOCKER.  No in-test workaround
+//     exists without modifying the backend.
+//
+// ── Observations filed ───────────────────────────────────────────────────────
+//
+// Observations will be filed by the Phase 9 controller after reviewing this
+// spec.  Placeholder IDs below; update when observation IDs are assigned.
+//
+//   elspeth-obs-PLACEHOLDER-gap1: startGuided not wired to UI entry point
+//   elspeth-obs-PLACEHOLDER-gap5: recipe-match unreachable via SchemaForm path
+//     (source_blob_id always "" for SCHEMA_FORM-set sources)
+//
+// ── What the spec verifies today ─────────────────────────────────────────────
+//
+// The smoke spec (smoke.spec.ts) already verifies session CRUD and auth.
+// The guided spec WOULD verify the full recipe-match flow once Gap 5 is fixed.
+//
+// The partial steps 1-4 (csv chip → source schema → json chip → sink schema)
+// were verified to work correctly during Phase 9 testing:
+//   POST /guided/respond 200 OK ×4 (one per step)
+//   POST /guided/respond 400 Bad Request (Apply recipe fails, Gap 5)
+// The test is written as fixme so that the step-by-step logic and commentary
+// are preserved for the developer who fixes Gap 5.
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  authedContext,
+  createSession,
+  deleteSession,
+  tokenFromStorageState,
+  uploadBlob,
+} from "./helpers/api";
+import { ComposerPage } from "./page-objects/composer-page";
+
+const BLOB_FILENAME = "playwright-orders.csv";
+
+// Minimal CSV content: header + one data row.
+const SAMPLE_CSV = "id,name,value\n1,widget,42\n";
+
+// Worktree root: playwright.config.ts starts uvicorn from cwd="../../../.."
+// relative to the frontend dir (= worktree root, 4 levels up from frontend/).
+// This spec lives at tests/e2e/ (2 levels inside frontend/).
+// Total: 6 levels up from this file's __dirname.
+const WORKTREE_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../../",
+);
+const E2E_DATA_DIR = resolve(WORKTREE_ROOT, ".e2e-data");
+
+// Construct the blob storage path.
+// service.py:207-211: data_dir/blobs/{session_id}/{blob_id}_{filename}
+function blobStoragePath(sessionId: string, blobId: string): string {
+  return resolve(E2E_DATA_DIR, "blobs", sessionId, `${blobId}_${BLOB_FILENAME}`);
+}
+
+// Sink output path — must be under data_dir/outputs/ (paths.py:44).
+const SINK_OUTPUT_PATH = resolve(E2E_DATA_DIR, "outputs", "playwright-guided-output.json");
+
+test.describe("composer-guided — recipe-match happy path", () => {
+  test.fixme(
+    true,
+    "BLOCKED: recipe-match path unreachable (Gap 5) — source set via SchemaForm " +
+    "has no blob_id in options; _classify_slot_resolver returns source_blob_id=''; " +
+    "_resolve_source_blob fails 'Blob not found' → HTTP 400 on Apply recipe. " +
+    "Backend fix required (steps.py / recipe_match.py / recipes.py). " +
+    "Full blocker analysis in spec file header.",
+  );
+
+  test(
+    "guided demo path: CSV → classify-rows-llm-jsonl (≤9 clicks, <30s)",
+    async ({ page }) => {
+      const start = Date.now();
+      let clicks = 0;
+
+      // ── Out-of-band setup ──────────────────────────────────────────────────
+      // Create session + upload CSV blob via REST before navigating the SPA.
+      // These REST calls are NOT counted as user clicks.
+      const storageState = await page.context().storageState();
+      const token = tokenFromStorageState(storageState);
+      const ctx = await authedContext(token);
+
+      let sessionId: string | undefined;
+      try {
+        const session = await createSession(ctx, "playwright-guided-demo");
+        sessionId = session.id;
+
+        // Upload the seed CSV. We keep blob.id to construct the storage path
+        // used in the source SchemaForm (Gap 2: S2 path allowlist).
+        const blob = await uploadBlob(ctx, sessionId, BLOB_FILENAME, SAMPLE_CSV);
+
+        // ── Navigate to the session ──────────────────────────────────────────
+        // Auto-start fix (Gap 1): selectSession now calls startGuided() in
+        // sessionStore.ts; the wizard renders on navigation.
+        const composer = new ComposerPage(page);
+        await composer.goto(sessionId);
+        await composer.waitForChatReady();
+
+        // ── Step 1 source: SINGLE_SELECT — pick "csv" ──────────────────────
+        // Chip label = plugin.name verbatim (emitters.py:127).
+        await expect(
+          page.getByRole("button", { name: "csv", exact: true }),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "csv", exact: true }).click();
+        clicks++;
+
+        // ── Step 1 source: SCHEMA_FORM — fill required fields, Continue ──
+        // CSV source has THREE required fields (config_base.py):
+        //   schema:                json-fallback (prefilled {"mode":"observed"})
+        //   path:                  text, no default (PathConfig:319)
+        //   on_validation_failure: text, no default (SourceDataConfig:358-361) [Gap 3]
+        //
+        // Path must be under data_dir/blobs/ (S2, tools.py:2086-2108) [Gap 2].
+        // We construct the blob storage path from session_id + blob.id.
+        const sourcePath = blobStoragePath(sessionId, blob.id);
+        await expect(page.getByLabel(/^path$/i)).toBeVisible();
+        await page.getByLabel(/^path$/i).fill(sourcePath);
+        await expect(page.getByLabel(/on\s+validation\s+failure/i)).toBeVisible();
+        await page.getByLabel(/on\s+validation\s+failure/i).fill("discard");
+
+        await expect(
+          page.getByRole("button", { name: "Continue", exact: true }),
+        ).toBeEnabled();
+        await page.getByRole("button", { name: "Continue", exact: true }).click();
+        clicks++;
+
+        // ── Step 2 sink: SINGLE_SELECT — pick "json" ───────────────────────
+        // _classify_predicate requires sink.outputs[0].plugin == "json"
+        // (recipe_match.py:88-89); "jsonl" would fail the recipe match.
+        await expect(
+          page.getByRole("button", { name: "json", exact: true }),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "json", exact: true }).click();
+        clicks++;
+
+        // ── Step 2 sink: SCHEMA_FORM — fill path + collision_policy, Continue
+        // JSON sink: REQUIRED path, OPTIONAL collision_policy.
+        // collision_policy is REQUIRED in composer mode [Gap 4], hidden behind
+        // "Show advanced".  We expand and set "auto_increment".
+        await expect(page.getByLabel(/^path$/i)).toBeVisible();
+        await page.getByLabel(/^path$/i).fill(SINK_OUTPUT_PATH);
+        await page.getByRole("button", { name: /show advanced/i }).click();
+        clicks++;
+        await expect(page.getByLabel(/collision.?policy/i)).toBeVisible();
+        await page.getByLabel(/collision.?policy/i).fill('"auto_increment"');
+        await expect(
+          page.getByRole("button", { name: "Continue", exact: true }),
+        ).toBeEnabled();
+        await page.getByRole("button", { name: "Continue", exact: true }).click();
+        clicks++;
+
+        // ── Step 2 required fields: MULTI_SELECT_WITH_CUSTOM ──────────────
+        // Add "category" as a custom required field — satisfies
+        // _classify_predicate (recipe_match.py:100, _CLASSIFY_KEYWORDS).
+        const customInput = page.getByLabel("Custom field", { exact: true });
+        await expect(customInput).toBeVisible();
+        await customInput.fill("category");
+        await expect(
+          page.getByRole("button", { name: "Add", exact: true }),
+        ).toBeEnabled();
+        await page.getByRole("button", { name: "Add", exact: true }).click();
+        clicks++;
+        await expect(page.getByText("category")).toBeVisible();
+        await page.getByRole("button", { name: "Continue", exact: true }).click();
+        clicks++;
+
+        // ── Step 2.5 RECIPE_OFFER — Apply recipe ──────────────────────────
+        // Blocked by Gap 5: Apply recipe → HTTP 400 (source_blob_id = "").
+        // This assertion is expected to fail until Gap 5 is fixed.
+        await expect(
+          page.getByRole("button", { name: "Apply recipe", exact: true }),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "Apply recipe", exact: true }).click();
+        clicks++;
+
+        // ── CompletionSummary terminal ─────────────────────────────────────
+        await expect(
+          page.getByRole("button", { name: "Save and exit", exact: true }),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "Save and exit", exact: true }).click();
+        clicks++;
+
+        // ── Demo SLA assertions ────────────────────────────────────────────
+        // ≤9 clicks (9 in this revised path due to Gap 4 adding Show advanced).
+        expect(clicks).toBeLessThanOrEqual(9);
+        expect(Date.now() - start).toBeLessThan(30_000);
+      } finally {
+        if (sessionId !== undefined) {
+          await deleteSession(ctx, sessionId);
+        }
+        await ctx.dispose();
+      }
+    },
+  );
+});

--- a/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
+++ b/src/elspeth/web/frontend/tests/e2e/composer-guided.spec.ts
@@ -1,103 +1,24 @@
 // E2E spec: guided-mode wizard recipe-match happy path.
 //
 // Targets the demo SLA defined in §10.3 of the implementation plan
-// (2026-05-11-composer-guided-mode.md:4619-4621, corrected at df5306cf):
+// (2026-05-11-composer-guided-mode.md):
 //   ≤9 user clicks to reach CompletionSummary via the recipe-match path.
 //   <30s wall-clock (recipe match is deterministic — zero LLM calls).
 //
-// ── Gap 5 fixed (2026-05-12, commit 74ea68eb) ────────────────────────────────
+// ── Gap 6 RESOLVED in this dispatch (Task 10.0) ──────────────────────────────
 //
-// This spec was previously blocked by Gap 5 (recipe-match path unreachable via
-// SchemaForm).  The fix uses a combined approach (options a + b):
+// RecipeOfferPayload now carries `unsatisfied_slots` — the schema for each
+// required slot the resolver could not pre-fill (slot_type, description,
+// required).  RecipeOfferTurn renders an inline editable form for these
+// entries; the Apply button is disabled until every required slot has a
+// non-empty value, and the typed values are merged into edited_values.slots
+// before submission.  Filling those inputs is typing, not clicks — the SLA
+// click budget is unchanged.
 //
-//   (a) recipe_match.py: _classify_slot_resolver / _split_threshold_slot_resolver
-//       now read source.options["blob_ref"] (composer-canonical) instead of
-//       source.options.get("blob_id", ""). Missing blob_ref → offensive crash
-//       (state-machine invariant: resolver is only reached for blob-backed sources).
-//
-//   (b) steps.py / tools.py: handle_step_1_source now accepts session_engine +
-//       session_id, looks up the blob by storage_path after _execute_set_source
-//       commits, and injects blob_ref into SourceResolved.options when found.
-//       This lets the guided SchemaForm path (where the user types the blob's
-//       file path) populate blob_ref without switching to set_source_from_blob.
-//
-// Gap 5 VERIFIED FIXED: Playwright page snapshot after clicking "Apply recipe"
-// shows source_blob_id: f2852ea6-9e19-4db1-a03d-4dba2b92b9da (real UUID) in
-// the recipe_offer card. Steps 1–5 now return HTTP 200. The 400 is downstream.
-//
-// ── Gap 6 — recipe_offer missing unsatisfied-slot UX (blocks Apply recipe) ───
-//
-// The recipe_offer step still returns HTTP 400 at Apply recipe time.  This is a
-// NEW blocker revealed after Gap 5 was fixed.
-//
-// Root cause: RecipeOfferPayload.slots carries only the pre-filled slots
-// {source_blob_id, output_path, label_field}.  The RecipeOfferTurn widget echoes
-// payload.slots unchanged in edited_values when "Apply recipe" is clicked.  But
-// classify-rows-llm-jsonl declares three required slots without defaults:
-//   - classifier_template (str)
-//   - model (str)
-//   - api_key_secret (str)
-// validate_slots raises RecipeValidationError for each missing required slot →
-// _execute_apply_pipeline_recipe returns failure → HTTP 400.
-//
-// The RecipeOfferPayload type (guided.ts:240-244) carries no slot-schema, so the
-// frontend cannot know which slots need user input.  Both layers need changes:
-//   (a) backend: include the recipe's slot specs (type, required, description) in
-//       RecipeOfferPayload so the frontend can distinguish pre-filled from empty.
-//   (b) frontend: RecipeOfferTurn renders editable form fields for unsatisfied
-//       required slots (using payload.slot_specs[name].required + value absent).
-//
-// Gaps discovered during Phase 9 Task 9.1 (in order encountered):
-//
-//   Gap 1 — startGuided not wired to any UI entry point:
-//     sessionStore.createSession and selectSession both set guidedSession: null.
-//     startGuided() is implemented in the store but never called from any
-//     component. ChatPanel's guided-mode discriminator never fires. Fix applied
-//     in sessionStore.ts (both createSession and selectSession now call
-//     void get().startGuided(id)) — this is the minimum needed for the wizard
-//     to render. See observation filed as elspeth-obs-d3d0d7fa70.
-//
-//   Gap 2 — S2 path allowlist blocks raw /tmp paths:
-//     _validate_source_path (tools.py:2086) rejects paths outside data_dir/blobs/.
-//     Test must use the blob's storage path (service.py:207-211 format:
-//     data_dir/blobs/{session_id}/{blob_id}_{filename}).  Worked around in spec
-//     by constructing the path from known session_id and blob.id.
-//
-//   Gap 3 — on_validation_failure is required in source SchemaForm:
-//     SourceDataConfig.on_validation_failure (config_base.py:358) has no default
-//     and appears in the REQUIRED section of the SchemaForm.  The test must fill
-//     it with "discard" to enable Continue.
-//
-//   Gap 4 — collision_policy required in composer mode but hidden behind
-//     Show advanced:
-//     validate_composer_file_sink_collision_policy (tools.py:2317) rejects null
-//     collision_policy when data_dir is not None.  The field is optional in the
-//     JSON schema (default null) and rendered behind "Show advanced".  The test
-//     must expand the section and set "auto_increment".  Adds 1 to click budget.
-//
-//   Gap 5 — recipe-match structurally unreachable (blocks Apply recipe → 400):
-//     FIXED in commit 74ea68eb (Phase 9 dispatch).
-//
-//   Gap 6 — recipe_offer missing unsatisfied-slot UX (blocks Apply recipe → 400):
-//     See root cause above.  THIS IS THE CURRENT HARD BLOCKER.
-//     Filed as elspeth-obs-<gap6-id> (see Observations section).
-//
-// ── Observations filed ───────────────────────────────────────────────────────
-//
-//   elspeth-obs-d3d0d7fa70: startGuided not wired to UI entry point (Gap 1)
-//     Fixed in sessionStore.ts (createSession + selectSession now call startGuided).
-//   elspeth-obs-a8a9bc010a: recipe-match unreachable via SchemaForm path (Gap 5)
-//     Fixed in 74ea68eb (this Phase 9 dispatch).
-//   elspeth-obs-f626607b13: RecipeOfferTurn missing editable form for
-//     unsatisfied required slots; RecipeOfferPayload missing slot-schema (Gap 6).
-//
-// ── What the spec verifies today ─────────────────────────────────────────────
-//
-// Steps 1–5 (csv chip → source schema → json chip → sink schema → required
-// fields → recipe_offer render) now return HTTP 200 (verified in this dispatch).
-// The test is marked fixme because Apply recipe still returns HTTP 400 (Gap 6).
-// All step-by-step logic is preserved so whoever fixes Gap 6 can un-fixme in
-// one step without reconstructing the test.
+// For prior gap history (Gap 1 startGuided wiring, Gap 2 S2 path allowlist,
+// Gap 3 on_validation_failure, Gap 4 collision_policy, Gap 5 blob_ref
+// resolver) see git log on this file plus elspeth-obs-d3d0d7fa70 /
+// elspeth-obs-a8a9bc010a / elspeth-obs-f626607b13.
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -138,20 +59,6 @@ function blobStoragePath(sessionId: string, blobId: string): string {
 const SINK_OUTPUT_PATH = resolve(E2E_DATA_DIR, "outputs", "playwright-guided-output.json");
 
 test.describe("composer-guided — recipe-match happy path", () => {
-  test.fixme(
-    true,
-    "BLOCKED: Apply recipe → HTTP 400 (Gap 6) — recipe_offer payload contains " +
-    "only the pre-filled slots {source_blob_id, output_path, label_field}; the " +
-    "RecipeOfferTurn widget echoes payload.slots unchanged; missing required slots " +
-    "classifier_template / model / api_key_secret cause RecipeValidationError at " +
-    "apply time.  Gap 5 (blob_ref lookup) is VERIFIED FIXED (page snapshot shows " +
-    "source_blob_id: f2852ea6-...) — the recipe_offer now renders correctly. " +
-    "Fix requires: (a) backend to include slot-schema in RecipeOfferPayload so the " +
-    "frontend knows which slots need user input, and (b) RecipeOfferTurn editable " +
-    "form fields for unsatisfied required slots. " +
-    "Full analysis in spec file header."
-  );
-
   test(
     "guided demo path: CSV → classify-rows-llm-jsonl (≤9 clicks, <30s)",
     async ({ page }) => {
@@ -249,15 +156,27 @@ test.describe("composer-guided — recipe-match happy path", () => {
         await page.getByRole("button", { name: "Continue", exact: true }).click();
         clicks++;
 
-        // ── Step 2.5 RECIPE_OFFER — Apply recipe ──────────────────────────
-        // Gap 5 FIXED: recipe_offer now renders with correct source_blob_id.
-        // Apply recipe still returns HTTP 400 (Gap 6): required slots
-        // classifier_template / model / api_key_secret are not pre-filled and
-        // the RecipeOfferTurn widget has no editable form to supply them.
-        // This assertion is expected to fail until Gap 6 is fixed.
+        // ── Step 2.5 RECIPE_OFFER — fill unsatisfied slots, Apply recipe ──
+        // The classify-rows-llm-jsonl recipe declares three required slots
+        // that the resolver cannot pre-fill: classifier_template, model,
+        // api_key_secret.  RecipeOfferTurn (Task 10.0 / Gap 6) renders an
+        // inline editable form for these; Apply is disabled until every
+        // required value is filled.  Typing into inputs is NOT counted as
+        // clicks in the SLA budget.
         await expect(
           page.getByRole("button", { name: "Apply recipe", exact: true }),
         ).toBeVisible();
+        await expect(page.getByLabel(/classifier_template/i)).toBeVisible();
+        await page
+          .getByLabel(/classifier_template/i)
+          .fill("Classify {{ row['name'] }} as widget or gadget.");
+        await page.getByLabel(/^model\b/i).fill("anthropic/claude-3-5-sonnet");
+        // api_key_secret carries the NAME of an inventory secret_ref, not a
+        // raw credential.  The input is type="text" (not password) by design.
+        await page.getByLabel(/api_key_secret/i).fill("openrouter-api-key");
+        await expect(
+          page.getByRole("button", { name: "Apply recipe", exact: true }),
+        ).toBeEnabled();
         await page.getByRole("button", { name: "Apply recipe", exact: true }).click();
         clicks++;
 

--- a/src/elspeth/web/frontend/tests/e2e/helpers/api.ts
+++ b/src/elspeth/web/frontend/tests/e2e/helpers/api.ts
@@ -56,3 +56,45 @@ export async function deleteSession(
     );
   }
 }
+
+// Minimal blob metadata fields used by tests.  The backend returns more fields
+// (session_id, mime_type, size_bytes, etc.) — we only surface what tests need
+// to avoid coupling the helper to the full BlobMetadata interface in types/index.ts.
+export interface BlobMetadata {
+  id: string;
+  filename: string;
+}
+
+/**
+ * Upload a text blob to a session via multipart POST.
+ *
+ * Mirrors the frontend's uploadBlob() in src/api/client.ts — same endpoint,
+ * same multipart "file" field name.  Used by guided-mode E2E tests to seed a
+ * source CSV before navigating the wizard.
+ *
+ * Error responses (4xx/5xx) throw with the first 500 chars of the response
+ * body so the Playwright report shows a useful failure message.
+ */
+export async function uploadBlob(
+  ctx: APIRequestContext,
+  sessionId: string,
+  filename: string,
+  contents: string,
+  mimeType: string = "text/csv",
+): Promise<BlobMetadata> {
+  const resp = await ctx.post(`/api/sessions/${sessionId}/blobs`, {
+    multipart: {
+      file: {
+        name: filename,
+        mimeType,
+        buffer: Buffer.from(contents, "utf-8"),
+      },
+    },
+  });
+  if (!resp.ok()) {
+    throw new Error(
+      `POST /api/sessions/${sessionId}/blobs failed (${resp.status()}): ${(await resp.text()).slice(0, 500)}`,
+    );
+  }
+  return (await resp.json()) as BlobMetadata;
+}

--- a/src/elspeth/web/sessions/_guided_solve_chain.py
+++ b/src/elspeth/web/sessions/_guided_solve_chain.py
@@ -1,0 +1,173 @@
+"""Transient-LLM-failure wrapper for ``solve_chain`` (I2 — PR-review finding).
+
+Lives outside ``routes.py`` deliberately. ``scripts/cicd/enforce_tier_model.py``
+fingerprints findings by AST path from the module root, so adding a new
+top-level function to ``routes.py`` between ``_dispatch_guided_respond`` and
+``create_session_router`` would shift the AST sibling index of every existing
+allowlisted ``isinstance`` check in those functions and invalidate the
+fingerprints. Extracting this helper into its own module is the only way to
+introduce the wrap without churning a dozen unrelated allowlist entries.
+
+Contract: see :func:`solve_chain_with_auto_drop`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import structlog
+
+from elspeth.web.composer.audit import BufferingRecorder
+from elspeth.web.composer.guided.audit import emit_dropped_to_freeform
+from elspeth.web.composer.guided.chain_solver import solve_chain
+from elspeth.web.composer.guided.protocol import GuidedStep
+from elspeth.web.composer.guided.state_machine import (
+    ChainProposal,
+    GuidedSession,
+    SinkResolved,
+    SourceResolved,
+    TerminalReason,
+    mark_solver_exhausted,
+)
+
+slog = structlog.get_logger()
+
+
+def _safe_frame_strings(
+    exc: BaseException,
+    *,
+    max_frames: int = 16,
+) -> tuple[str, ...]:
+    """Mirror of ``routes._safe_frame_strings`` — frame-only traceback strings.
+
+    Duplicated here rather than imported from ``routes.py`` to avoid a layer
+    cycle (this module is imported by ``routes.py``). The capture rule is
+    identical: file path + line + function name only, walking the
+    ``__cause__`` chain, no source lines or local-variable reprs that could
+    carry Tier-3 data. Cap of 16 frames matches the routes.py default for
+    audit-row size predictability.
+    """
+    frames: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and len(frames) < max_frames:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        tb = current.__traceback__
+        while tb is not None and len(frames) < max_frames:
+            f = tb.tb_frame
+            frames.append(f"frame={f.f_code.co_filename}:{tb.tb_lineno}:{f.f_code.co_name}")
+            tb = tb.tb_next
+        current = current.__cause__
+    return tuple(frames)
+
+
+async def solve_chain_with_auto_drop(
+    *,
+    site: str,
+    session: GuidedSession,
+    session_id: str,
+    user_id: str,
+    composition_version: int,
+    recorder: BufferingRecorder,
+    model: str,
+    source: SourceResolved,
+    sink: SinkResolved,
+    recipe_match: Any | None = None,
+    repair_context: str | None = None,
+) -> tuple[ChainProposal | None, GuidedSession]:
+    """Wrap ``solve_chain`` with the auto-drop-on-transient contract (I2).
+
+    On success, returns ``(proposal, session)`` unchanged — the caller proceeds
+    with the proposal. On transient LLM failure (LiteLLM API/auth/bad-request,
+    timeouts, malformed-response shape from ``response.choices[0].message``),
+    marks the session ``solver_exhausted`` via :func:`mark_solver_exhausted`,
+    fans the ``guided_dropped_to_freeform`` directive to the audit emitter,
+    and returns ``(None, new_terminal_session)`` so the caller can short-circuit
+    with ``return state, new_session, None``.
+
+    ``InvariantError`` and ``ValueError`` are NOT absorbed — they propagate so
+    real programming bugs (the chain solver violating its own contract, or a
+    bad client payload) continue to raise to the outer dispatch handlers.
+
+    The transient exception set mirrors the project canonical at
+    ``composer/service.py:3173-3268`` (the advisor invocation path):
+    ``LiteLLMAPIError``, ``LiteLLMAuthError``, ``LiteLLMBadRequestError``,
+    plus ``TimeoutError`` for asyncio timeouts. ``IndexError``,
+    ``AttributeError``, and ``json.JSONDecodeError`` cover malformed-response
+    shape from ``chain_solver._extract_tool_call`` (empty ``choices``,
+    missing ``message``, invalid tool-call JSON).
+
+    ``asyncio.CancelledError`` is deliberately NOT in the set — client
+    disconnects must propagate, not be silently absorbed as a "drop".
+
+    ``str(exc)`` is NEVER captured into the audit payload: LiteLLM error
+    reprs can carry the request body (which embeds the system prompt and
+    the GUIDED CONTEXT block, including Tier-3 ``sample_rows``). Only
+    ``type(exc).__name__`` lands in ``validation_result.errors[].message``;
+    diagnostic frames go to slog (which is operator-scoped, not
+    Landscape-archived).
+
+    Args:
+        site: Stable identifier for the call site, used in the slog event
+            (e.g. ``"step_2_sink_initial_solve"``). Required for triage so
+            on-call can distinguish which solve attempt failed.
+        composition_version: ``state.version`` at the dispatch site; passed
+            verbatim into ``emit_dropped_to_freeform`` so the audit row
+            stamps the version the operator was working against.
+    """
+    from litellm.exceptions import APIError as LiteLLMAPIError
+    from litellm.exceptions import AuthenticationError as LiteLLMAuthError
+    from litellm.exceptions import BadRequestError as LiteLLMBadRequestError
+
+    try:
+        proposal = await solve_chain(
+            model=model,
+            source=source,
+            sink=sink,
+            recipe_match=recipe_match,
+            repair_context=repair_context,
+        )
+        return proposal, session
+    except (
+        LiteLLMAPIError,
+        LiteLLMAuthError,
+        LiteLLMBadRequestError,
+        TimeoutError,
+        IndexError,
+        AttributeError,
+        json.JSONDecodeError,
+    ) as exc:
+        slog.error(
+            "guided.chain_solver_transient_failure",
+            session_id=session_id,
+            user_id=user_id,
+            site=site,
+            exc_class=type(exc).__name__,
+            frames=_safe_frame_strings(exc),
+        )
+        validation_result_payload: Mapping[str, Any] = {
+            "is_valid": False,
+            "errors": [
+                {"message": f"Chain solver failed: {type(exc).__name__}"},
+            ],
+        }
+        new_session, _terminal, directives = mark_solver_exhausted(
+            session=session,
+            validation_result=validation_result_payload,
+        )
+        for directive in directives:
+            if directive.tool_name == "guided_dropped_to_freeform":
+                args = dict(directive.arguments)
+                emit_dropped_to_freeform(
+                    recorder,
+                    prev=GuidedStep(args["prev_step"]),
+                    drop_reason=TerminalReason(args["drop_reason"]),
+                    validation_result=args["validation_result"],
+                    composition_version=composition_version,
+                    actor=user_id,
+                )
+        return None, new_session

--- a/src/elspeth/web/sessions/converters.py
+++ b/src/elspeth/web/sessions/converters.py
@@ -7,11 +7,20 @@ object with SourceSpec, NodeSpec, etc.).
 Both sessions/routes.py and execution/service.py need this conversion.
 It lives here (not in routes.py) to avoid forcing execution/ to import
 from a route module.
+
+GuidedSession persistence:
+  ``guided_session`` is NOT a first-class column in ``composition_states``; it
+  rides in ``composer_meta["guided_session"]`` as a serialised dict.  When
+  ``composer_meta`` is present and contains a ``"guided_session"`` key,
+  ``state_from_record`` reconstructs the full ``GuidedSession`` object and
+  attaches it to the returned ``CompositionState``.  The absence of the key is
+  honest (freeform session — ``guided_session`` stays ``None``).
 """
 
 from __future__ import annotations
 
 from elspeth.contracts.freeze import deep_thaw
+from elspeth.web.composer.guided.state_machine import GuidedSession
 from elspeth.web.composer.state import CompositionState
 from elspeth.web.sessions.protocol import CompositionStateRecord
 
@@ -24,6 +33,9 @@ def state_from_record(record: CompositionStateRecord) -> CompositionState:
 
     Tier 1: metadata_ must always be populated. A None here indicates
     database corruption or a migration gap — crash immediately.
+
+    Guided-mode: if ``composer_meta["guided_session"]`` is present, the
+    GuidedSession is restored via ``GuidedSession.from_dict()``.
     """
     if record.metadata_ is None:
         msg = f"CompositionStateRecord {record.id} has None metadata_ — database corruption or migration gap"
@@ -40,4 +52,20 @@ def state_from_record(record: CompositionStateRecord) -> CompositionState:
         "outputs": [deep_thaw(o) for o in record.outputs] if record.outputs is not None else [],
         "metadata": deep_thaw(record.metadata_),
     }
-    return CompositionState.from_dict(state_dict)
+    state = CompositionState.from_dict(state_dict)
+
+    # Restore guided_session from composer_meta side-channel.
+    # Tier 1: any malformed guided_session dict is a corruption event — crash.
+    if record.composer_meta is not None:
+        thawed_meta = deep_thaw(record.composer_meta)
+        if "guided_session" in thawed_meta:
+            guided_session_raw = thawed_meta["guided_session"]
+            if guided_session_raw is None:
+                # Explicitly-null key: freeform session, no session to restore.
+                return state
+            guided_session = GuidedSession.from_dict(guided_session_raw)
+            from dataclasses import replace
+
+            state = replace(state, guided_session=guided_session)
+
+    return state

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1744,6 +1744,20 @@ async def _dispatch_guided_respond(
                         f"schema_form response at step 1 edited_values['sample_rows'] must be a list; got {type(sample_rows_raw).__name__}"
                     ),
                 )
+            # Codex #16: validate each element is a Mapping before calling
+            # dict(r).  A non-Mapping element (e.g. int, str, list) triggers
+            # TypeError from dict() — uncontrolled 500 instead of a clear 400.
+            # The HTTP boundary is a trust boundary: external data may contain
+            # arbitrary JSON values at any list position.
+            for _sr_idx, _sr_elem in enumerate(sample_rows_raw):
+                if not isinstance(_sr_elem, Mapping):
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"schema_form response at step 1 edited_values['sample_rows'][{_sr_idx}] "
+                            f"must be an object; got {type(_sr_elem).__name__}"
+                        ),
+                    )
             resolved = SourceResolved(
                 plugin=plugin_name,
                 options=dict(options_raw),

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -2355,6 +2355,15 @@ def create_session_router() -> APIRouter:
                 else:
                     pre_send_state_id = state_record.id
 
+            # 1b. Detect guided→freeform mode transition (spec §8.2).
+            # The first freeform chat turn after guided_session.terminal is set
+            # uses a layered system prompt. ``transition_consumed`` guards against
+            # re-firing on subsequent turns.
+            _guided = state.guided_session
+            _guided_terminal_for_compose = (
+                _guided.terminal if (_guided is not None and _guided.terminal is not None and not _guided.transition_consumed) else None
+            )
+
             # 2. Persist user message with pre-send provenance.
             # Keep the inserted row so the subsequent snapshot can prove
             # it is composing against the transcript that actually ends
@@ -2417,6 +2426,7 @@ def create_session_router() -> APIRouter:
                         session_id=str(session_id),
                         user_id=str(user.user_id),
                         progress=progress_sink,
+                        guided_terminal=_guided_terminal_for_compose,
                     )
                 except ComposerConvergenceError as exc:
                     terminal_status = "timed_out" if exc.budget_exhausted == "timeout" else "failed"
@@ -2663,6 +2673,41 @@ def create_session_router() -> APIRouter:
                 # shared helper. Without this wrapper, a path-2 raise escapes
                 # as Starlette's bare 500 — partial_state is dropped from
                 # the audit trail and the frontend receives an opaque error.
+                #
+                # 5a. Compute the post-compose guided_session.
+                # If the transition prompt fired this turn, flip transition_consumed
+                # on the guided_session so subsequent turns use the freeform-only
+                # prompt.  The updated guided_session is included in composer_meta
+                # for both the version-changed save path and the version-unchanged
+                # standalone save below.
+                _post_compose_guided: GuidedSession | None = result.state.guided_session
+                if _guided_terminal_for_compose is not None:
+                    # transition_consumed flip — _guided is non-None because
+                    # _guided_terminal_for_compose was derived from _guided.terminal.
+                    # The explicit RuntimeError defends against an impossible state
+                    # (the gate above ensures _guided is not None when this fires)
+                    # and satisfies the type checker without defensive get() calls.
+                    if _guided is None:
+                        raise RuntimeError(
+                            "guided_terminal_for_compose is set but guided_session is None — "
+                            "impossible state: transition gate should have blocked this path"
+                        )
+                    from dataclasses import replace as _replace_dc
+
+                    _post_compose_guided = _replace_dc(
+                        _guided,
+                        transition_consumed=True,
+                    )
+
+                # 5b. Compute the composer_meta that carries both repair_turns_used
+                # and guided_session.  Guided_session rides in composer_meta (not a
+                # first-class column) so any save must propagate it forward — failing
+                # to include it would silently drop the guided session from the DB on
+                # every freeform compose turn that mutates state.
+                _post_compose_meta: dict[str, Any] = {"repair_turns_used": result.repair_turns_used}
+                if _post_compose_guided is not None:
+                    _post_compose_meta["guided_session"] = _post_compose_guided.to_dict()
+
                 state_response: CompositionStateResponse | None = None
                 post_compose_state_id: UUID | None = pre_send_state_id
                 if result.state.version != state.version:
@@ -2688,7 +2733,7 @@ def create_session_router() -> APIRouter:
                             preflight_exception_policy="raise",
                             initial_version=state.version,
                             telemetry_source="compose",
-                            composer_meta={"repair_turns_used": result.repair_turns_used},
+                            composer_meta=_post_compose_meta,
                         )
                     except ComposerRuntimePreflightError as rpf_exc:
                         rpf_exc = ComposerRuntimePreflightError(
@@ -2743,6 +2788,31 @@ def create_session_router() -> APIRouter:
                     )
                     state_response = _state_response(new_state_record, live_validation=validation)
                     post_compose_state_id = new_state_record.id
+                elif _guided_terminal_for_compose is not None and _post_compose_guided is not None:
+                    # Version unchanged but transition_consumed must be flipped.
+                    # Persist the updated guided_session in a new state row so
+                    # subsequent turns pick up transition_consumed=True.
+                    _existing_meta: dict[str, Any] = {}
+                    if state_record is not None and state_record.composer_meta is not None:
+                        _existing_meta = dict(deep_thaw(state_record.composer_meta))
+                    _transition_meta = {**_existing_meta, **_post_compose_meta}
+                    _transition_state = result.state
+                    _transition_state_d = _transition_state.to_dict()
+                    _transition_state_data = CompositionStateData(
+                        source=_transition_state_d["source"],
+                        nodes=_transition_state_d["nodes"],
+                        edges=_transition_state_d["edges"],
+                        outputs=_transition_state_d["outputs"],
+                        metadata_=_transition_state_d["metadata"],
+                        is_valid=False,
+                        validation_errors=None,
+                        composer_meta=_transition_meta,
+                    )
+                    _transition_record = await service.save_composition_state(
+                        session.id,
+                        _transition_state_data,
+                    )
+                    post_compose_state_id = _transition_record.id
 
                 # 6. Persist assistant message with post-compose provenance
                 assistant_msg = await service.add_message(

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1582,6 +1582,80 @@ def _validate_control_signal(raw: str | None) -> None:
         )
 
 
+def _validate_step_indices(
+    turn_type: TurnType,
+    accepted_step_index: int | None,
+    edit_step_index: int | None,
+    guided: GuidedSession,
+) -> None:
+    """Validate ``accepted_step_index`` / ``edit_step_index`` against the current step.
+
+    Raises :class:`HTTPException` (400) when an index field is non-None for a
+    turn type that carries no step-index semantics, or when the index is out of
+    range for the proposal that is actually staged.
+
+    Step-index semantics exist **only** for ``PROPOSE_CHAIN`` turns: they
+    reference positions within ``guided.step_3_proposal.steps``.  Every other
+    turn type must send both fields as ``None`` — a non-None value on any other
+    turn type indicates a stale or mis-shaped client payload.
+
+    Matrix (exhaustive):
+
+    +---------------------------------+--------------------------------------+
+    | Turn type                       | Accepted / edit index               |
+    +=================================+======================================+
+    | PROPOSE_CHAIN                   | Must be None or                     |
+    |                                 | 0 <= idx < len(proposal.steps)      |
+    +---------------------------------+--------------------------------------+
+    | All other turn types            | Must be None                         |
+    +---------------------------------+--------------------------------------+
+    """
+    if turn_type is not TurnType.PROPOSE_CHAIN:
+        if accepted_step_index is not None or edit_step_index is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"accepted_step_index and edit_step_index must be null for turn type "
+                    f"{turn_type.value!r}; got accepted_step_index={accepted_step_index!r}, "
+                    f"edit_step_index={edit_step_index!r}."
+                ),
+            )
+        return
+
+    # PROPOSE_CHAIN: validate against the staged proposal.
+    # If step_3_proposal is None but an index was supplied, the client is
+    # sending a step-index against a step that has not been reached yet —
+    # treat as a client-fault 400 (not a server 500) because the proposal
+    # absence is not necessarily an invariant violation at this point (the
+    # route handler checks later for the accept path).
+    proposal = guided.step_3_proposal
+    if proposal is None:
+        if accepted_step_index is not None or edit_step_index is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "accepted_step_index / edit_step_index sent but no chain proposal is staged for this session (step_3_proposal is None)."
+                ),
+            )
+        return
+
+    step_count = len(proposal.steps)
+    for field_name, idx in (
+        ("accepted_step_index", accepted_step_index),
+        ("edit_step_index", edit_step_index),
+    ):
+        if idx is None:
+            continue
+        if not (0 <= idx < step_count):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"{field_name}={idx!r} is out of range for the current proposal "
+                    f"(proposal has {step_count} step(s); valid range is 0-{step_count - 1})."
+                ),
+            )
+
+
 async def _dispatch_guided_respond(
     *,
     state: CompositionState,
@@ -4492,13 +4566,21 @@ def create_session_router() -> APIRouter:
 
             current_turn_type = existing_record.turn_type
 
-            # --- Wire-boundary validation (Codex #12) -----------------------
-            # Validates before the TurnResponse dict is assembled so that
+            # --- Wire-boundary validation (Codex #7, #12) -------------------
+            # Both guards run before the TurnResponse dict is assembled so that
             # invalid requests are rejected before response_hash is computed or
             # guided_turn_answered is emitted.
 
             # Codex #12: validate control_signal against the ControlSignal enum.
             _validate_control_signal(body.control_signal)
+
+            # Codex #7: validate step-index fields against the current proposal.
+            _validate_step_indices(
+                current_turn_type,
+                body.accepted_step_index,
+                body.edit_step_index,
+                guided,
+            )
 
             # Build the TurnResponse dict from the request body.
             from dataclasses import replace as _replace

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1993,7 +1993,12 @@ async def _dispatch_guided_respond(
 
             recipe_name = str(edited.get("recipe_name", ""))
             slots = dict(edited.get("slots", {}))
-            match = _RecipeMatch(recipe_name=recipe_name, slots=slots)
+            # The "accept" reconstruction is post-acceptance: the operator has
+            # supplied the slot values (merged into ``edited.slots`` by the
+            # widget).  ``unsatisfied_slots`` was a property of the *offer*;
+            # at apply time ``handle_step_2_5_recipe_apply`` consumes only
+            # ``recipe_name`` and ``slots``, so an empty mapping is correct.
+            match = _RecipeMatch(recipe_name=recipe_name, slots=slots, unsatisfied_slots={})
 
             handler_result = handle_step_2_5_recipe_apply(
                 state=state,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1559,27 +1559,31 @@ def _initial_composition_state_with_guided_session() -> CompositionState:
     )
 
 
-def _validate_control_signal(raw: str | None) -> None:
+def _validate_control_signal(raw: str | None) -> ControlSignal | None:
     """Validate ``control_signal`` against the closed :class:`ControlSignal` enum.
 
+    Returns the parsed :class:`ControlSignal` (or ``None`` if *raw* is ``None``).
     Raises :class:`HTTPException` (400) when *raw* is non-None and not a
     recognised enum value.  Null passes through — omitting the signal is
     the normal (non-control) path.
 
-    The ``GuidedRespondRequest`` schema keeps this field as ``str | None``
-    intentionally (see schemas.py docstring) so that stale clients carrying
-    an unknown signal value receive a clear protocol error from this guard
-    rather than a Pydantic deserialization crash.  This function is the
-    matching enforcement point on the route handler side.
+    This is the Tier-3 -> Tier-2 coercion site: ``GuidedRespondRequest`` keeps
+    ``control_signal`` as ``str | None`` so stale clients carrying an unknown
+    signal value receive a clear protocol error from this guard rather than a
+    Pydantic deserialization crash. After this function returns, the parsed
+    :class:`ControlSignal` is the typed value flowing into ``TurnResponse``,
+    where the field is declared ``ControlSignal | None``.
     """
     if raw is None:
-        return
-    valid = [e.value for e in ControlSignal]
-    if raw not in valid:
+        return None
+    try:
+        return ControlSignal(raw)
+    except ValueError as exc:
+        valid = [e.value for e in ControlSignal]
         raise HTTPException(
             status_code=400,
             detail=(f"Unknown control_signal: {raw!r}. Valid values: {valid}"),
-        )
+        ) from exc
 
 
 def _validate_step_indices(
@@ -4714,7 +4718,9 @@ def create_session_router() -> APIRouter:
                 # guided_turn_answered is emitted.
 
                 # Codex #12: validate control_signal against the ControlSignal enum.
-                _validate_control_signal(body.control_signal)
+                # This is the Tier-3 -> Tier-2 coercion: the parsed enum (or
+                # None) flows into the typed ``TurnResponse`` below.
+                control_signal = _validate_control_signal(body.control_signal)
 
                 # Codex #7: validate step-index fields against the current proposal.
                 _validate_step_indices(
@@ -4733,7 +4739,7 @@ def create_session_router() -> APIRouter:
                     "custom_inputs": body.custom_inputs,
                     "accepted_step_index": body.accepted_step_index,
                     "edit_step_index": body.edit_step_index,
-                    "control_signal": body.control_signal,
+                    "control_signal": control_signal,
                 }
 
                 # Record the response_hash on the existing TurnRecord.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -4309,182 +4309,198 @@ def create_session_router() -> APIRouter:
 
         compose_lock = await _get_session_compose_lock_registry(request).get_lock(str(session_id))
         async with compose_lock:
-            # Load or create CompositionState.
-            state_record = await service.get_current_state(session_id)
-            if state_record is None:
-                state = _initial_composition_state_with_guided_session()
-            else:
-                state = _state_from_record(state_record)
+            # PR-review B3: drain the recorder on every exit path, including
+            # ``raise HTTPException`` rejections.  Without this, any audit
+            # event emitted before a mid-body raise would be discarded — a
+            # CLAUDE.md auditability violation ("rejected requests are facts
+            # worth recording").  ``state_record_out`` is hoisted so the
+            # finally block can pass its id (or None) regardless of where
+            # control left the try.
+            state_record_out: CompositionStateRecord | None = None
+            try:
+                # Load or create CompositionState.
+                state_record = await service.get_current_state(session_id)
+                if state_record is None:
+                    state = _initial_composition_state_with_guided_session()
+                else:
+                    state = _state_from_record(state_record)
+                state_record_out = state_record
 
-            # Reject freeform sessions.
-            if state.guided_session is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
+                # Reject freeform sessions.
+                if state.guided_session is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
+                    )
+
+                guided = state.guided_session
+                current_step = guided.step
+
+                # Idempotency check: if this step already has an emitted TurnRecord,
+                # return the existing payload without re-emitting.
+                existing_record_for_step: TurnRecord | None = next(
+                    (r for r in reversed(guided.history) if r.step == current_step),
+                    None,
                 )
 
-            guided = state.guided_session
-            current_step = guided.step
+                # Build the initial turn for the current step (deterministic from
+                # state + catalog).  Returns None for steps with no rebuildable
+                # initial turn (STEP_3 / no-recipe STEP_2_5 path) or when the
+                # session is already terminal.
+                turn = _build_get_guided_turn(state, guided, catalog=catalog) if guided.terminal is None else None
+                turn_type: TurnType | None = TurnType(turn["type"]) if turn is not None else None
+                payload_hash: str | None = stable_hash(turn["payload"]) if turn is not None else None
 
-            # Idempotency check: if this step already has an emitted TurnRecord,
-            # return the existing payload without re-emitting.
-            existing_record_for_step: TurnRecord | None = next(
-                (r for r in reversed(guided.history) if r.step == current_step),
-                None,
-            )
-
-            # Build the initial turn for the current step (deterministic from
-            # state + catalog).  Returns None for steps with no rebuildable
-            # initial turn (STEP_3 / no-recipe STEP_2_5 path) or when the
-            # session is already terminal.
-            turn = _build_get_guided_turn(state, guided, catalog=catalog) if guided.terminal is None else None
-            turn_type: TurnType | None = TurnType(turn["type"]) if turn is not None else None
-            payload_hash: str | None = stable_hash(turn["payload"]) if turn is not None else None
-
-            state_record_out: CompositionStateRecord | None = state_record
-            if existing_record_for_step is None and turn is not None:
-                # First fetch for this step AND a turn exists: record TurnRecord,
-                # persist, emit audit.  When turn is None (terminal state, STEP_3,
-                # or no-recipe STEP_2_5 path) there is no turn to record.
-                # Guaranteed by the conditional assignments above: turn is not
-                # None on this branch, so both turn_type and payload_hash were
-                # populated from turn["type"] / stable_hash(turn["payload"]).
-                # Use InvariantError (not bare assert) so python -O does not
-                # strip the gate and silently feed None to TurnRecord.
-                if turn_type is None:
-                    raise InvariantError(
-                        "GET guided: turn is not None but turn_type is None — TurnType derivation skipped despite turn being present."
+                if existing_record_for_step is None and turn is not None:
+                    # First fetch for this step AND a turn exists: record TurnRecord,
+                    # persist, emit audit.  When turn is None (terminal state, STEP_3,
+                    # or no-recipe STEP_2_5 path) there is no turn to record.
+                    # Guaranteed by the conditional assignments above: turn is not
+                    # None on this branch, so both turn_type and payload_hash were
+                    # populated from turn["type"] / stable_hash(turn["payload"]).
+                    # Use InvariantError (not bare assert) so python -O does not
+                    # strip the gate and silently feed None to TurnRecord.
+                    if turn_type is None:
+                        raise InvariantError(
+                            "GET guided: turn is not None but turn_type is None — TurnType derivation skipped despite turn being present."
+                        )
+                    if payload_hash is None:
+                        raise InvariantError(
+                            "GET guided: turn is not None but payload_hash is None — stable_hash derivation skipped despite turn being present."
+                        )
+                    new_record = TurnRecord(
+                        step=current_step,
+                        turn_type=turn_type,
+                        payload_hash=payload_hash,
+                        response_hash=None,
+                        emitter="server",
                     )
-                if payload_hash is None:
-                    raise InvariantError(
-                        "GET guided: turn is not None but payload_hash is None — stable_hash derivation skipped despite turn being present."
-                    )
-                new_record = TurnRecord(
-                    step=current_step,
-                    turn_type=turn_type,
-                    payload_hash=payload_hash,
-                    response_hash=None,
-                    emitter="server",
-                )
-                from dataclasses import replace as _replace
+                    from dataclasses import replace as _replace
 
-                # If this is the STEP_2_5_RECIPE_MATCH step, populate
-                # step_2_5_recipe_offer so the POST /respond accept branch
-                # can verify the client-supplied recipe_name against the offer.
-                # This covers the GET-before-POST flow (user reloads the page
-                # while the session is at the recipe-offer step).
+                    # If this is the STEP_2_5_RECIPE_MATCH step, populate
+                    # step_2_5_recipe_offer so the POST /respond accept branch
+                    # can verify the client-supplied recipe_name against the offer.
+                    # This covers the GET-before-POST flow (user reloads the page
+                    # while the session is at the recipe-offer step).
+                    if (
+                        current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
+                        and guided.step_1_result is not None
+                        and guided.step_2_result is not None
+                    ):
+                        staged_offer = match_recipe(guided.step_1_result, guided.step_2_result)
+                    else:
+                        staged_offer = None
+
+                    new_guided = _replace(guided, history=(*guided.history, new_record))
+                    if staged_offer is not None:
+                        new_guided = _replace(new_guided, step_2_5_recipe_offer=staged_offer)
+                    new_state = _replace(state, guided_session=new_guided)
+
+                    # Persist state with updated guided_session in composer_meta.
+                    # Preserve any existing composer_meta keys (e.g. repair_turns_used).
+                    existing_meta: dict[str, Any] = {}
+                    if state_record is not None and state_record.composer_meta is not None:
+                        existing_meta = dict(deep_thaw(state_record.composer_meta))
+                    new_composer_meta = {**existing_meta, "guided_session": new_guided.to_dict()}
+
+                    state_d = new_state.to_dict()
+                    state_data = CompositionStateData(
+                        source=state_d["source"],
+                        nodes=state_d["nodes"],
+                        edges=state_d["edges"],
+                        outputs=state_d["outputs"],
+                        metadata_=state_d["metadata"],
+                        is_valid=False,
+                        validation_errors=None,
+                        composer_meta=new_composer_meta,
+                    )
+                    state_record_out = await service.save_composition_state(session_id, state_data)
+
+                    # Emit audit event.  Persistence of the buffered invocations
+                    # is handled by the finally block below — that way both
+                    # success and rejection paths drain identically.
+                    emit_turn_emitted(
+                        recorder,
+                        step=current_step,
+                        turn_type=turn_type,
+                        payload_hash=payload_hash,
+                        payload_payload_id="",  # No payload store for server-emitted turns yet.
+                        emitter="server",
+                        composition_version=new_state.version,
+                        actor=user.user_id,
+                    )
+
+                    guided = new_guided
+
+                # Idempotency-path repair: if the session is at STEP_2_5_RECIPE_MATCH
+                # and the staged offer is absent (persisted before the step_2_5_recipe_offer
+                # field was introduced), re-populate it and persist the repaired state so
+                # the POST /respond accept branch can verify the recipe_name.  Without this
+                # repair, sessions that reached STEP_2_5 before this field was added would
+                # always fail the accept binding check with 400.  The offer is
+                # deterministically reconstructable from (step_1_result, step_2_result).
                 if (
-                    current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
+                    existing_record_for_step is not None
+                    and current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
+                    and guided.step_2_5_recipe_offer is None
                     and guided.step_1_result is not None
                     and guided.step_2_result is not None
                 ):
-                    staged_offer = match_recipe(guided.step_1_result, guided.step_2_result)
-                else:
-                    staged_offer = None
+                    recovered_offer = match_recipe(guided.step_1_result, guided.step_2_result)
+                    if recovered_offer is not None:
+                        from dataclasses import replace as _replace_repair
 
-                new_guided = _replace(guided, history=(*guided.history, new_record))
-                if staged_offer is not None:
-                    new_guided = _replace(new_guided, step_2_5_recipe_offer=staged_offer)
-                new_state = _replace(state, guided_session=new_guided)
-
-                # Persist state with updated guided_session in composer_meta.
-                # Preserve any existing composer_meta keys (e.g. repair_turns_used).
-                existing_meta: dict[str, Any] = {}
-                if state_record is not None and state_record.composer_meta is not None:
-                    existing_meta = dict(deep_thaw(state_record.composer_meta))
-                new_composer_meta = {**existing_meta, "guided_session": new_guided.to_dict()}
-
-                state_d = new_state.to_dict()
-                state_data = CompositionStateData(
-                    source=state_d["source"],
-                    nodes=state_d["nodes"],
-                    edges=state_d["edges"],
-                    outputs=state_d["outputs"],
-                    metadata_=state_d["metadata"],
-                    is_valid=False,
-                    validation_errors=None,
-                    composer_meta=new_composer_meta,
-                )
-                state_record_out = await service.save_composition_state(session_id, state_data)
-
-                # Emit audit event.
-                emit_turn_emitted(
-                    recorder,
-                    step=current_step,
-                    turn_type=turn_type,
-                    payload_hash=payload_hash,
-                    payload_payload_id="",  # No payload store for server-emitted turns yet.
-                    emitter="server",
-                    composition_version=new_state.version,
-                    actor=user.user_id,
-                )
-
-                # Drain recorder into the DB as role=tool audit rows.
-                tool_invocations = recorder.invocations
-                if tool_invocations:
-                    await _persist_tool_invocations(
-                        service,
-                        session_id,
-                        tool_invocations,
-                        state_record_out.id,
-                    )
-
-                guided = new_guided
-
-            # Idempotency-path repair: if the session is at STEP_2_5_RECIPE_MATCH
-            # and the staged offer is absent (persisted before the step_2_5_recipe_offer
-            # field was introduced), re-populate it and persist the repaired state so
-            # the POST /respond accept branch can verify the recipe_name.  Without this
-            # repair, sessions that reached STEP_2_5 before this field was added would
-            # always fail the accept binding check with 400.  The offer is
-            # deterministically reconstructable from (step_1_result, step_2_result).
-            if (
-                existing_record_for_step is not None
-                and current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
-                and guided.step_2_5_recipe_offer is None
-                and guided.step_1_result is not None
-                and guided.step_2_result is not None
-            ):
-                recovered_offer = match_recipe(guided.step_1_result, guided.step_2_result)
-                if recovered_offer is not None:
-                    from dataclasses import replace as _replace_repair
-
-                    repaired_guided = _replace_repair(guided, step_2_5_recipe_offer=recovered_offer)
-                    repaired_state = _replace_repair(state, guided_session=repaired_guided)
-                    existing_meta_repair: dict[str, Any] = {}
-                    if state_record is not None and state_record.composer_meta is not None:
-                        existing_meta_repair = dict(deep_thaw(state_record.composer_meta))
-                    repair_meta = {**existing_meta_repair, "guided_session": repaired_guided.to_dict()}
-                    repaired_state_d = repaired_state.to_dict()
-                    repair_data = CompositionStateData(
-                        source=repaired_state_d["source"],
-                        nodes=repaired_state_d["nodes"],
-                        edges=repaired_state_d["edges"],
-                        outputs=repaired_state_d["outputs"],
-                        metadata_=repaired_state_d["metadata"],
-                        is_valid=False,
-                        validation_errors=None,
-                        composer_meta=repair_meta,
-                    )
-                    state_record_out = await service.save_composition_state(session_id, repair_data)
-                    guided = repaired_guided
-
-            # Build response.  On re-fetch the same turn is returned (deterministic
-            # rebuild) and the payload_hash matches what was recorded on first visit.
-            terminal = guided.terminal
-            return GetGuidedResponse(
-                guided_session=GuidedSessionResponse(
-                    step=guided.step.value,
-                    history=[
-                        TurnRecordResponse(
-                            step=r.step.value,
-                            turn_type=r.turn_type.value,
-                            payload_hash=r.payload_hash,
-                            response_hash=r.response_hash,
-                            emitter=r.emitter,
+                        repaired_guided = _replace_repair(guided, step_2_5_recipe_offer=recovered_offer)
+                        repaired_state = _replace_repair(state, guided_session=repaired_guided)
+                        existing_meta_repair: dict[str, Any] = {}
+                        if state_record is not None and state_record.composer_meta is not None:
+                            existing_meta_repair = dict(deep_thaw(state_record.composer_meta))
+                        repair_meta = {**existing_meta_repair, "guided_session": repaired_guided.to_dict()}
+                        repaired_state_d = repaired_state.to_dict()
+                        repair_data = CompositionStateData(
+                            source=repaired_state_d["source"],
+                            nodes=repaired_state_d["nodes"],
+                            edges=repaired_state_d["edges"],
+                            outputs=repaired_state_d["outputs"],
+                            metadata_=repaired_state_d["metadata"],
+                            is_valid=False,
+                            validation_errors=None,
+                            composer_meta=repair_meta,
                         )
-                        for r in guided.history
-                    ],
+                        state_record_out = await service.save_composition_state(session_id, repair_data)
+                        guided = repaired_guided
+
+                # Build response.  On re-fetch the same turn is returned (deterministic
+                # rebuild) and the payload_hash matches what was recorded on first visit.
+                terminal = guided.terminal
+                return GetGuidedResponse(
+                    guided_session=GuidedSessionResponse(
+                        step=guided.step.value,
+                        history=[
+                            TurnRecordResponse(
+                                step=r.step.value,
+                                turn_type=r.turn_type.value,
+                                payload_hash=r.payload_hash,
+                                response_hash=r.response_hash,
+                                emitter=r.emitter,
+                            )
+                            for r in guided.history
+                        ],
+                        terminal=TerminalStateResponse(
+                            kind=terminal.kind.value,
+                            reason=terminal.reason.value if terminal.reason is not None else None,
+                            pipeline_yaml=terminal.pipeline_yaml,
+                        )
+                        if terminal is not None
+                        else None,
+                    ),
+                    next_turn=TurnPayloadResponse(
+                        type=turn["type"],
+                        step_index=turn["step_index"],
+                        payload=dict(turn["payload"]),
+                    )
+                    if turn is not None
+                    else None,
                     terminal=TerminalStateResponse(
                         kind=terminal.kind.value,
                         reason=terminal.reason.value if terminal.reason is not None else None,
@@ -4492,23 +4508,42 @@ def create_session_router() -> APIRouter:
                     )
                     if terminal is not None
                     else None,
-                ),
-                next_turn=TurnPayloadResponse(
-                    type=turn["type"],
-                    step_index=turn["step_index"],
-                    payload=dict(turn["payload"]),
+                    composition_state=_state_response(state_record_out) if state_record_out is not None else None,
                 )
-                if turn is not None
-                else None,
-                terminal=TerminalStateResponse(
-                    kind=terminal.kind.value,
-                    reason=terminal.reason.value if terminal.reason is not None else None,
-                    pipeline_yaml=terminal.pipeline_yaml,
-                )
-                if terminal is not None
-                else None,
-                composition_state=_state_response(state_record_out) if state_record_out is not None else None,
-            )
+            finally:
+                # PR-review B3: drain the recorder unconditionally — success
+                # paths and ``raise HTTPException`` rejection paths take the
+                # same exit.  Empty drains are a no-op (BufferingRecorder
+                # starts with an empty invocations list and
+                # ``_persist_tool_invocations`` iterates an empty tuple).
+                #
+                # The inner ``try`` prevents an audit-persist failure from
+                # masking the in-flight HTTPException — Python's default
+                # behaviour is to let a ``finally``-block exception replace
+                # the original, which would surface a generic 500 instead
+                # of the intended 400/409.  Per CLAUDE.md telemetry/logging
+                # primacy, audit-system failures during exception handling
+                # are the one exemption where ``slog`` is the correct
+                # channel.  The log payload follows the B1 convention:
+                # ``exc_class`` + ``frames`` only, never ``str(exc)`` or
+                # ``exc_info`` (frames are bounded and value-free; the
+                # exception message can carry Tier-bearing strings).
+                try:
+                    await _persist_tool_invocations(
+                        service,
+                        session_id,
+                        recorder.invocations,
+                        state_record_out.id if state_record_out is not None else None,
+                    )
+                except Exception as persist_exc:
+                    slog.error(
+                        "guided.audit_persist_failed_during_exception_handling",
+                        session_id=str(session_id),
+                        user_id=user.user_id,
+                        site="get_guided",
+                        exc_class=type(persist_exc).__name__,
+                        frames=_safe_frame_strings(persist_exc),
+                    )
 
     @router.post("/{session_id}/guided/respond", response_model=GuidedRespondResponse)
     async def post_guided_respond(
@@ -4539,207 +4574,149 @@ def create_session_router() -> APIRouter:
 
         compose_lock = await _get_session_compose_lock_registry(request).get_lock(str(session_id))
         async with compose_lock:
-            # Load state.
-            state_record = await service.get_current_state(session_id)
-            if state_record is None:
-                state = _initial_composition_state_with_guided_session()
-            else:
-                state = _state_from_record(state_record)
-
-            if state.guided_session is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
-                )
-
-            guided = state.guided_session
-
-            # Reject if session already terminal.
-            if guided.terminal is not None:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Guided session is already in a terminal state. No further responses accepted.",
-                )
-
-            # Derive the current turn type from the last TurnRecord for the
-            # current step.  Crash if history is empty — the caller must have
-            # fetched GET /guided first (which seeds the initial TurnRecord).
-            current_step = guided.step
-            existing_record: TurnRecord | None = next(
-                (r for r in reversed(guided.history) if r.step == current_step),
-                None,
-            )
-            if existing_record is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=("No turn has been emitted for the current step. Fetch GET /api/sessions/{id}/guided first."),
-                )
-
-            current_turn_type = existing_record.turn_type
-
-            # --- Wire-boundary validation (Codex #7, #12) -------------------
-            # Both guards run before the TurnResponse dict is assembled so that
-            # invalid requests are rejected before response_hash is computed or
-            # guided_turn_answered is emitted.
-
-            # Codex #12: validate control_signal against the ControlSignal enum.
-            _validate_control_signal(body.control_signal)
-
-            # Codex #7: validate step-index fields against the current proposal.
-            _validate_step_indices(
-                current_turn_type,
-                body.accepted_step_index,
-                body.edit_step_index,
-                guided,
-            )
-
-            # Build the TurnResponse dict from the request body.
-            from dataclasses import replace as _replace
-
-            turn_response: TurnResponse = {
-                "chosen": body.chosen,
-                "edited_values": body.edited_values,
-                "custom_inputs": body.custom_inputs,
-                "accepted_step_index": body.accepted_step_index,
-                "edit_step_index": body.edit_step_index,
-                "control_signal": body.control_signal,
-            }
-
-            # Record the response_hash on the existing TurnRecord.
-            response_hash = stable_hash(turn_response)
-            updated_record = _replace(existing_record, response_hash=response_hash)
-            # Rebuild history tuple with response_hash stamped on this record.
-            updated_history = tuple(updated_record if r is existing_record else r for r in guided.history)
-            guided = _replace(guided, history=updated_history)
-
-            # Emit guided_turn_answered audit event.
-            emit_turn_answered(
-                recorder,
-                step=current_step,
-                turn_type=current_turn_type,
-                response_hash=response_hash,
-                response_payload_id="",
-                control_signal=body.control_signal,
-                composition_version=state.version,
-                actor=user.user_id,
-            )
-
-            # Run step_advance (pure — no I/O).
-            # InvariantError indicates a server-side bug (e.g. stamped an
-            # invalid turn type on a history record) — propagate as HTTP 500
-            # with a static message so the response body never carries
-            # ``str(exc)``. ``InvariantError`` raised from ``from_dict`` call
-            # sites embeds ``{d!r}`` of the corrupted Tier-1 record, which
-            # includes Tier-3 ``sample_rows`` source data. Interpolating that
-            # into the HTTP detail field would have leaked user/PII content
-            # into the JSON 500 body returned to the browser (PR #37 review
-            # finding B1).
+            # PR-review B3: drain the recorder on every exit path, including
+            # ``raise HTTPException`` rejections.  This handler emits
+            # ``guided_turn_answered`` (line below the ``_validate_*`` calls)
+            # BEFORE the dispatcher's try-block can raise 400, so without an
+            # unconditional drain the turn-answered event for a rejected
+            # advance attempt is silently dropped — a CLAUDE.md auditability
+            # violation ("rejected requests are facts worth recording").
             #
-            # Diagnostic trace is preserved via ``slog.error`` under the
-            # audit-system-failure exemption (CLAUDE.md primacy order: when
-            # ``from_dict`` itself fails, the audit-derivation path can't be
-            # trusted to record the failure consistently). The slog event
-            # carries ``exc_class`` + ``frames`` only — never the message
-            # string, since for ``{d!r}`` -bearing InvariantErrors that text
-            # is the leak vector. Sibling helpers in this file follow the
-            # same "class + frames, no message" pattern when the exception
-            # carries Tier-bearing strings (see ``_safe_frame_strings`` docs).
-            #
-            # ValueError indicates a client-supplied payload violated the
-            # guided-mode protocol contract (e.g. unexpected chosen value on a
-            # recipe_offer turn, or null edited_values on inspect_and_confirm)
-            # — propagate as HTTP 400 so the caller can correct the request.
-            # ValueError is not raised by ``from_dict`` and does not embed
-            # ``{d!r}`` of Tier-1 records, so interpolating ``str(exc)`` here
-            # is safe.
+            # ``state_record_out`` is hoisted above the try so the finally
+            # block can reference it regardless of where control left.  On
+            # rejection paths it may legitimately remain ``None`` — the
+            # ``_persist_tool_invocations`` signature accepts that.
+            state_record_out: CompositionStateRecord | None = None
             try:
-                new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
+                # Load state.
+                state_record = await service.get_current_state(session_id)
+                if state_record is None:
+                    state = _initial_composition_state_with_guided_session()
+                else:
+                    state = _state_from_record(state_record)
+
+                if state.guided_session is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
+                    )
+
+                guided = state.guided_session
+
+                # Reject if session already terminal.
+                if guided.terminal is not None:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Guided session is already in a terminal state. No further responses accepted.",
+                    )
+
+                # Derive the current turn type from the last TurnRecord for the
+                # current step.  Crash if history is empty — the caller must have
+                # fetched GET /guided first (which seeds the initial TurnRecord).
+                current_step = guided.step
+                existing_record: TurnRecord | None = next(
+                    (r for r in reversed(guided.history) if r.step == current_step),
+                    None,
+                )
+                if existing_record is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=("No turn has been emitted for the current step. Fetch GET /api/sessions/{id}/guided first."),
+                    )
+
+                current_turn_type = existing_record.turn_type
+
+                # --- Wire-boundary validation (Codex #7, #12) -------------------
+                # Both guards run before the TurnResponse dict is assembled so that
+                # invalid requests are rejected before response_hash is computed or
+                # guided_turn_answered is emitted.
+
+                # Codex #12: validate control_signal against the ControlSignal enum.
+                _validate_control_signal(body.control_signal)
+
+                # Codex #7: validate step-index fields against the current proposal.
+                _validate_step_indices(
+                    current_turn_type,
+                    body.accepted_step_index,
+                    body.edit_step_index,
                     guided,
-                    turn_response,
-                    current_turn_type=current_turn_type,
                 )
-            except InvariantError as exc:
-                slog.error(
-                    "guided.invariant_violated",
-                    session_id=str(session_id),
-                    user_id=user.user_id,
-                    exc_class=type(exc).__name__,
-                    site="step_advance",
-                    frames=_safe_frame_strings(exc),
+
+                # Build the TurnResponse dict from the request body.
+                from dataclasses import replace as _replace
+
+                turn_response: TurnResponse = {
+                    "chosen": body.chosen,
+                    "edited_values": body.edited_values,
+                    "custom_inputs": body.custom_inputs,
+                    "accepted_step_index": body.accepted_step_index,
+                    "edit_step_index": body.edit_step_index,
+                    "control_signal": body.control_signal,
+                }
+
+                # Record the response_hash on the existing TurnRecord.
+                response_hash = stable_hash(turn_response)
+                updated_record = _replace(existing_record, response_hash=response_hash)
+                # Rebuild history tuple with response_hash stamped on this record.
+                updated_history = tuple(updated_record if r is existing_record else r for r in guided.history)
+                guided = _replace(guided, history=updated_history)
+
+                # Emit guided_turn_answered audit event.  This writes to the
+                # recorder BEFORE the dispatcher's try-block — if the
+                # dispatcher then raises 400, this event must still reach
+                # the audit DB (see PR-review B3 finally-drain rationale).
+                emit_turn_answered(
+                    recorder,
+                    step=current_step,
+                    turn_type=current_turn_type,
+                    response_hash=response_hash,
+                    response_payload_id="",
+                    control_signal=body.control_signal,
+                    composition_version=state.version,
+                    actor=user.user_id,
                 )
-                raise HTTPException(
-                    status_code=500,
-                    detail="Server invariant violated. See application audit log for diagnostic detail.",
-                ) from exc
-            except ValueError as exc:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Guided-mode protocol error: {exc}",
-                ) from exc
 
-            # Fan directives to emit_* helpers.
-            for directive in directives:
-                if directive.tool_name == "guided_step_advanced":
-                    args = dict(directive.arguments)
-                    emit_step_advanced(
-                        recorder,
-                        prev=GuidedStep(args["prev_step"]),
-                        next_=GuidedStep(args["next_step"]),
-                        reason=args["reason"],
-                        composition_version=state.version,
-                        actor=user.user_id,
-                    )
-                elif directive.tool_name == "guided_dropped_to_freeform":
-                    args = dict(directive.arguments)
-                    emit_dropped_to_freeform(
-                        recorder,
-                        prev=GuidedStep(args["prev_step"]),
-                        drop_reason=TerminalReason(args["drop_reason"]),
-                        validation_result=args["validation_result"],
-                        composition_version=state.version,
-                        actor=user.user_id,
-                    )
-
-            guided = new_guided
-            terminal = terminal_from_advance
-
-            # Run side-effect dispatcher if the session is not yet terminal.
-            # The dispatcher calls step handlers (handle_step_1_source,
-            # handle_step_2_sink, handle_step_2_5_recipe_apply) and emits
-            # the next turn based on the updated step + turn type.
-            next_turn: Any | None = None
-            settings = request.app.state.settings
-            data_dir: str | None = str(settings.data_dir) if settings.data_dir else None
-            session_engine = request.app.state.session_engine
-
-            if terminal is None:
+                # Run step_advance (pure — no I/O).
+                # InvariantError indicates a server-side bug (e.g. stamped an
+                # invalid turn type on a history record) — propagate as HTTP 500
+                # with a static message so the response body never carries
+                # ``str(exc)``. ``InvariantError`` raised from ``from_dict`` call
+                # sites embeds ``{d!r}`` of the corrupted Tier-1 record, which
+                # includes Tier-3 ``sample_rows`` source data. Interpolating that
+                # into the HTTP detail field would have leaked user/PII content
+                # into the JSON 500 body returned to the browser (PR #37 review
+                # finding B1).
+                #
+                # Diagnostic trace is preserved via ``slog.error`` under the
+                # audit-system-failure exemption (CLAUDE.md primacy order: when
+                # ``from_dict`` itself fails, the audit-derivation path can't be
+                # trusted to record the failure consistently). The slog event
+                # carries ``exc_class`` + ``frames`` only — never the message
+                # string, since for ``{d!r}`` -bearing InvariantErrors that text
+                # is the leak vector. Sibling helpers in this file follow the
+                # same "class + frames, no message" pattern when the exception
+                # carries Tier-bearing strings (see ``_safe_frame_strings`` docs).
+                #
+                # ValueError indicates a client-supplied payload violated the
+                # guided-mode protocol contract (e.g. unexpected chosen value on a
+                # recipe_offer turn, or null edited_values on inspect_and_confirm)
+                # — propagate as HTTP 400 so the caller can correct the request.
+                # ValueError is not raised by ``from_dict`` and does not embed
+                # ``{d!r}`` of Tier-1 records, so interpolating ``str(exc)`` here
+                # is safe.
                 try:
-                    state, guided, next_turn = await _dispatch_guided_respond(
-                        state=state,
-                        guided=guided,
-                        current_step=current_step,
+                    new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
+                        guided,
+                        turn_response,
                         current_turn_type=current_turn_type,
-                        turn_response=turn_response,
-                        catalog=catalog,
-                        recorder=recorder,
-                        user_id=user.user_id,
-                        data_dir=data_dir,
-                        session_engine=session_engine,
-                        session_id=str(session_id),
-                        model=settings.composer_model,
                     )
                 except InvariantError as exc:
-                    # Same B1-sanitization rationale as the step_advance
-                    # catch above: ``str(exc)`` from a ``from_dict`` site
-                    # embeds ``{d!r}`` of the corrupted Tier-1 record
-                    # including Tier-3 ``sample_rows``. Static detail; slog
-                    # carries exc_class + frames only.
                     slog.error(
                         "guided.invariant_violated",
                         session_id=str(session_id),
                         user_id=user.user_id,
                         exc_class=type(exc).__name__,
-                        site="dispatch_guided_respond",
+                        site="step_advance",
                         frames=_safe_frame_strings(exc),
                     )
                     raise HTTPException(
@@ -4747,60 +4724,143 @@ def create_session_router() -> APIRouter:
                         detail="Server invariant violated. See application audit log for diagnostic detail.",
                     ) from exc
                 except ValueError as exc:
-                    # ValueError from inside the dispatcher indicates a
-                    # client-supplied payload violated the guided-mode protocol
-                    # contract (e.g. unknown plugin name from chosen, null
-                    # edited_values) — propagate as HTTP 400. See Codex #8,
-                    # #11, #15 and commit message for full context.
                     raise HTTPException(
                         status_code=400,
                         detail=f"Guided-mode protocol error: {exc}",
                     ) from exc
-                terminal = guided.terminal
 
-            # Persist updated state.
-            new_state = _replace(state, guided_session=guided)
-            existing_meta: dict[str, Any] = {}
-            if state_record is not None and state_record.composer_meta is not None:
-                existing_meta = dict(deep_thaw(state_record.composer_meta))
-            new_composer_meta = {**existing_meta, "guided_session": guided.to_dict()}
-
-            state_d = new_state.to_dict()
-            state_data = CompositionStateData(
-                source=state_d["source"],
-                nodes=state_d["nodes"],
-                edges=state_d["edges"],
-                outputs=state_d["outputs"],
-                metadata_=state_d["metadata"],
-                is_valid=False,
-                validation_errors=None,
-                composer_meta=new_composer_meta,
-            )
-            state_record_out = await service.save_composition_state(session_id, state_data)
-
-            # Drain recorder.
-            tool_invocations = recorder.invocations
-            if tool_invocations:
-                await _persist_tool_invocations(
-                    service,
-                    session_id,
-                    tool_invocations,
-                    state_record_out.id,
-                )
-
-            return GuidedRespondResponse(
-                guided_session=GuidedSessionResponse(
-                    step=guided.step.value,
-                    history=[
-                        TurnRecordResponse(
-                            step=r.step.value,
-                            turn_type=r.turn_type.value,
-                            payload_hash=r.payload_hash,
-                            response_hash=r.response_hash,
-                            emitter=r.emitter,
+                # Fan directives to emit_* helpers.
+                for directive in directives:
+                    if directive.tool_name == "guided_step_advanced":
+                        args = dict(directive.arguments)
+                        emit_step_advanced(
+                            recorder,
+                            prev=GuidedStep(args["prev_step"]),
+                            next_=GuidedStep(args["next_step"]),
+                            reason=args["reason"],
+                            composition_version=state.version,
+                            actor=user.user_id,
                         )
-                        for r in guided.history
-                    ],
+                    elif directive.tool_name == "guided_dropped_to_freeform":
+                        args = dict(directive.arguments)
+                        emit_dropped_to_freeform(
+                            recorder,
+                            prev=GuidedStep(args["prev_step"]),
+                            drop_reason=TerminalReason(args["drop_reason"]),
+                            validation_result=args["validation_result"],
+                            composition_version=state.version,
+                            actor=user.user_id,
+                        )
+
+                guided = new_guided
+                terminal = terminal_from_advance
+
+                # Run side-effect dispatcher if the session is not yet terminal.
+                # The dispatcher calls step handlers (handle_step_1_source,
+                # handle_step_2_sink, handle_step_2_5_recipe_apply) and emits
+                # the next turn based on the updated step + turn type.
+                next_turn: Any | None = None
+                settings = request.app.state.settings
+                data_dir: str | None = str(settings.data_dir) if settings.data_dir else None
+                session_engine = request.app.state.session_engine
+
+                if terminal is None:
+                    try:
+                        state, guided, next_turn = await _dispatch_guided_respond(
+                            state=state,
+                            guided=guided,
+                            current_step=current_step,
+                            current_turn_type=current_turn_type,
+                            turn_response=turn_response,
+                            catalog=catalog,
+                            recorder=recorder,
+                            user_id=user.user_id,
+                            data_dir=data_dir,
+                            session_engine=session_engine,
+                            session_id=str(session_id),
+                            model=settings.composer_model,
+                        )
+                    except InvariantError as exc:
+                        # Same B1-sanitization rationale as the step_advance
+                        # catch above: ``str(exc)`` from a ``from_dict`` site
+                        # embeds ``{d!r}`` of the corrupted Tier-1 record
+                        # including Tier-3 ``sample_rows``. Static detail; slog
+                        # carries exc_class + frames only.
+                        slog.error(
+                            "guided.invariant_violated",
+                            session_id=str(session_id),
+                            user_id=user.user_id,
+                            exc_class=type(exc).__name__,
+                            site="dispatch_guided_respond",
+                            frames=_safe_frame_strings(exc),
+                        )
+                        raise HTTPException(
+                            status_code=500,
+                            detail="Server invariant violated. See application audit log for diagnostic detail.",
+                        ) from exc
+                    except ValueError as exc:
+                        # ValueError from inside the dispatcher indicates a
+                        # client-supplied payload violated the guided-mode protocol
+                        # contract (e.g. unknown plugin name from chosen, null
+                        # edited_values) — propagate as HTTP 400. See Codex #8,
+                        # #11, #15 and commit message for full context.
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Guided-mode protocol error: {exc}",
+                        ) from exc
+                    terminal = guided.terminal
+
+                # Persist updated state.
+                new_state = _replace(state, guided_session=guided)
+                existing_meta: dict[str, Any] = {}
+                if state_record is not None and state_record.composer_meta is not None:
+                    existing_meta = dict(deep_thaw(state_record.composer_meta))
+                new_composer_meta = {**existing_meta, "guided_session": guided.to_dict()}
+
+                state_d = new_state.to_dict()
+                state_data = CompositionStateData(
+                    source=state_d["source"],
+                    nodes=state_d["nodes"],
+                    edges=state_d["edges"],
+                    outputs=state_d["outputs"],
+                    metadata_=state_d["metadata"],
+                    is_valid=False,
+                    validation_errors=None,
+                    composer_meta=new_composer_meta,
+                )
+                state_record_out = await service.save_composition_state(session_id, state_data)
+
+                # Recorder persistence happens in the finally block below so
+                # rejection paths drain identically to the success path.
+
+                return GuidedRespondResponse(
+                    guided_session=GuidedSessionResponse(
+                        step=guided.step.value,
+                        history=[
+                            TurnRecordResponse(
+                                step=r.step.value,
+                                turn_type=r.turn_type.value,
+                                payload_hash=r.payload_hash,
+                                response_hash=r.response_hash,
+                                emitter=r.emitter,
+                            )
+                            for r in guided.history
+                        ],
+                        terminal=TerminalStateResponse(
+                            kind=terminal.kind.value,
+                            reason=terminal.reason.value if terminal.reason is not None else None,
+                            pipeline_yaml=terminal.pipeline_yaml,
+                        )
+                        if terminal is not None
+                        else None,
+                    ),
+                    next_turn=TurnPayloadResponse(
+                        type=next_turn["type"],
+                        step_index=next_turn["step_index"],
+                        payload=dict(next_turn["payload"]),
+                    )
+                    if next_turn is not None
+                    else None,
                     terminal=TerminalStateResponse(
                         kind=terminal.kind.value,
                         reason=terminal.reason.value if terminal.reason is not None else None,
@@ -4808,23 +4868,42 @@ def create_session_router() -> APIRouter:
                     )
                     if terminal is not None
                     else None,
-                ),
-                next_turn=TurnPayloadResponse(
-                    type=next_turn["type"],
-                    step_index=next_turn["step_index"],
-                    payload=dict(next_turn["payload"]),
+                    composition_state=_state_response(state_record_out),
                 )
-                if next_turn is not None
-                else None,
-                terminal=TerminalStateResponse(
-                    kind=terminal.kind.value,
-                    reason=terminal.reason.value if terminal.reason is not None else None,
-                    pipeline_yaml=terminal.pipeline_yaml,
-                )
-                if terminal is not None
-                else None,
-                composition_state=_state_response(state_record_out),
-            )
+            finally:
+                # PR-review B3: drain the recorder unconditionally — success
+                # paths and ``raise HTTPException`` rejection paths take the
+                # same exit.  Empty drains are a no-op (BufferingRecorder
+                # starts with an empty invocations list and
+                # ``_persist_tool_invocations`` iterates an empty tuple).
+                #
+                # The inner ``try`` prevents an audit-persist failure from
+                # masking the in-flight HTTPException — Python's default
+                # behaviour is to let a ``finally``-block exception replace
+                # the original, which would surface a generic 500 instead
+                # of the intended 400/409.  Per CLAUDE.md telemetry/logging
+                # primacy, audit-system failures during exception handling
+                # are the one exemption where ``slog`` is the correct
+                # channel.  The log payload follows the B1 convention:
+                # ``exc_class`` + ``frames`` only, never ``str(exc)`` or
+                # ``exc_info`` (frames are bounded and value-free; the
+                # exception message can carry Tier-bearing strings).
+                try:
+                    await _persist_tool_invocations(
+                        service,
+                        session_id,
+                        recorder.invocations,
+                        state_record_out.id if state_record_out is not None else None,
+                    )
+                except Exception as persist_exc:
+                    slog.error(
+                        "guided.audit_persist_failed_during_exception_handling",
+                        session_id=str(session_id),
+                        user_id=user.user_id,
+                        site="post_guided_respond",
+                        exc_class=type(persist_exc).__name__,
+                        frames=_safe_frame_strings(persist_exc),
+                    )
 
     return router
 

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1571,6 +1571,7 @@ async def _dispatch_guided_respond(
     data_dir: str | None,
     session_engine: Any,
     session_id: str,
+    model: str,
 ) -> tuple[CompositionState, GuidedSession, Any | None]:
     """Dispatch a guided respond to the correct step handler and next-turn emitter.
 
@@ -2046,7 +2047,7 @@ async def _dispatch_guided_respond(
             return state, guided, next_turn
 
         # No recipe match — solve the chain via the LLM and emit propose_chain.
-        proposal = await solve_chain(source=source, sink=sink, recipe_match=None)
+        proposal = await solve_chain(model=model, source=source, sink=sink, recipe_match=None)
         guided = _replace(guided, step=GuidedStep.STEP_3_TRANSFORMS, step_3_proposal=proposal)
         next_turn = build_step_3_propose_chain_turn(proposal)
         new_record = TurnRecord(
@@ -2196,7 +2197,7 @@ async def _dispatch_guided_respond(
                 )
             source = guided.step_1_result
             sink = guided.step_2_result
-            proposal = await solve_chain(source=source, sink=sink, recipe_match=None)
+            proposal = await solve_chain(model=model, source=source, sink=sink, recipe_match=None)
             guided = _replace(guided, step_3_proposal=proposal)
             next_turn = build_step_3_propose_chain_turn(proposal)
             new_record = TurnRecord(
@@ -2271,6 +2272,7 @@ async def _dispatch_guided_respond(
                     if guided.step_2_result is None:
                         raise RuntimeError("repair: step_2_result is None — STEP_3 unreachable without Step 2 commit")
                     repair_proposal = await solve_chain(
+                        model=model,
                         source=guided.step_1_result,
                         sink=guided.step_2_result,
                         recipe_match=None,
@@ -4493,6 +4495,7 @@ def create_session_router() -> APIRouter:
                         data_dir=data_dir,
                         session_engine=session_engine,
                         session_id=str(session_id),
+                        model=settings.composer_model,
                     )
                 except InvariantError as exc:
                     raise HTTPException(

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -42,6 +42,7 @@ from elspeth.web.composer.guided.audit import (
     emit_turn_answered,
     emit_turn_emitted,
 )
+from elspeth.web.composer.guided.chain_solver import solve_chain
 from elspeth.web.composer.guided.emitters import (
     build_initial_step_1_turn,
     build_step_1_schema_form_turn,
@@ -49,6 +50,7 @@ from elspeth.web.composer.guided.emitters import (
     build_step_2_multi_select_turn,
     build_step_2_schema_form_turn,
     build_step_2_single_select_turn,
+    build_step_3_propose_chain_turn,
 )
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.recipe_match import match_recipe
@@ -63,6 +65,7 @@ from elspeth.web.composer.guided.steps import (
     handle_step_1_source,
     handle_step_2_5_recipe_apply,
     handle_step_2_sink,
+    handle_step_3_chain_accept,
 )
 from elspeth.web.composer.progress import (
     ComposerProgressEvent,
@@ -1899,8 +1902,39 @@ async def _dispatch_guided_respond(
             guided = _replace(guided, history=(*guided.history, new_record))
             return state, guided, next_turn
 
-        # No recipe match — Step 3 (chain solver) is deferred to Phase 4.
-        return state, guided, None
+        # No recipe match — solve the chain via the LLM and emit propose_chain.
+        proposal = await solve_chain(source=source, sink=sink, recipe_match=None)
+        guided = _replace(guided, step=GuidedStep.STEP_3_TRANSFORMS, step_3_proposal=proposal)
+        next_turn = build_step_3_propose_chain_turn(proposal)
+        new_record = TurnRecord(
+            step=GuidedStep.STEP_3_TRANSFORMS,
+            turn_type=TurnType.PROPOSE_CHAIN,
+            payload_hash=stable_hash(next_turn["payload"]),
+            response_hash=None,
+            emitter="server",
+        )
+        emit_step_advanced(
+            recorder,
+            prev=GuidedStep.STEP_2_5_RECIPE_MATCH,
+            next_=GuidedStep.STEP_3_TRANSFORMS,
+            # System-driven advance: no recipe matched the (source, sink) topology,
+            # so the dispatcher hops STEP_2_5 → STEP_3 without operator input.
+            reason="auto_advanced",
+            composition_version=state.version,
+            actor=user_id,
+        )
+        emit_turn_emitted(
+            recorder,
+            step=GuidedStep.STEP_3_TRANSFORMS,
+            turn_type=TurnType.PROPOSE_CHAIN,
+            payload_hash=stable_hash(next_turn["payload"]),
+            payload_payload_id="",
+            emitter="server",
+            composition_version=state.version,
+            actor=user_id,
+        )
+        guided = _replace(guided, history=(*guided.history, new_record))
+        return state, guided, next_turn
 
     # --- STEP_2_5_RECIPE_MATCH turns ------------------------------------
     if current_step is GuidedStep.STEP_2_5_RECIPE_MATCH:
@@ -1950,13 +1984,87 @@ async def _dispatch_guided_respond(
             return state, guided, None
 
         if chosen == ["build_manually"]:
-            # step_advance already advanced to STEP_3.
-            # Step 3 chain solver is deferred to Phase 4.
-            return state, guided, None
+            # step_advance already advanced to STEP_3.  Solve the chain via the LLM.
+            if guided.step_1_result is None or guided.step_2_result is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Dispatcher invariant: step_1_result and step_2_result must be set at build_manually.",
+                )
+            source = guided.step_1_result
+            sink = guided.step_2_result
+            proposal = await solve_chain(source=source, sink=sink, recipe_match=None)
+            guided = _replace(guided, step_3_proposal=proposal)
+            next_turn = build_step_3_propose_chain_turn(proposal)
+            new_record = TurnRecord(
+                step=GuidedStep.STEP_3_TRANSFORMS,
+                turn_type=TurnType.PROPOSE_CHAIN,
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_turn_emitted(
+                recorder,
+                step=GuidedStep.STEP_3_TRANSFORMS,
+                turn_type=TurnType.PROPOSE_CHAIN,
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
 
         raise HTTPException(
             status_code=400,
             detail=f"recipe_offer response must have chosen=['accept'] or chosen=['build_manually'], got {chosen!r}.",
+        )
+
+    # --- STEP_3_TRANSFORMS turns ----------------------------------------
+    # The only response shape we handle in Phase 4 is ACCEPT on a
+    # propose_chain turn.  Reject and clarifying SINGLE_SELECT responses are
+    # deferred to Phase 5 (which adds re-solve, repair, and advisor flows).
+    if current_step is GuidedStep.STEP_3_TRANSFORMS:
+        if current_turn_type is TurnType.PROPOSE_CHAIN:
+            chosen = list(turn_response["chosen"] or [])
+            if chosen == ["accept"]:
+                if guided.step_3_proposal is None:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Dispatcher invariant: step_3_proposal must be set when accepting a propose_chain turn.",
+                    )
+                handler_result = handle_step_3_chain_accept(
+                    state=state,
+                    session=guided,
+                    proposal=guided.step_3_proposal,
+                    catalog=catalog,
+                    data_dir=data_dir,
+                    session_engine=session_engine,
+                    session_id=session_id,
+                )
+                if not handler_result.tool_result.success:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Step 3 chain commit failed: {handler_result.tool_result}",
+                    )
+                # handler_result.session.terminal is COMPLETED on success.
+                return handler_result.state, handler_result.session, None
+            if chosen == ["reject"]:
+                raise HTTPException(
+                    status_code=501,
+                    detail=(
+                        "Step 3 chain rejection is not yet implemented — Phase 5 will add "
+                        "re-solve and repair flows. Use exit-to-freeform to drop to freeform mode."
+                    ),
+                )
+            raise HTTPException(
+                status_code=400,
+                detail=f"propose_chain response must have chosen=['accept'] or chosen=['reject'], got {chosen!r}.",
+            )
+        # SINGLE_SELECT clarifying-question response at STEP_3 — Phase 5.
+        raise HTTPException(
+            status_code=501,
+            detail="Step 3 clarifying question handling is not yet implemented — Phase 5.",
         )
 
     # Unhandled branch — this is a dispatcher gap, not a user error.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -62,6 +62,7 @@ from elspeth.web.composer.guided.state_machine import (
 from elspeth.web.composer.guided.steps import (
     handle_step_1_source,
     handle_step_2_5_recipe_apply,
+    handle_step_2_sink,
 )
 from elspeth.web.composer.progress import (
     ComposerProgressEvent,
@@ -1581,30 +1582,38 @@ async def _dispatch_guided_respond(
     Decision table:
 
     +-------------------+---------------------------+---------------------------+
-    | step              | current_turn_type          | action                    |
+    | current_step      | guided.step (after adv.)  | action                    |
     +-------------------+---------------------------+---------------------------+
-    | STEP_1_SOURCE     | SINGLE_SELECT             | emit schema_form (source) |
-    | STEP_1_SOURCE     | SCHEMA_FORM               | handle_step_1_source;     |
-    |                   |                           | advance to STEP_2;        |
+    | STEP_1_SOURCE     | STEP_1_SOURCE             | intra-step; turn_type     |
+    |   (intra)         | (no advance fired)        | decides next turn:        |
+    |                   |                           | SINGLE_SELECT →           |
+    |                   |                           |   emit SCHEMA_FORM        |
+    |                   |                           | SCHEMA_FORM →             |
+    |                   |                           |   handle_step_1_source;   |
+    |                   |                           |   advance to STEP_2;      |
+    |                   |                           |   emit SINGLE_SELECT      |
+    | STEP_1_SOURCE     | STEP_2_SINK               | INSPECT_AND_CONFIRM path; |
+    |   (advancing)     | (step_advance fired)      | handle_step_1_source;     |
     |                   |                           | emit SINGLE_SELECT (sink) |
-    | STEP_1_SOURCE     | INSPECT_AND_CONFIRM       | handle_step_1_source;     |
-    |                   |                           | (step_advance already      |
-    |                   |                           |  advanced to STEP_2);     |
-    |                   |                           | emit SINGLE_SELECT (sink) |
-    | STEP_2_SINK       | SINGLE_SELECT             | emit schema_form (sink)   |
-    | STEP_2_SINK       | SCHEMA_FORM               | emit multi_select_custom  |
-    | STEP_2_SINK       | MULTI_SELECT_WITH_CUSTOM  | handle_step_2_sink;       |
-    |                   |                           | (step_advance advanced     |
-    |                   |                           |  to STEP_2_5);            |
+    | STEP_2_SINK       | STEP_2_SINK               | intra-step; turn_type     |
+    |   (intra)         | (no advance fired)        | decides next turn:        |
+    |                   |                           | SINGLE_SELECT →           |
+    |                   |                           |   emit SCHEMA_FORM        |
+    |                   |                           | SCHEMA_FORM →             |
+    |                   |                           |   emit MULTI_SELECT       |
+    |                   |                           | MULTI_SELECT →            |
+    |                   |                           |   unreachable here        |
+    |                   |                           |   (_advance_step_2 always |
+    |                   |                           |   fires for this type)    |
+    | STEP_2_SINK       | STEP_2_5_RECIPE_MATCH     | MULTI_SELECT path;        |
+    |   (advancing)     | (step_advance fired)      | handle_step_2_sink;       |
     |                   |                           | match_recipe;             |
-    |                   |                           | emit recipe_offer or      |
-    |                   |                           | advance to STEP_3         |
-    | STEP_2_5_RECIPE   | RECIPE_OFFER chosen=accept| handled by step_advance   |
-    |                   |                           | (terminal set);           |
-    |                   |                           | caller detects terminal   |
-    | STEP_2_5_RECIPE   | RECIPE_OFFER              | handle_step_2_5 + apply   |
-    |                   | chosen=build_manually     | (step_advance advanced     |
-    |                   |                           |  to STEP_3)               |
+    |                   |                           | emit RECIPE_OFFER or None |
+    | STEP_2_5_RECIPE   | STEP_2_5_RECIPE_MATCH     | RECIPE_OFFER chosen=      |
+    |   (intra/term.)   | (accept: no advance)      | accept → recipe apply;    |
+    |                   |                           | terminal=COMPLETED        |
+    | STEP_2_5_RECIPE   | STEP_3_TRANSFORMS         | RECIPE_OFFER chosen=      |
+    |   (advancing)     | (step_advance fired)      | build_manually → step 3   |
     +-------------------+---------------------------+---------------------------+
 
     ``step_advance`` has already run; ``guided.step`` may already point to the
@@ -1652,8 +1661,17 @@ async def _dispatch_guided_respond(
         if current_turn_type is TurnType.SCHEMA_FORM:
             # User submitted source options. Call handle_step_1_source to commit.
             edited = turn_response["edited_values"] or {}
+            # "plugin" is required — absence is Tier-3 evidence that the client
+            # sent a malformed payload; reject with 422 rather than fabricating
+            # a value from state.source (inference from adjacent fields is
+            # fabrication per CLAUDE.md §Three-Tier Trust Model).
+            if "plugin" not in edited:
+                raise HTTPException(
+                    status_code=422,
+                    detail="schema_form response must include 'plugin' in edited_values.",
+                )
             resolved = SourceResolved(
-                plugin=str(edited.get("plugin", state.source.plugin if state.source else "")),
+                plugin=str(edited["plugin"]),
                 options=dict(edited.get("options", {})),
                 observed_columns=tuple(edited.get("observed_columns", [])),
                 sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
@@ -1716,8 +1734,16 @@ async def _dispatch_guided_respond(
     if current_step is GuidedStep.STEP_1_SOURCE and guided.step is GuidedStep.STEP_2_SINK:
         # step_advance advanced the step. Build SourceResolved from edited_values.
         edited = turn_response["edited_values"] or {}
+        # "plugin" is required — absence is a malformed client payload; reject
+        # with 422 rather than fabricating an empty string (same boundary rule
+        # as the SCHEMA_FORM branch above).
+        if "plugin" not in edited:
+            raise HTTPException(
+                status_code=422,
+                detail="inspect_and_confirm response must include 'plugin' in edited_values.",
+            )
         resolved = SourceResolved(
-            plugin=str(edited.get("plugin", "")),
+            plugin=str(edited["plugin"]),
             options=dict(edited.get("options", {})),
             observed_columns=tuple(edited.get("observed_columns", [])),
             sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
@@ -1816,53 +1842,12 @@ async def _dispatch_guided_respond(
             guided = _replace(guided, history=(*guided.history, new_record))
             return state, guided, next_turn
 
-        if current_turn_type is TurnType.MULTI_SELECT_WITH_CUSTOM:
-            # step_advance already advanced the step to STEP_2_5 (via
-            # _advance_step_2). The new sink is encoded in step_advance's
-            # updated session (guided.step_2_result). Run match_recipe.
-            # Emit recipe_offer if matched; else advance to STEP_3 (out of scope).
-            if guided.step_2_result is None:
-                raise HTTPException(
-                    status_code=500,
-                    detail="Dispatcher invariant: step_2_result must be set after MULTI_SELECT_WITH_CUSTOM advance.",
-                )
-            source = guided.step_1_result
-            sink = guided.step_2_result
-            if source is None:
-                raise HTTPException(
-                    status_code=500,
-                    detail="Dispatcher invariant: step_1_result must be set before step 2 completes.",
-                )
-            recipe_match = match_recipe(source, sink)
-            if recipe_match is not None:
-                next_turn = build_step_2_5_recipe_offer_turn(recipe_match)
-                new_record = TurnRecord(
-                    step=GuidedStep.STEP_2_5_RECIPE_MATCH,
-                    turn_type=TurnType(next_turn["type"]),
-                    payload_hash=stable_hash(next_turn["payload"]),
-                    response_hash=None,
-                    emitter="server",
-                )
-                emit_turn_emitted(
-                    recorder,
-                    step=GuidedStep.STEP_2_5_RECIPE_MATCH,
-                    turn_type=TurnType(next_turn["type"]),
-                    payload_hash=stable_hash(next_turn["payload"]),
-                    payload_payload_id="",
-                    emitter="server",
-                    composition_version=state.version,
-                    actor=user_id,
-                )
-                guided = _replace(guided, history=(*guided.history, new_record))
-                return state, guided, next_turn
-
-            # No recipe match — advance silently to Step 3 (chain solver).
-            # Step 3 is deferred to Phase 4; return no next_turn.
-            return state, guided, None
-
     # --- STEP_2_SINK → STEP_2_5 (step_advance fired for MULTI_SELECT_WITH_CUSTOM)
-    # This branch handles the case where step_advance advanced the step AND
-    # we're now at STEP_2_5, but the turn_response is for MULTI_SELECT_WITH_CUSTOM.
+    # step_advance sets guided.step=STEP_2_5_RECIPE_MATCH and populates
+    # guided.step_2_result for every MULTI_SELECT_WITH_CUSTOM response, so the
+    # intra-step branch (current_step==guided.step==STEP_2_SINK) for this turn
+    # type is structurally unreachable — _advance_step_2 always fires.
+    # This is the ONLY reachable MULTI_SELECT_WITH_CUSTOM dispatch point.
     if current_step is GuidedStep.STEP_2_SINK and guided.step is GuidedStep.STEP_2_5_RECIPE_MATCH:
         # step_advance already set guided.step_2_result and advanced to STEP_2_5.
         if guided.step_1_result is None or guided.step_2_result is None:
@@ -1872,6 +1857,25 @@ async def _dispatch_guided_respond(
             )
         source = guided.step_1_result
         sink = guided.step_2_result
+
+        # Commit the sink to CompositionState.outputs via handle_step_2_sink.
+        # step_advance (pure) encoded the sink in guided.step_2_result but did
+        # NOT call _execute_set_output — that side-effect is our responsibility.
+        sink_handler_result = handle_step_2_sink(
+            state=state,
+            session=guided,
+            resolved=sink,
+            catalog=catalog,
+            data_dir=data_dir,
+        )
+        if not sink_handler_result.tool_result.success:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Step 2 sink commit failed: {sink_handler_result.tool_result}",
+            )
+        state = sink_handler_result.state
+        guided = sink_handler_result.session
+
         recipe_match = match_recipe(source, sink)
         if recipe_match is not None:
             next_turn = build_step_2_5_recipe_offer_turn(recipe_match)
@@ -1895,6 +1899,7 @@ async def _dispatch_guided_respond(
             guided = _replace(guided, history=(*guided.history, new_record))
             return state, guided, next_turn
 
+        # No recipe match — Step 3 (chain solver) is deferred to Phase 4.
         return state, guided, None
 
     # --- STEP_2_5_RECIPE_MATCH turns ------------------------------------
@@ -3534,6 +3539,54 @@ def create_session_router() -> APIRouter:
             composition_state=_state_response(copied_state) if copied_state else None,
         )
 
+    def _build_get_guided_turn(
+        state: Any,
+        guided: Any,
+        *,
+        catalog: Any,
+    ) -> Any | None:
+        """Build the initial turn payload for the current guided step.
+
+        Called exclusively by ``get_guided`` to determine ``next_turn`` in the
+        response.  Each step has one canonical "initial" turn that is
+        deterministically rebuildable from ``(state, guided, catalog)`` alone:
+
+        - STEP_1_SOURCE: ``build_initial_step_1_turn`` (single_select or
+          inspect_and_confirm based on blob state; no blob facts on GET).
+        - STEP_2_SINK: ``build_step_2_single_select_turn`` (sink plugin list).
+        - STEP_2_5_RECIPE_MATCH: ``build_step_2_5_recipe_offer_turn`` if a
+          recipe was matched and recorded; ``None`` if no recipe matched
+          (session stays at this step but no turn exists — Phase 4 path).
+        - STEP_3_TRANSFORMS: not yet implemented; returns ``None``.
+
+        SCHEMA_FORM and MULTI_SELECT_WITH_CUSTOM turns are intra-step turns
+        emitted by POST /respond.  They are NOT re-emitted by GET /guided
+        because the chosen plugin name (needed to rebuild SCHEMA_FORM) is not
+        stored in the session.  GET /guided always returns the *initial* turn
+        for the current step, not the latest intra-step turn.  Clients that
+        need to restore intra-step context must re-submit the prior response.
+
+        Returns:
+            A ``Turn`` TypedDict, or ``None`` when the step has no rebuildable
+            initial turn (STEP_3 / no-recipe path).
+        """
+        step = guided.step
+        if step is GuidedStep.STEP_1_SOURCE:
+            return build_initial_step_1_turn(state, blob_inspection=None, catalog=catalog)
+        if step is GuidedStep.STEP_2_SINK:
+            return build_step_2_single_select_turn(catalog)
+        if step is GuidedStep.STEP_2_5_RECIPE_MATCH:
+            # A recipe_offer TurnRecord exists iff a recipe was matched.
+            # Reconstruct by re-running match_recipe (deterministic).
+            if guided.step_1_result is not None and guided.step_2_result is not None:
+                recipe_match = match_recipe(guided.step_1_result, guided.step_2_result)
+                if recipe_match is not None:
+                    return build_step_2_5_recipe_offer_turn(recipe_match)
+            # No recipe matched — no initial turn for this step.
+            return None
+        # STEP_3_TRANSFORMS and beyond: not yet implemented (Phase 4).
+        return None
+
     @router.get("/{session_id}/guided", response_model=GetGuidedResponse)
     async def get_guided(
         session_id: UUID,
@@ -3587,20 +3640,21 @@ def create_session_router() -> APIRouter:
                 None,
             )
 
-            # Always build the turn (deterministic from current state + catalog).
-            # Building is cheap and allows idempotent re-fetch to return the
-            # same payload without needing a payload store.
-            turn = build_initial_step_1_turn(
-                state,
-                blob_inspection=None,
-                catalog=catalog,
-            )
-            turn_type = TurnType(turn["type"])
-            payload_hash = stable_hash(turn["payload"])
+            # Build the initial turn for the current step (deterministic from
+            # state + catalog).  Returns None for steps with no rebuildable
+            # initial turn (STEP_3 / no-recipe STEP_2_5 path) or when the
+            # session is already terminal.
+            turn = _build_get_guided_turn(state, guided, catalog=catalog) if guided.terminal is None else None
+            turn_type: TurnType | None = TurnType(turn["type"]) if turn is not None else None
+            payload_hash: str | None = stable_hash(turn["payload"]) if turn is not None else None
 
             state_record_out: CompositionStateRecord | None = state_record
-            if existing_record_for_step is None:
-                # First fetch for this step: record TurnRecord, persist, emit audit.
+            if existing_record_for_step is None and turn is not None:
+                # First fetch for this step AND a turn exists: record TurnRecord,
+                # persist, emit audit.  When turn is None (terminal state, STEP_3,
+                # or no-recipe STEP_2_5 path) there is no turn to record.
+                assert turn_type is not None  # guaranteed: turn is not None → type set
+                assert payload_hash is not None  # guaranteed: turn is not None → hash set
                 new_record = TurnRecord(
                     step=current_step,
                     turn_type=turn_type,
@@ -3685,7 +3739,9 @@ def create_session_router() -> APIRouter:
                     type=turn["type"],
                     step_index=turn["step_index"],
                     payload=dict(turn["payload"]),
-                ),
+                )
+                if turn is not None
+                else None,
                 terminal=TerminalStateResponse(
                     kind=terminal.kind.value,
                     reason=terminal.reason.value if terminal.reason is not None else None,
@@ -3819,7 +3875,7 @@ def create_session_router() -> APIRouter:
                         recorder,
                         prev=GuidedStep(args["prev_step"]),
                         drop_reason=TerminalReason(args["drop_reason"]),
-                        validation_result=args.get("validation_result"),
+                        validation_result=args["validation_result"],
                         composition_version=state.version,
                         actor=user.user_id,
                     )
@@ -3834,7 +3890,7 @@ def create_session_router() -> APIRouter:
             next_turn: Any | None = None
             settings = request.app.state.settings
             data_dir: str | None = str(settings.data_dir) if settings.data_dir else None
-            session_engine = getattr(request.app.state, "session_engine", None)
+            session_engine = request.app.state.session_engine
 
             if terminal is None:
                 state, guided, next_turn = await _dispatch_guided_respond(

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1688,6 +1688,8 @@ async def _dispatch_guided_respond(
                 resolved=resolved,
                 catalog=catalog,
                 data_dir=data_dir,
+                session_engine=session_engine,
+                session_id=session_id,
             )
             if not handler_result.tool_result.success:
                 raise HTTPException(
@@ -1760,6 +1762,8 @@ async def _dispatch_guided_respond(
             resolved=resolved,
             catalog=catalog,
             data_dir=data_dir,
+            session_engine=session_engine,
+            session_id=session_id,
         )
         if not handler_result.tool_result.success:
             raise HTTPException(

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -42,7 +42,6 @@ from elspeth.web.composer.guided.audit import (
     emit_turn_answered,
     emit_turn_emitted,
 )
-from elspeth.web.composer.guided.chain_solver import solve_chain
 from elspeth.web.composer.guided.emitters import (
     build_initial_step_1_turn,
     build_step_1_inspect_and_confirm_turn_from_intent,
@@ -94,6 +93,7 @@ from elspeth.web.execution.accounting import load_run_accounting_for_settings
 from elspeth.web.execution.schemas import RunAccounting, RunStatusResponse, ValidationResult
 from elspeth.web.execution.validation import validate_pipeline
 from elspeth.web.middleware.rate_limit import ComposerRateLimiter, get_rate_limiter
+from elspeth.web.sessions._guided_solve_chain import solve_chain_with_auto_drop
 from elspeth.web.sessions.converters import state_from_record as _state_from_record
 from elspeth.web.sessions.protocol import (
     SESSION_TERMINAL_RUN_STATUS_VALUES,
@@ -2172,7 +2172,24 @@ async def _dispatch_guided_respond(
             return state, guided, next_turn
 
         # No recipe match — solve the chain via the LLM and emit propose_chain.
-        proposal = await solve_chain(model=model, source=source, sink=sink, recipe_match=None)
+        # I2: wrap transient LLM failures (LiteLLM API/auth/bad-request,
+        # timeouts, malformed-response shape) so they auto-drop to freeform
+        # via mark_solver_exhausted rather than escape as 500s.  See
+        # ``solve_chain_with_auto_drop`` for the contract.
+        proposal, guided = await solve_chain_with_auto_drop(
+            site="step_2_sink_initial_solve",
+            session=guided,
+            session_id=session_id,
+            user_id=user_id,
+            composition_version=state.version,
+            recorder=recorder,
+            model=model,
+            source=source,
+            sink=sink,
+            recipe_match=None,
+        )
+        if proposal is None:
+            return state, guided, None
         guided = _replace(guided, step=GuidedStep.STEP_3_TRANSFORMS, step_3_proposal=proposal)
         next_turn = build_step_3_propose_chain_turn(proposal)
         new_record = TurnRecord(
@@ -2322,7 +2339,21 @@ async def _dispatch_guided_respond(
                 )
             source = guided.step_1_result
             sink = guided.step_2_result
-            proposal = await solve_chain(model=model, source=source, sink=sink, recipe_match=None)
+            # I2: same auto-drop wrap as the no-recipe-match branch above.
+            proposal, guided = await solve_chain_with_auto_drop(
+                site="step_2_5_build_manually_solve",
+                session=guided,
+                session_id=session_id,
+                user_id=user_id,
+                composition_version=state.version,
+                recorder=recorder,
+                model=model,
+                source=source,
+                sink=sink,
+                recipe_match=None,
+            )
+            if proposal is None:
+                return state, guided, None
             guided = _replace(guided, step_3_proposal=proposal)
             next_turn = build_step_3_propose_chain_turn(proposal)
             new_record = TurnRecord(
@@ -2396,13 +2427,27 @@ async def _dispatch_guided_respond(
                         raise InvariantError("repair: step_1_result is None — STEP_3 unreachable without Step 1 commit")
                     if guided.step_2_result is None:
                         raise InvariantError("repair: step_2_result is None — STEP_3 unreachable without Step 2 commit")
-                    repair_proposal = await solve_chain(
+                    # I2: a transient failure during repair auto-drops
+                    # IMMEDIATELY — repair is already attempt #2, so a
+                    # transient on repair means we are done trying. The
+                    # early ``return`` below short-circuits BEFORE the
+                    # downstream ``mark_solver_exhausted`` path so we never
+                    # double-emit ``guided_dropped_to_freeform``.
+                    repair_proposal, guided = await solve_chain_with_auto_drop(
+                        site="step_3_repair_solve",
+                        session=guided,
+                        session_id=session_id,
+                        user_id=user_id,
+                        composition_version=state.version,
+                        recorder=recorder,
                         model=model,
                         source=guided.step_1_result,
                         sink=guided.step_2_result,
                         recipe_match=None,
                         repair_context=repair_context,
                     )
+                    if repair_proposal is None:
+                        return state, guided, None
                     repair_result = handle_step_3_chain_accept(
                         # state is the original pre-attempt state — _execute_set_pipeline
                         # is validate-then-mutate: on failure the state is untouched,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1909,7 +1909,14 @@ async def _dispatch_guided_respond(
                 composition_version=state.version,
                 actor=user_id,
             )
-            guided = _replace(guided, history=(*guided.history, new_record))
+            # Persist the chosen plugin name so GET /guided can rebuild the SCHEMA_FORM
+            # on refresh (rebuild requires the plugin name to fetch the schema from the
+            # catalog).  Cleared atomically when step_2_sink_intent is set below.
+            guided = _replace(
+                guided,
+                history=(*guided.history, new_record),
+                step_2_chosen_plugin=plugin_name,
+            )
             return state, guided, next_turn
 
         if current_turn_type is TurnType.SCHEMA_FORM:
@@ -1958,7 +1965,13 @@ async def _dispatch_guided_respond(
                 plugin=plugin_name,
                 options=dict(options_raw),
             )
-            guided = _replace(guided, step_2_sink_intent=sink_intent)
+            # Set step_2_sink_intent and clear step_2_chosen_plugin atomically.
+            # Once step_2_sink_intent is set, the full plugin+options tuple is
+            # held there; step_2_chosen_plugin is only needed in the window
+            # between SINGLE_SELECT and SCHEMA_FORM (to rebuild SCHEMA_FORM on
+            # GET /guided refresh).  Having both set simultaneously would be
+            # redundant and could mislead rebuild logic about the intra-step phase.
+            guided = _replace(guided, step_2_sink_intent=sink_intent, step_2_chosen_plugin=None)
 
             # Emit multi_select_with_custom for required fields.
             # Observed columns come from step_1_result if available.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -85,6 +85,7 @@ from elspeth.web.composer.protocol import (
 )
 from elspeth.web.composer.redaction import redact_source_storage_path
 from elspeth.web.composer.state import CompositionState, PipelineMetadata, ValidationEntry, ValidationSummary
+from elspeth.web.composer.tools import _DATA_ERROR_KEY
 from elspeth.web.composer.yaml_generator import generate_yaml
 from elspeth.web.execution.accounting import load_run_accounting_for_settings
 from elspeth.web.execution.schemas import RunAccounting, RunStatusResponse, ValidationResult
@@ -2056,15 +2057,17 @@ async def _dispatch_guided_respond(
                         # No validation errors but a data-layer error message;
                         # use it verbatim so the LLM sees the actual fault.
                         raw_data = dict(failed_result.data)
-                        if "error" in raw_data:
-                            repair_context_lines = [str(raw_data["error"])]
+                        if _DATA_ERROR_KEY in raw_data:
+                            repair_context_lines = [str(raw_data[_DATA_ERROR_KEY])]
                     repair_context = "\n".join(repair_context_lines) or str(failed_result.validation)
 
                     # Obtain source/sink from the guided session for the repair call.
                     # Both must be non-None because Step 3 can only be reached after
                     # Steps 1 and 2 commit successfully (dispatcher invariant).
-                    assert guided.step_1_result is not None, "repair: step_1_result missing"
-                    assert guided.step_2_result is not None, "repair: step_2_result missing"
+                    if guided.step_1_result is None:
+                        raise RuntimeError("repair: step_1_result is None — STEP_3 unreachable without Step 1 commit")
+                    if guided.step_2_result is None:
+                        raise RuntimeError("repair: step_2_result is None — STEP_3 unreachable without Step 2 commit")
                     repair_proposal = await solve_chain(
                         source=guided.step_1_result,
                         sink=guided.step_2_result,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -56,6 +56,7 @@ from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnT
 from elspeth.web.composer.guided.recipe_match import match_recipe
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
+    SinkIntent,
     SourceResolved,
     TerminalReason,
     TurnRecord,
@@ -1821,7 +1822,31 @@ async def _dispatch_guided_respond(
             return state, guided, next_turn
 
         if current_turn_type is TurnType.SCHEMA_FORM:
-            # User filled in sink options. Emit multi_select_with_custom for required fields.
+            # User filled in sink options. Persist the chosen plugin + options into
+            # step_2_sink_intent so _advance_step_2 can reconstruct the full
+            # SinkOutputResolved when the subsequent MULTI_SELECT_WITH_CUSTOM
+            # response arrives (which only carries required_fields, not the plugin).
+            edited = turn_response["edited_values"] or {}
+            # "plugin" is required — absence is Tier-3 evidence that the client
+            # sent a malformed payload. Reject with 422 (same boundary rule as
+            # the Step-1 SCHEMA_FORM dispatcher).
+            if "plugin" not in edited:
+                raise HTTPException(
+                    status_code=422,
+                    detail="schema_form response at step 2 must include 'plugin' in edited_values.",
+                )
+            if "options" not in edited:
+                raise HTTPException(
+                    status_code=422,
+                    detail="schema_form response at step 2 must include 'options' in edited_values.",
+                )
+            sink_intent = SinkIntent(
+                plugin=str(edited["plugin"]),
+                options=dict(edited["options"]),
+            )
+            guided = _replace(guided, step_2_sink_intent=sink_intent)
+
+            # Emit multi_select_with_custom for required fields.
             # Observed columns come from step_1_result if available.
             observed_columns: tuple[str, ...] = ()
             if guided.step_1_result is not None:

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -45,6 +45,7 @@ from elspeth.web.composer.guided.audit import (
 from elspeth.web.composer.guided.chain_solver import solve_chain
 from elspeth.web.composer.guided.emitters import (
     build_initial_step_1_turn,
+    build_step_1_inspect_and_confirm_turn_from_intent,
     build_step_1_schema_form_turn,
     build_step_2_5_recipe_offer_turn,
     build_step_2_multi_select_turn,
@@ -4074,35 +4075,76 @@ def create_session_router() -> APIRouter:
         *,
         catalog: Any,
     ) -> Any | None:
-        """Build the initial turn payload for the current guided step.
+        """Build the turn payload to return from GET /guided for the current step.
 
         Called exclusively by ``get_guided`` to determine ``next_turn`` in the
-        response.  Each step has one canonical "initial" turn that is
-        deterministically rebuildable from ``(state, guided, catalog)`` alone:
+        response.  Rebuilds the correct turn deterministically from
+        ``(state, guided, catalog)`` alone, including intra-step turns for
+        steps that maintain staging fields on the session.
 
-        - STEP_1_SOURCE: ``build_initial_step_1_turn`` (single_select or
-          inspect_and_confirm based on blob state; no blob facts on GET).
-        - STEP_2_SINK: ``build_step_2_single_select_turn`` (sink plugin list).
-        - STEP_2_5_RECIPE_MATCH: ``build_step_2_5_recipe_offer_turn`` if a
-          recipe was matched and recorded; ``None`` if no recipe matched
-          (session stays at this step but no turn exists — Phase 4 path).
-        - STEP_3_TRANSFORMS: not yet implemented; returns ``None``.
+        Per-step rebuild rules:
 
-        SCHEMA_FORM and MULTI_SELECT_WITH_CUSTOM turns are intra-step turns
-        emitted by POST /respond.  They are NOT re-emitted by GET /guided
-        because the chosen plugin name (needed to rebuild SCHEMA_FORM) is not
-        stored in the session.  GET /guided always returns the *initial* turn
-        for the current step, not the latest intra-step turn.  Clients that
-        need to restore intra-step context must re-submit the prior response.
+        - STEP_1_SOURCE: three sub-cases in priority order:
+          1. ``step_1_source_intent`` is set → the SCHEMA_FORM response was
+             submitted; the session is waiting for INSPECT_AND_CONFIRM
+             confirmation.  Emit ``inspect_and_confirm`` from the intent's
+             observed columns (warnings are not stored on SourceIntent;
+             the rebuild emits an empty warnings list).
+          2. ``step_1_source_intent`` is None → initial state or SINGLE_SELECT
+             window.  Fall through to ``build_initial_step_1_turn``.
+             Note: the window between SINGLE_SELECT and SCHEMA_FORM does not
+             persist the chosen source plugin name; a GET /guided in that
+             window will re-emit the SINGLE_SELECT.  This is an observation-
+             not-fix gap (parallel to Finding 2, addressed by
+             step_2_chosen_plugin) and is tracked as obs-STEP1-chosen-plugin.
+
+        - STEP_2_SINK: three sub-cases in priority order:
+          1. ``step_2_sink_intent`` is set → the SCHEMA_FORM response was
+             submitted; the session is waiting for MULTI_SELECT_WITH_CUSTOM
+             confirmation.  Emit ``multi_select_with_custom`` from step_1_result.
+          2. ``step_2_chosen_plugin`` is set → the SINGLE_SELECT response was
+             submitted; the session is waiting for SCHEMA_FORM submission.
+             Emit ``schema_form`` for the chosen plugin.
+          3. Neither is set → initial state.  Emit ``single_select`` listing
+             all registered sink plugins.
+
+        - STEP_2_5_RECIPE_MATCH: deterministically re-run ``match_recipe``; if a
+          match is found, emit ``recipe_offer``.  Returns ``None`` when no
+          recipe matched (session stays at this step but no turn exists).
+
+        - STEP_3_TRANSFORMS: if ``step_3_proposal`` is set, emit
+          ``propose_chain`` from the staged proposal (this is the normal
+          path — step_3_proposal is always set when the session reaches
+          STEP_3_TRANSFORMS via the LLM chain solver).  Returns ``None``
+          if the proposal is absent (LLM call has not completed; should
+          not occur in practice — guarded defensively to avoid a crash).
 
         Returns:
             A ``Turn`` TypedDict, or ``None`` when the step has no rebuildable
-            initial turn (STEP_3 / no-recipe path).
+            turn (no-recipe STEP_2_5 path, or STEP_3 without a proposal).
         """
         step = guided.step
         if step is GuidedStep.STEP_1_SOURCE:
+            # Finding 3 (Codex #14): if step_1_source_intent is set, the SCHEMA_FORM
+            # was already submitted and the session is waiting for INSPECT_AND_CONFIRM.
+            # Rebuild from the staged intent (observed_columns; warnings default to empty
+            # as they are not stored on SourceIntent).
+            if guided.step_1_source_intent is not None:
+                return build_step_1_inspect_and_confirm_turn_from_intent(guided.step_1_source_intent)
             return build_initial_step_1_turn(state, blob_inspection=None, catalog=catalog)
         if step is GuidedStep.STEP_2_SINK:
+            # Finding 2 (Codex #10): determine intra-step position and rebuild
+            # the correct turn, not always the initial SINGLE_SELECT.
+            if guided.step_2_sink_intent is not None:
+                # SCHEMA_FORM was submitted; session is waiting for MULTI_SELECT_WITH_CUSTOM.
+                observed_columns: tuple[str, ...] = ()
+                if guided.step_1_result is not None:
+                    observed_columns = tuple(guided.step_1_result.observed_columns)
+                return build_step_2_multi_select_turn(observed_columns)
+            if guided.step_2_chosen_plugin is not None:
+                # SINGLE_SELECT was submitted; session is waiting for SCHEMA_FORM submission.
+                return build_step_2_schema_form_turn(guided.step_2_chosen_plugin, catalog)
+            # Initial state: no plugin chosen yet.  Emit the sink plugin list.
             return build_step_2_single_select_turn(catalog)
         if step is GuidedStep.STEP_2_5_RECIPE_MATCH:
             # A recipe_offer TurnRecord exists iff a recipe was matched.
@@ -4113,7 +4155,18 @@ def create_session_router() -> APIRouter:
                     return build_step_2_5_recipe_offer_turn(recipe_match)
             # No recipe matched — no initial turn for this step.
             return None
-        # STEP_3_TRANSFORMS and beyond: not yet implemented (Phase 4).
+        if step is GuidedStep.STEP_3_TRANSFORMS:
+            # Finding 1 (Codex #5): rebuild propose_chain from the staged proposal.
+            # step_3_proposal is always set when the session reaches STEP_3_TRANSFORMS
+            # via the LLM chain solver (set atomically with the step pointer in the
+            # dispatcher at routes.py:2051 and routes.py:4063).  A None here would
+            # mean the proposal was never computed — guarded defensively to avoid
+            # crashing on a corrupt session rather than returning a misleading null.
+            if guided.step_3_proposal is not None:
+                return build_step_3_propose_chain_turn(guided.step_3_proposal)
+            # No proposal yet — LLM call has not completed; return None and let the
+            # idempotency machinery handle it (no TurnRecord emitted; client retries).
+            return None
         return None
 
     @router.get("/{session_id}/guided", response_model=GetGuidedResponse)

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1950,7 +1950,7 @@ async def _dispatch_guided_respond(
         # after _advance_step_1 sets step_1_result).  Assert to keep mypy happy and
         # provide a clear crash message if this invariant is ever violated.
         if guided.step_1_result is None:
-            raise AssertionError(
+            raise InvariantError(
                 "inspect_and_confirm post-advance: guided.step_1_result is None after "
                 "_advance_step_1 ran — this is an invariant violation in the state machine."
             )
@@ -2471,7 +2471,7 @@ async def _dispatch_guided_respond(
         )
 
     # Unhandled branch — this is a dispatcher gap, not a user error.
-    raise AssertionError(
+    raise InvariantError(
         f"_dispatch_guided_respond: unhandled branch "
         f"current_step={current_step!r}, current_turn_type={current_turn_type!r}, "
         f"guided.step={guided.step!r}"
@@ -4346,8 +4346,19 @@ def create_session_router() -> APIRouter:
                 # First fetch for this step AND a turn exists: record TurnRecord,
                 # persist, emit audit.  When turn is None (terminal state, STEP_3,
                 # or no-recipe STEP_2_5 path) there is no turn to record.
-                assert turn_type is not None  # guaranteed: turn is not None → type set
-                assert payload_hash is not None  # guaranteed: turn is not None → hash set
+                # Guaranteed by the conditional assignments above: turn is not
+                # None on this branch, so both turn_type and payload_hash were
+                # populated from turn["type"] / stable_hash(turn["payload"]).
+                # Use InvariantError (not bare assert) so python -O does not
+                # strip the gate and silently feed None to TurnRecord.
+                if turn_type is None:
+                    raise InvariantError(
+                        "GET guided: turn is not None but turn_type is None — TurnType derivation skipped despite turn being present."
+                    )
+                if payload_hash is None:
+                    raise InvariantError(
+                        "GET guided: turn is not None but payload_hash is None — stable_hash derivation skipped despite turn being present."
+                    )
                 new_record = TurnRecord(
                     step=current_step,
                     turn_type=turn_type,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1666,21 +1666,63 @@ async def _dispatch_guided_respond(
 
         if current_turn_type is TurnType.SCHEMA_FORM:
             # User submitted source options. Call handle_step_1_source to commit.
-            edited = turn_response["edited_values"] or {}
-            # "plugin" is required — absence is Tier-3 evidence that the client
-            # sent a malformed payload; reject with 422 rather than fabricating
-            # a value from state.source (inference from adjacent fields is
-            # fabrication per CLAUDE.md §Three-Tier Trust Model).
-            if "plugin" not in edited:
+            # ``edited_values`` is the wire contract for the Step-1 SCHEMA_FORM
+            # response: the SchemaFormTurn widget always sends
+            # ``{"plugin": str, "options": Mapping, "observed_columns": list,
+            # "sample_rows": list}``. A missing key, a null payload, a non-string
+            # ``plugin``, or non-list-shaped ``observed_columns`` / ``sample_rows``
+            # is a protocol violation, not a Tier-3 "user typo" we paper over
+            # with ``.get()`` defaults — silent defaults here would surface
+            # far downstream as inference from adjacent fields (forbidden per
+            # CLAUDE.md §Three-Tier Trust Model). The HTTP boundary is a trust
+            # boundary, so we raise 400 with a contract-citing message.
+            edited = turn_response["edited_values"]
+            if edited is None:
                 raise HTTPException(
-                    status_code=422,
-                    detail="schema_form response must include 'plugin' in edited_values.",
+                    status_code=400,
+                    detail="schema_form response at step 1 requires edited_values; received null.",
+                )
+            missing = {"plugin", "options", "observed_columns", "sample_rows"} - edited.keys()
+            if missing:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"schema_form response at step 1 edited_values missing required keys: {sorted(missing)}; got keys: {sorted(edited.keys())}"
+                    ),
+                )
+            plugin_name = edited["plugin"]
+            if not isinstance(plugin_name, str) or not plugin_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"schema_form response at step 1 edited_values['plugin'] must be a non-empty string; got {plugin_name!r}"),
+                )
+            options_raw = edited["options"]
+            if not isinstance(options_raw, Mapping):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"schema_form response at step 1 edited_values['options'] must be an object; got {type(options_raw).__name__}"),
+                )
+            observed_columns_raw = edited["observed_columns"]
+            if not isinstance(observed_columns_raw, list):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"schema_form response at step 1 edited_values['observed_columns'] must be a list; got {type(observed_columns_raw).__name__}"
+                    ),
+                )
+            sample_rows_raw = edited["sample_rows"]
+            if not isinstance(sample_rows_raw, list):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"schema_form response at step 1 edited_values['sample_rows'] must be a list; got {type(sample_rows_raw).__name__}"
+                    ),
                 )
             resolved = SourceResolved(
-                plugin=str(edited["plugin"]),
-                options=dict(edited.get("options", {})),
-                observed_columns=tuple(edited.get("observed_columns", [])),
-                sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
+                plugin=plugin_name,
+                options=dict(options_raw),
+                observed_columns=tuple(observed_columns_raw),
+                sample_rows=tuple(dict(r) for r in sample_rows_raw),
             )
             handler_result = handle_step_1_source(
                 state=state,
@@ -1741,20 +1783,78 @@ async def _dispatch_guided_respond(
     # --- STEP_1_SOURCE → STEP_2_SINK (step_advance fired for INSPECT_AND_CONFIRM)
     if current_step is GuidedStep.STEP_1_SOURCE and guided.step is GuidedStep.STEP_2_SINK:
         # step_advance advanced the step. Build SourceResolved from edited_values.
-        edited = turn_response["edited_values"] or {}
-        # "plugin" is required — absence is a malformed client payload; reject
-        # with 422 rather than fabricating an empty string (same boundary rule
-        # as the SCHEMA_FORM branch above).
-        if "plugin" not in edited:
+        # ``edited_values`` is the wire contract for the post-advance
+        # INSPECT_AND_CONFIRM response (server-side; per the unit-test contract
+        # in test_state_machine.test_initial_session_advances_after_source_confirmed):
+        # ``{"plugin": str, "options": Mapping, "observed_columns": list,
+        # "sample_rows": list}``. A missing key, a null payload, or a wrong-typed
+        # value is a protocol violation — silent ``.get()`` defaults would
+        # fabricate fields the client never supplied (forbidden per CLAUDE.md
+        # §Three-Tier Trust Model). The HTTP boundary is a trust boundary, so
+        # we raise 400 with a contract-citing message.
+        #
+        # Shadowing note: ``_advance_step_1`` in state_machine.py runs BEFORE
+        # this dispatcher branch and itself raises ``ValueError`` on null
+        # ``edited_values`` and ``KeyError`` on missing required keys — those
+        # errors propagate as HTTP 500 long before reaching here. The null and
+        # missing-key guards below are defense-in-depth: structurally
+        # unreachable as 400 in the production flow, but kept so the validator
+        # is locally complete and the dispatcher remains correct in isolation
+        # (e.g. if ``_advance_step_1``'s guards were ever relaxed). The
+        # guards that ARE HTTP-reachable as 400 are those where
+        # ``_advance_step_1``'s ``str()`` / ``tuple()`` coercion passes the
+        # raw value through unchanged: non-empty/non-string ``plugin``,
+        # non-Mapping ``options``, non-list ``observed_columns`` /
+        # ``sample_rows``.
+        edited = turn_response["edited_values"]
+        if edited is None:
             raise HTTPException(
-                status_code=422,
-                detail="inspect_and_confirm response must include 'plugin' in edited_values.",
+                status_code=400,
+                detail="inspect_and_confirm response at step 1 requires edited_values; received null.",
+            )
+        missing = {"plugin", "options", "observed_columns", "sample_rows"} - edited.keys()
+        if missing:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"inspect_and_confirm response at step 1 edited_values missing required keys: {sorted(missing)}; got keys: {sorted(edited.keys())}"
+                ),
+            )
+        plugin_name = edited["plugin"]
+        if not isinstance(plugin_name, str) or not plugin_name:
+            raise HTTPException(
+                status_code=400,
+                detail=(f"inspect_and_confirm response at step 1 edited_values['plugin'] must be a non-empty string; got {plugin_name!r}"),
+            )
+        options_raw = edited["options"]
+        if not isinstance(options_raw, Mapping):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"inspect_and_confirm response at step 1 edited_values['options'] must be an object; got {type(options_raw).__name__}"
+                ),
+            )
+        observed_columns_raw = edited["observed_columns"]
+        if not isinstance(observed_columns_raw, list):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"inspect_and_confirm response at step 1 edited_values['observed_columns'] must be a list; got {type(observed_columns_raw).__name__}"
+                ),
+            )
+        sample_rows_raw = edited["sample_rows"]
+        if not isinstance(sample_rows_raw, list):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"inspect_and_confirm response at step 1 edited_values['sample_rows'] must be a list; got {type(sample_rows_raw).__name__}"
+                ),
             )
         resolved = SourceResolved(
-            plugin=str(edited["plugin"]),
-            options=dict(edited.get("options", {})),
-            observed_columns=tuple(edited.get("observed_columns", [])),
-            sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
+            plugin=plugin_name,
+            options=dict(options_raw),
+            observed_columns=tuple(observed_columns_raw),
+            sample_rows=tuple(dict(r) for r in sample_rows_raw),
         )
         handler_result = handle_step_1_source(
             state=state,
@@ -1830,23 +1930,46 @@ async def _dispatch_guided_respond(
             # step_2_sink_intent so _advance_step_2 can reconstruct the full
             # SinkOutputResolved when the subsequent MULTI_SELECT_WITH_CUSTOM
             # response arrives (which only carries required_fields, not the plugin).
-            edited = turn_response["edited_values"] or {}
-            # "plugin" is required — absence is Tier-3 evidence that the client
-            # sent a malformed payload. Reject with 422 (same boundary rule as
-            # the Step-1 SCHEMA_FORM dispatcher).
-            if "plugin" not in edited:
+            # ``edited_values`` is the wire contract for the Step-2 SCHEMA_FORM
+            # response: the SchemaFormTurn widget always sends
+            # ``{"plugin": str, "options": Mapping, "observed_columns": list,
+            # "sample_rows": list}``. Step 2 only consumes ``plugin`` + ``options``
+            # for the sink_intent, but the wire shape is fully validated to keep
+            # the contract identical with Step 1 (no silent-tolerance drift).
+            # A missing key, a null payload, or a wrong-typed value is a
+            # protocol violation — silent ``.get()`` defaults would fabricate
+            # fields the client never supplied (forbidden per CLAUDE.md
+            # §Three-Tier Trust Model). The HTTP boundary is a trust boundary,
+            # so we raise 400 with a contract-citing message.
+            edited = turn_response["edited_values"]
+            if edited is None:
                 raise HTTPException(
-                    status_code=422,
-                    detail="schema_form response at step 2 must include 'plugin' in edited_values.",
+                    status_code=400,
+                    detail="schema_form response at step 2 requires edited_values; received null.",
                 )
-            if "options" not in edited:
+            missing = {"plugin", "options"} - edited.keys()
+            if missing:
                 raise HTTPException(
-                    status_code=422,
-                    detail="schema_form response at step 2 must include 'options' in edited_values.",
+                    status_code=400,
+                    detail=(
+                        f"schema_form response at step 2 edited_values missing required keys: {sorted(missing)}; got keys: {sorted(edited.keys())}"
+                    ),
+                )
+            plugin_name = edited["plugin"]
+            if not isinstance(plugin_name, str) or not plugin_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"schema_form response at step 2 edited_values['plugin'] must be a non-empty string; got {plugin_name!r}"),
+                )
+            options_raw = edited["options"]
+            if not isinstance(options_raw, Mapping):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"schema_form response at step 2 edited_values['options'] must be an object; got {type(options_raw).__name__}"),
                 )
             sink_intent = SinkIntent(
-                plugin=str(edited["plugin"]),
-                options=dict(edited["options"]),
+                plugin=plugin_name,
+                options=dict(options_raw),
             )
             guided = _replace(guided, step_2_sink_intent=sink_intent)
 

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -2393,9 +2393,9 @@ async def _dispatch_guided_respond(
                     # Both must be non-None because Step 3 can only be reached after
                     # Steps 1 and 2 commit successfully (dispatcher invariant).
                     if guided.step_1_result is None:
-                        raise RuntimeError("repair: step_1_result is None — STEP_3 unreachable without Step 1 commit")
+                        raise InvariantError("repair: step_1_result is None — STEP_3 unreachable without Step 1 commit")
                     if guided.step_2_result is None:
-                        raise RuntimeError("repair: step_2_result is None — STEP_3 unreachable without Step 2 commit")
+                        raise InvariantError("repair: step_2_result is None — STEP_3 unreachable without Step 2 commit")
                     repair_proposal = await solve_chain(
                         model=model,
                         source=guided.step_1_result,
@@ -3017,7 +3017,7 @@ def create_session_router() -> APIRouter:
                     # (the gate above ensures _guided is not None when this fires)
                     # and satisfies the type checker without defensive get() calls.
                     if _guided is None:
-                        raise RuntimeError(
+                        raise InvariantError(
                             "guided_terminal_for_compose is set but guided_session is None — "
                             "impossible state: transition gate should have blocked this path"
                         )
@@ -3200,6 +3200,27 @@ def create_session_router() -> APIRouter:
                 )
                 terminal_status = "completed"
                 return response
+            except InvariantError as exc:
+                # Same B1-sanitization rationale as the /guided/respond
+                # step_advance and dispatch handlers: server-invariant
+                # violations route through a static 500 detail and a
+                # structured slog event so on-call dashboards can filter on
+                # ``guided.invariant_violated``.  Without this handler an
+                # InvariantError raised from the post-compose transition_consumed
+                # impossible-state guard would land at FastAPI's default 500
+                # ({"detail": "Internal Server Error"}) with no structured log.
+                slog.error(
+                    "guided.invariant_violated",
+                    session_id=str(session_id),
+                    user_id=user.user_id,
+                    exc_class=type(exc).__name__,
+                    site="send_message",
+                    frames=_safe_frame_strings(exc),
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail="Server invariant violated. See application audit log for diagnostic detail.",
+                ) from exc
             except asyncio.CancelledError as exc:
                 # Client-disconnect or operator cancel during the
                 # composer-engaged window. Publish a discriminated
@@ -3523,7 +3544,7 @@ def create_session_router() -> APIRouter:
                     # transition_consumed flip — _guided is non-None because
                     # _guided_terminal_for_compose was derived from _guided.terminal.
                     if _guided is None:
-                        raise RuntimeError(
+                        raise InvariantError(
                             "guided_terminal_for_compose is set but guided_session is None — "
                             "impossible state: transition gate should have blocked this path"
                         )
@@ -3691,6 +3712,22 @@ def create_session_router() -> APIRouter:
                 )
                 terminal_status = "completed"
                 return response
+            except InvariantError as exc:
+                # Mirror of send_message InvariantError handler — same
+                # B1-sanitization rationale. Static 500 detail; slog carries
+                # exc_class + frames only.
+                slog.error(
+                    "guided.invariant_violated",
+                    session_id=str(session_id),
+                    user_id=user.user_id,
+                    exc_class=type(exc).__name__,
+                    site="recompose",
+                    frames=_safe_frame_strings(exc),
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail="Server invariant violated. See application audit log for diagnostic detail.",
+                ) from exc
             except asyncio.CancelledError as exc:
                 # Mirror of send_message cancellation path. See block
                 # comment there for the shielded-publish rationale.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1794,9 +1794,9 @@ async def _dispatch_guided_respond(
         # server-side knowledge held in step_1_source_intent before the turn is
         # emitted; the widget never sees them in the response body.
         #
-        # Shadowing note: ``_advance_step_1`` raises ValueError on null
-        # ``edited_values`` and KeyError on missing ``columns`` — those propagate
-        # as HTTP 500 before reaching here. The null guard and missing-key guard
+        # Shadowing note: ``_advance_step_1`` raises ValueError (client-fault)
+        # on null ``edited_values`` and KeyError on missing ``columns`` — those
+        # propagate as HTTP 500 before reaching here. The null guard and missing-key guard
         # below are defense-in-depth (locally complete; unreachable as 400 in
         # normal flow). The isinstance(columns_raw, list) guard IS HTTP-reachable
         # as 400: _advance_step_1's ``tuple(str(c) for c in columns_raw)`` coercion

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -2976,6 +2976,15 @@ def create_session_router() -> APIRouter:
                     likely_next="ELSPETH will prepare the composer prompt with the current pipeline.",
                 ),
             )
+            # Detect guided→freeform mode transition (spec §8.2).
+            # Recompose is a retried freeform chat call — progressive disclosure
+            # fires here on the same semantics as send_message (first freeform
+            # turn after guided_session.terminal is set uses the layered prompt).
+            _guided = state.guided_session
+            _guided_terminal_for_compose = (
+                _guided.terminal if (_guided is not None and _guided.terminal is not None and not _guided.transition_consumed) else None
+            )
+
             _COMPOSER_REQUESTS_INFLIGHT.add(1, {"endpoint": "recompose"})
             terminal_status: _ComposerRequestTerminalStatus = "failed"
             try:
@@ -2996,6 +3005,7 @@ def create_session_router() -> APIRouter:
                         session_id=str(session_id),
                         user_id=str(user.user_id),
                         progress=progress_sink,
+                        guided_terminal=_guided_terminal_for_compose,
                     )
                 except ComposerConvergenceError as exc:
                     terminal_status = "timed_out" if exc.budget_exhausted == "timeout" else "failed"
@@ -3174,6 +3184,31 @@ def create_session_router() -> APIRouter:
                         detail={"error_type": "composer_error", "detail": str(exc)},
                     ) from exc
 
+                # Compute the post-compose guided_session and composer_meta.
+                # Mirror of send_message §5a-§5b: if the transition prompt fired
+                # this turn, flip transition_consumed so subsequent turns use the
+                # freeform-only prompt.  guided_session rides in composer_meta (not
+                # a first-class column) — any save must propagate it forward.
+                _post_compose_guided: GuidedSession | None = result.state.guided_session
+                if _guided_terminal_for_compose is not None:
+                    # transition_consumed flip — _guided is non-None because
+                    # _guided_terminal_for_compose was derived from _guided.terminal.
+                    if _guided is None:
+                        raise RuntimeError(
+                            "guided_terminal_for_compose is set but guided_session is None — "
+                            "impossible state: transition gate should have blocked this path"
+                        )
+                    from dataclasses import replace as _replace_dc
+
+                    _post_compose_guided = _replace_dc(
+                        _guided,
+                        transition_consumed=True,
+                    )
+
+                _post_compose_meta: dict[str, Any] = {"repair_turns_used": result.repair_turns_used}
+                if _post_compose_guided is not None:
+                    _post_compose_meta["guided_session"] = _post_compose_guided.to_dict()
+
                 # Save state if version changed.
                 # Path 2 (post-compose runtime preflight): mirror of the
                 # send_message post-compose try/except — see the send_message
@@ -3203,7 +3238,7 @@ def create_session_router() -> APIRouter:
                             preflight_exception_policy="raise",
                             initial_version=state.version,
                             telemetry_source="recompose",
-                            composer_meta={"repair_turns_used": result.repair_turns_used},
+                            composer_meta=_post_compose_meta,
                         )
                     except ComposerRuntimePreflightError as rpf_exc:
                         rpf_exc = ComposerRuntimePreflightError(
@@ -3254,6 +3289,31 @@ def create_session_router() -> APIRouter:
                     )
                     state_response = _state_response(new_state_record, live_validation=validation)
                     post_compose_state_id = new_state_record.id
+                elif _guided_terminal_for_compose is not None and _post_compose_guided is not None:
+                    # Version unchanged but transition_consumed must be flipped.
+                    # Persist the updated guided_session in a new state row so
+                    # subsequent turns pick up transition_consumed=True.
+                    _existing_meta: dict[str, Any] = {}
+                    if state_record is not None and state_record.composer_meta is not None:
+                        _existing_meta = dict(deep_thaw(state_record.composer_meta))
+                    _transition_meta = {**_existing_meta, **_post_compose_meta}
+                    _transition_state = result.state
+                    _transition_state_d = _transition_state.to_dict()
+                    _transition_state_data = CompositionStateData(
+                        source=_transition_state_d["source"],
+                        nodes=_transition_state_d["nodes"],
+                        edges=_transition_state_d["edges"],
+                        outputs=_transition_state_d["outputs"],
+                        metadata_=_transition_state_d["metadata"],
+                        is_valid=False,
+                        validation_errors=None,
+                        composer_meta=_transition_meta,
+                    )
+                    _transition_record = await service.save_composition_state(
+                        session.id,
+                        _transition_state_data,
+                    )
+                    post_compose_state_id = _transition_record.id
 
                 # Persist assistant message
                 assistant_msg = await service.add_message(

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1782,80 +1782,65 @@ async def _dispatch_guided_respond(
 
     # --- STEP_1_SOURCE → STEP_2_SINK (step_advance fired for INSPECT_AND_CONFIRM)
     if current_step is GuidedStep.STEP_1_SOURCE and guided.step is GuidedStep.STEP_2_SINK:
-        # step_advance advanced the step. Build SourceResolved from edited_values.
-        # ``edited_values`` is the wire contract for the post-advance
-        # INSPECT_AND_CONFIRM response (server-side; per the unit-test contract
-        # in test_state_machine.test_initial_session_advances_after_source_confirmed):
-        # ``{"plugin": str, "options": Mapping, "observed_columns": list,
-        # "sample_rows": list}``. A missing key, a null payload, or a wrong-typed
-        # value is a protocol violation — silent ``.get()`` defaults would
-        # fabricate fields the client never supplied (forbidden per CLAUDE.md
-        # §Three-Tier Trust Model). The HTTP boundary is a trust boundary, so
-        # we raise 400 with a contract-citing message.
+        # step_advance already ran and advanced the step.  _advance_step_1 built
+        # SourceResolved from step_1_source_intent (plugin/options/samples) +
+        # edited_values["columns"] (the only field the widget can edit) and stored
+        # the result in guided.step_1_result.  It also cleared step_1_source_intent.
         #
-        # Shadowing note: ``_advance_step_1`` in state_machine.py runs BEFORE
-        # this dispatcher branch and itself raises ``ValueError`` on null
-        # ``edited_values`` and ``KeyError`` on missing required keys — those
-        # errors propagate as HTTP 500 long before reaching here. The null and
-        # missing-key guards below are defense-in-depth: structurally
-        # unreachable as 400 in the production flow, but kept so the validator
-        # is locally complete and the dispatcher remains correct in isolation
-        # (e.g. if ``_advance_step_1``'s guards were ever relaxed). The
-        # guards that ARE HTTP-reachable as 400 are those where
-        # ``_advance_step_1``'s ``str()`` / ``tuple()`` coercion passes the
-        # raw value through unchanged: non-empty/non-string ``plugin``,
-        # non-Mapping ``options``, non-list ``observed_columns`` /
-        # ``sample_rows``.
+        # The new wire contract for INSPECT_AND_CONFIRM edited_values is narrow:
+        #   ``{"columns": list[str]}``
+        # Plugin, options, observed_columns (samples), and warnings are now
+        # server-side knowledge held in step_1_source_intent before the turn is
+        # emitted; the widget never sees them in the response body.
+        #
+        # Shadowing note: ``_advance_step_1`` raises ValueError on null
+        # ``edited_values`` and KeyError on missing ``columns`` — those propagate
+        # as HTTP 500 before reaching here. The null guard and missing-key guard
+        # below are defense-in-depth (locally complete; unreachable as 400 in
+        # normal flow). The isinstance(columns_raw, list) guard IS HTTP-reachable
+        # as 400: _advance_step_1's ``tuple(str(c) for c in columns_raw)`` coercion
+        # silently accepts a scalar string (iterating its characters), so the
+        # dispatcher catches non-list here before that coercion runs.
+        #
+        # EMIT-SITE NOTE: step_1_source_intent must be set before emitting the
+        # INSPECT_AND_CONFIRM turn.  Today no production code path emits this turn
+        # (``_build_get_guided_turn`` always passes blob_inspection=None); the only
+        # emitter is _seed_inspect_and_confirm_history in the integration test suite.
+        # When a real emitter is added, it must
+        #   ``replace(session, step_1_source_intent=SourceIntent(...))``
+        # before returning.
         edited = turn_response["edited_values"]
         if edited is None:
             raise HTTPException(
                 status_code=400,
                 detail="inspect_and_confirm response at step 1 requires edited_values; received null.",
             )
-        missing = {"plugin", "options", "observed_columns", "sample_rows"} - edited.keys()
-        if missing:
+        if "columns" not in edited:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"inspect_and_confirm response at step 1 edited_values missing required keys: {sorted(missing)}; got keys: {sorted(edited.keys())}"
+                    f"inspect_and_confirm response at step 1 edited_values missing required key: 'columns'; got keys: {sorted(edited.keys())}"
                 ),
             )
-        plugin_name = edited["plugin"]
-        if not isinstance(plugin_name, str) or not plugin_name:
-            raise HTTPException(
-                status_code=400,
-                detail=(f"inspect_and_confirm response at step 1 edited_values['plugin'] must be a non-empty string; got {plugin_name!r}"),
-            )
-        options_raw = edited["options"]
-        if not isinstance(options_raw, Mapping):
+        columns_raw = edited["columns"]
+        if not isinstance(columns_raw, list):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"inspect_and_confirm response at step 1 edited_values['options'] must be an object; got {type(options_raw).__name__}"
+                    f"inspect_and_confirm response at step 1 edited_values['columns'] must be a list; got {type(columns_raw).__name__}"
                 ),
             )
-        observed_columns_raw = edited["observed_columns"]
-        if not isinstance(observed_columns_raw, list):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"inspect_and_confirm response at step 1 edited_values['observed_columns'] must be a list; got {type(observed_columns_raw).__name__}"
-                ),
+        # SourceResolved was built by _advance_step_1 and stored in guided.step_1_result.
+        # Unreachable None: _advance_step_1 always sets step_1_result on advance (the
+        # branch is only reached when guided.step is STEP_2_SINK, which only happens
+        # after _advance_step_1 sets step_1_result).  Assert to keep mypy happy and
+        # provide a clear crash message if this invariant is ever violated.
+        if guided.step_1_result is None:
+            raise AssertionError(
+                "inspect_and_confirm post-advance: guided.step_1_result is None after "
+                "_advance_step_1 ran — this is an invariant violation in the state machine."
             )
-        sample_rows_raw = edited["sample_rows"]
-        if not isinstance(sample_rows_raw, list):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"inspect_and_confirm response at step 1 edited_values['sample_rows'] must be a list; got {type(sample_rows_raw).__name__}"
-                ),
-            )
-        resolved = SourceResolved(
-            plugin=plugin_name,
-            options=dict(options_raw),
-            observed_columns=tuple(observed_columns_raw),
-            sample_rows=tuple(dict(r) for r in sample_rows_raw),
-        )
+        resolved = guided.step_1_result
         handler_result = handle_step_1_source(
             state=state,
             session=guided,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -25,6 +25,7 @@ from elspeth.contracts.composer_llm_audit import ComposerLLMCall
 from elspeth.contracts.errors import AuditIntegrityError
 from elspeth.contracts.freeze import deep_thaw
 from elspeth.contracts.secret_scrub import scrub_text_for_audit
+from elspeth.core.canonical import stable_hash
 from elspeth.core.dag.models import GraphValidationError
 from elspeth.plugins.infrastructure.config_base import PluginConfigError
 from elspeth.plugins.infrastructure.manager import PluginNotFoundError
@@ -32,9 +33,36 @@ from elspeth.web.async_workers import run_sync_in_worker
 from elspeth.web.auth.middleware import get_current_user
 from elspeth.web.auth.models import UserIdentity
 from elspeth.web.blobs.protocol import BlobQuotaExceededError, BlobServiceProtocol
+from elspeth.web.catalog.protocol import CatalogService as CatalogServiceProtocol
 from elspeth.web.composer import yaml_generator
-from elspeth.web.composer.audit import audit_envelope, llm_call_audit_envelope
-from elspeth.web.composer.guided.state_machine import GuidedSession
+from elspeth.web.composer.audit import BufferingRecorder, audit_envelope, llm_call_audit_envelope
+from elspeth.web.composer.guided.audit import (
+    emit_dropped_to_freeform,
+    emit_step_advanced,
+    emit_turn_answered,
+    emit_turn_emitted,
+)
+from elspeth.web.composer.guided.emitters import (
+    build_initial_step_1_turn,
+    build_step_1_schema_form_turn,
+    build_step_2_5_recipe_offer_turn,
+    build_step_2_multi_select_turn,
+    build_step_2_schema_form_turn,
+    build_step_2_single_select_turn,
+)
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
+from elspeth.web.composer.guided.recipe_match import match_recipe
+from elspeth.web.composer.guided.state_machine import (
+    GuidedSession,
+    SourceResolved,
+    TerminalReason,
+    TurnRecord,
+    step_advance,
+)
+from elspeth.web.composer.guided.steps import (
+    handle_step_1_source,
+    handle_step_2_5_recipe_apply,
+)
 from elspeth.web.composer.progress import (
     ComposerProgressEvent,
     ComposerProgressRegistry,
@@ -74,11 +102,18 @@ from elspeth.web.sessions.schemas import (
     CreateSessionRequest,
     ForkSessionRequest,
     ForkSessionResponse,
+    GetGuidedResponse,
+    GuidedRespondRequest,
+    GuidedRespondResponse,
+    GuidedSessionResponse,
     MessageWithStateResponse,
     RevertStateRequest,
     RunResponse,
     SendMessageRequest,
     SessionResponse,
+    TerminalStateResponse,
+    TurnPayloadResponse,
+    TurnRecordResponse,
     ValidationEntryResponse,
 )
 
@@ -1512,6 +1547,418 @@ def _initial_composition_state_with_guided_session() -> CompositionState:
         metadata=PipelineMetadata(),
         version=1,
         guided_session=GuidedSession.initial(),
+    )
+
+
+async def _dispatch_guided_respond(
+    *,
+    state: CompositionState,
+    guided: GuidedSession,
+    current_step: GuidedStep,
+    current_turn_type: TurnType,
+    turn_response: Mapping[str, Any],
+    catalog: CatalogServiceProtocol,
+    recorder: BufferingRecorder,
+    user_id: str,
+    data_dir: str | None,
+    session_engine: Any,
+    session_id: str,
+) -> tuple[CompositionState, GuidedSession, Any | None]:
+    """Dispatch a guided respond to the correct step handler and next-turn emitter.
+
+    Pure routing logic: identifies which branch to take based on
+    ``current_step`` and ``current_turn_type``, calls the appropriate
+    side-effect step handler, advances the session pointer, and emits
+    the next turn.
+
+    Returns ``(updated_state, updated_session, next_turn_or_None)``.
+
+    The dispatcher is called only when ``guided.terminal is None``.  The
+    caller checks terminality before and after; the dispatcher never
+    terminates a session (that is ``step_advance``'s responsibility for
+    exit_to_freeform and the step-2.5 recipe-accept path).
+
+    Decision table:
+
+    +-------------------+---------------------------+---------------------------+
+    | step              | current_turn_type          | action                    |
+    +-------------------+---------------------------+---------------------------+
+    | STEP_1_SOURCE     | SINGLE_SELECT             | emit schema_form (source) |
+    | STEP_1_SOURCE     | SCHEMA_FORM               | handle_step_1_source;     |
+    |                   |                           | advance to STEP_2;        |
+    |                   |                           | emit SINGLE_SELECT (sink) |
+    | STEP_1_SOURCE     | INSPECT_AND_CONFIRM       | handle_step_1_source;     |
+    |                   |                           | (step_advance already      |
+    |                   |                           |  advanced to STEP_2);     |
+    |                   |                           | emit SINGLE_SELECT (sink) |
+    | STEP_2_SINK       | SINGLE_SELECT             | emit schema_form (sink)   |
+    | STEP_2_SINK       | SCHEMA_FORM               | emit multi_select_custom  |
+    | STEP_2_SINK       | MULTI_SELECT_WITH_CUSTOM  | handle_step_2_sink;       |
+    |                   |                           | (step_advance advanced     |
+    |                   |                           |  to STEP_2_5);            |
+    |                   |                           | match_recipe;             |
+    |                   |                           | emit recipe_offer or      |
+    |                   |                           | advance to STEP_3         |
+    | STEP_2_5_RECIPE   | RECIPE_OFFER chosen=accept| handled by step_advance   |
+    |                   |                           | (terminal set);           |
+    |                   |                           | caller detects terminal   |
+    | STEP_2_5_RECIPE   | RECIPE_OFFER              | handle_step_2_5 + apply   |
+    |                   | chosen=build_manually     | (step_advance advanced     |
+    |                   |                           |  to STEP_3)               |
+    +-------------------+---------------------------+---------------------------+
+
+    ``step_advance`` has already run; ``guided.step`` may already point to the
+    next step (when step_advance fired a step transition).  The dispatcher uses
+    ``current_step`` (before advance) and ``guided.step`` (after advance) to
+    detect transitions.
+    """
+    from dataclasses import replace as _replace
+
+    next_turn: Any | None = None
+
+    # --- STEP_1_SOURCE intra-step turns ----------------------------------
+    if current_step is GuidedStep.STEP_1_SOURCE and guided.step is GuidedStep.STEP_1_SOURCE:
+        # step_advance did NOT advance the step — intra-step turn.
+        if current_turn_type is TurnType.SINGLE_SELECT:
+            # User picked a source plugin. Emit schema_form for the plugin options.
+            chosen = turn_response["chosen"] or []
+            if not chosen:
+                raise HTTPException(
+                    status_code=400,
+                    detail="single_select response at step 1 must include chosen plugin name.",
+                )
+            plugin_name = str(chosen[0])
+            next_turn = build_step_1_schema_form_turn(plugin_name, catalog)
+            new_record = TurnRecord(
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_turn_emitted(
+                recorder,
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
+
+        if current_turn_type is TurnType.SCHEMA_FORM:
+            # User submitted source options. Call handle_step_1_source to commit.
+            edited = turn_response["edited_values"] or {}
+            resolved = SourceResolved(
+                plugin=str(edited.get("plugin", state.source.plugin if state.source else "")),
+                options=dict(edited.get("options", {})),
+                observed_columns=tuple(edited.get("observed_columns", [])),
+                sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
+            )
+            handler_result = handle_step_1_source(
+                state=state,
+                session=guided,
+                resolved=resolved,
+                catalog=catalog,
+                data_dir=data_dir,
+            )
+            if not handler_result.tool_result.success:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Step 1 source commit failed: {handler_result.tool_result}",
+                )
+            state = handler_result.state
+            # Advance step pointer to STEP_2.
+            guided = _replace(
+                handler_result.session,
+                step=GuidedStep.STEP_2_SINK,
+            )
+            # Emit Step 2 initial turn.
+            next_turn = build_step_2_single_select_turn(catalog)
+            new_record = TurnRecord(
+                step=GuidedStep.STEP_2_SINK,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_step_advanced(
+                recorder,
+                prev=GuidedStep.STEP_1_SOURCE,
+                next_=GuidedStep.STEP_2_SINK,
+                reason="user_advanced",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            emit_turn_emitted(
+                recorder,
+                step=GuidedStep.STEP_2_SINK,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
+
+        # INSPECT_AND_CONFIRM at STEP_1: step_advance already advanced to STEP_2.
+        # But in this branch guided.step is still STEP_1 — step_advance
+        # must have already advanced it.  This case is unreachable (step_advance
+        # advances for INSPECT_AND_CONFIRM → guided.step becomes STEP_2).
+        # Fall through to the post-advance branch below.
+
+    # --- STEP_1_SOURCE → STEP_2_SINK (step_advance fired for INSPECT_AND_CONFIRM)
+    if current_step is GuidedStep.STEP_1_SOURCE and guided.step is GuidedStep.STEP_2_SINK:
+        # step_advance advanced the step. Build SourceResolved from edited_values.
+        edited = turn_response["edited_values"] or {}
+        resolved = SourceResolved(
+            plugin=str(edited.get("plugin", "")),
+            options=dict(edited.get("options", {})),
+            observed_columns=tuple(edited.get("observed_columns", [])),
+            sample_rows=tuple(dict(r) for r in edited.get("sample_rows", [])),
+        )
+        handler_result = handle_step_1_source(
+            state=state,
+            session=guided,
+            resolved=resolved,
+            catalog=catalog,
+            data_dir=data_dir,
+        )
+        if not handler_result.tool_result.success:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Step 1 source commit failed: {handler_result.tool_result}",
+            )
+        state = handler_result.state
+        guided = handler_result.session
+        next_turn = build_step_2_single_select_turn(catalog)
+        new_record = TurnRecord(
+            step=GuidedStep.STEP_2_SINK,
+            turn_type=TurnType(next_turn["type"]),
+            payload_hash=stable_hash(next_turn["payload"]),
+            response_hash=None,
+            emitter="server",
+        )
+        emit_turn_emitted(
+            recorder,
+            step=GuidedStep.STEP_2_SINK,
+            turn_type=TurnType(next_turn["type"]),
+            payload_hash=stable_hash(next_turn["payload"]),
+            payload_payload_id="",
+            emitter="server",
+            composition_version=state.version,
+            actor=user_id,
+        )
+        guided = _replace(guided, history=(*guided.history, new_record))
+        return state, guided, next_turn
+
+    # --- STEP_2_SINK intra-step turns ------------------------------------
+    if current_step is GuidedStep.STEP_2_SINK and guided.step is GuidedStep.STEP_2_SINK:
+        if current_turn_type is TurnType.SINGLE_SELECT:
+            # User picked a sink plugin. Emit schema_form for the plugin options.
+            chosen = turn_response["chosen"] or []
+            if not chosen:
+                raise HTTPException(
+                    status_code=400,
+                    detail="single_select response at step 2 must include chosen plugin name.",
+                )
+            plugin_name = str(chosen[0])
+            next_turn = build_step_2_schema_form_turn(plugin_name, catalog)
+            new_record = TurnRecord(
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_turn_emitted(
+                recorder,
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
+
+        if current_turn_type is TurnType.SCHEMA_FORM:
+            # User filled in sink options. Emit multi_select_with_custom for required fields.
+            # Observed columns come from step_1_result if available.
+            observed_columns: tuple[str, ...] = ()
+            if guided.step_1_result is not None:
+                observed_columns = tuple(guided.step_1_result.observed_columns)
+            next_turn = build_step_2_multi_select_turn(observed_columns)
+            new_record = TurnRecord(
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_turn_emitted(
+                recorder,
+                step=current_step,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
+
+        if current_turn_type is TurnType.MULTI_SELECT_WITH_CUSTOM:
+            # step_advance already advanced the step to STEP_2_5 (via
+            # _advance_step_2). The new sink is encoded in step_advance's
+            # updated session (guided.step_2_result). Run match_recipe.
+            # Emit recipe_offer if matched; else advance to STEP_3 (out of scope).
+            if guided.step_2_result is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Dispatcher invariant: step_2_result must be set after MULTI_SELECT_WITH_CUSTOM advance.",
+                )
+            source = guided.step_1_result
+            sink = guided.step_2_result
+            if source is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Dispatcher invariant: step_1_result must be set before step 2 completes.",
+                )
+            recipe_match = match_recipe(source, sink)
+            if recipe_match is not None:
+                next_turn = build_step_2_5_recipe_offer_turn(recipe_match)
+                new_record = TurnRecord(
+                    step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+                    turn_type=TurnType(next_turn["type"]),
+                    payload_hash=stable_hash(next_turn["payload"]),
+                    response_hash=None,
+                    emitter="server",
+                )
+                emit_turn_emitted(
+                    recorder,
+                    step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+                    turn_type=TurnType(next_turn["type"]),
+                    payload_hash=stable_hash(next_turn["payload"]),
+                    payload_payload_id="",
+                    emitter="server",
+                    composition_version=state.version,
+                    actor=user_id,
+                )
+                guided = _replace(guided, history=(*guided.history, new_record))
+                return state, guided, next_turn
+
+            # No recipe match — advance silently to Step 3 (chain solver).
+            # Step 3 is deferred to Phase 4; return no next_turn.
+            return state, guided, None
+
+    # --- STEP_2_SINK → STEP_2_5 (step_advance fired for MULTI_SELECT_WITH_CUSTOM)
+    # This branch handles the case where step_advance advanced the step AND
+    # we're now at STEP_2_5, but the turn_response is for MULTI_SELECT_WITH_CUSTOM.
+    if current_step is GuidedStep.STEP_2_SINK and guided.step is GuidedStep.STEP_2_5_RECIPE_MATCH:
+        # step_advance already set guided.step_2_result and advanced to STEP_2_5.
+        if guided.step_1_result is None or guided.step_2_result is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Dispatcher invariant: step_1_result and step_2_result must be set.",
+            )
+        source = guided.step_1_result
+        sink = guided.step_2_result
+        recipe_match = match_recipe(source, sink)
+        if recipe_match is not None:
+            next_turn = build_step_2_5_recipe_offer_turn(recipe_match)
+            new_record = TurnRecord(
+                step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                response_hash=None,
+                emitter="server",
+            )
+            emit_turn_emitted(
+                recorder,
+                step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+                turn_type=TurnType(next_turn["type"]),
+                payload_hash=stable_hash(next_turn["payload"]),
+                payload_payload_id="",
+                emitter="server",
+                composition_version=state.version,
+                actor=user_id,
+            )
+            guided = _replace(guided, history=(*guided.history, new_record))
+            return state, guided, next_turn
+
+        return state, guided, None
+
+    # --- STEP_2_5_RECIPE_MATCH turns ------------------------------------
+    if current_step is GuidedStep.STEP_2_5_RECIPE_MATCH:
+        chosen = list(turn_response["chosen"] or [])
+        if chosen == ["accept"]:
+            # User accepted the recipe. Extract the slots from edited_values
+            # (user may have filled in required slots).
+            edited = turn_response["edited_values"] or {}
+            # Reconstruct slots from the last RECIPE_OFFER turn's payload
+            # and overlay with user-edited values.
+            recipe_turn_record = next(
+                (r for r in reversed(guided.history) if r.step == GuidedStep.STEP_2_5_RECIPE_MATCH),
+                None,
+            )
+            if recipe_turn_record is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Dispatcher invariant: recipe_offer TurnRecord missing at step 2.5.",
+                )
+
+            # The slots must be passed as edited_values from the client.
+            # The recipe_offer turn pre-populates partial slots; the user fills
+            # the rest via the recipe_offer form and sends them back in edited_values.
+            from elspeth.web.composer.guided.recipe_match import RecipeMatch as _RecipeMatch
+
+            recipe_name = str(edited.get("recipe_name", ""))
+            slots = dict(edited.get("slots", {}))
+            match = _RecipeMatch(recipe_name=recipe_name, slots=slots)
+
+            handler_result = handle_step_2_5_recipe_apply(
+                state=state,
+                session=guided,
+                match=match,
+                catalog=catalog,
+                data_dir=data_dir,
+                session_engine=session_engine,
+                session_id=session_id,
+            )
+            if not handler_result.tool_result.success:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Recipe application failed: {handler_result.tool_result}",
+                )
+            state = handler_result.state
+            guided = handler_result.session
+            # terminal is now set on guided.terminal (TerminalKind.COMPLETED).
+            return state, guided, None
+
+        if chosen == ["build_manually"]:
+            # step_advance already advanced to STEP_3.
+            # Step 3 chain solver is deferred to Phase 4.
+            return state, guided, None
+
+        raise HTTPException(
+            status_code=400,
+            detail=f"recipe_offer response must have chosen=['accept'] or chosen=['build_manually'], got {chosen!r}.",
+        )
+
+    # Unhandled branch — this is a dispatcher gap, not a user error.
+    raise AssertionError(
+        f"_dispatch_guided_respond: unhandled branch "
+        f"current_step={current_step!r}, current_turn_type={current_turn_type!r}, "
+        f"guided.step={guided.step!r}"
     )
 
 
@@ -3087,4 +3534,408 @@ def create_session_router() -> APIRouter:
             composition_state=_state_response(copied_state) if copied_state else None,
         )
 
+    @router.get("/{session_id}/guided", response_model=GetGuidedResponse)
+    async def get_guided(
+        session_id: UUID,
+        request: Request,
+        user: UserIdentity = Depends(get_current_user),  # noqa: B008
+    ) -> GetGuidedResponse:
+        """Return the current guided-mode state for a session.
+
+        **Mutating on first visit:** if the current step has no emitted
+        TurnRecord in the guided session history, a turn is built and
+        persisted.  Subsequent fetches are idempotent — the existing
+        TurnRecord's payload_hash is returned verbatim.
+
+        If the session has no existing CompositionState, one is created
+        with ``GuidedSession.initial()`` attached (spec §5.2 default-guided
+        invariant).
+
+        Returns 404 if the session does not exist or does not belong to
+        the requesting user.
+        Returns 400 if the session's composition state has no guided_session
+        attached (freeform session — use /api/sessions/{id}/messages instead).
+        """
+        await _verify_session_ownership(session_id, user, request)
+        service: SessionServiceProtocol = request.app.state.session_service
+        catalog: CatalogServiceProtocol = request.app.state.catalog_service
+        recorder = BufferingRecorder()
+
+        compose_lock = await _get_session_compose_lock_registry(request).get_lock(str(session_id))
+        async with compose_lock:
+            # Load or create CompositionState.
+            state_record = await service.get_current_state(session_id)
+            if state_record is None:
+                state = _initial_composition_state_with_guided_session()
+            else:
+                state = _state_from_record(state_record)
+
+            # Reject freeform sessions.
+            if state.guided_session is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
+                )
+
+            guided = state.guided_session
+            current_step = guided.step
+
+            # Idempotency check: if this step already has an emitted TurnRecord,
+            # return the existing payload without re-emitting.
+            existing_record_for_step: TurnRecord | None = next(
+                (r for r in reversed(guided.history) if r.step == current_step),
+                None,
+            )
+
+            # Always build the turn (deterministic from current state + catalog).
+            # Building is cheap and allows idempotent re-fetch to return the
+            # same payload without needing a payload store.
+            turn = build_initial_step_1_turn(
+                state,
+                blob_inspection=None,
+                catalog=catalog,
+            )
+            turn_type = TurnType(turn["type"])
+            payload_hash = stable_hash(turn["payload"])
+
+            state_record_out: CompositionStateRecord | None = state_record
+            if existing_record_for_step is None:
+                # First fetch for this step: record TurnRecord, persist, emit audit.
+                new_record = TurnRecord(
+                    step=current_step,
+                    turn_type=turn_type,
+                    payload_hash=payload_hash,
+                    response_hash=None,
+                    emitter="server",
+                )
+                from dataclasses import replace as _replace
+
+                new_guided = _replace(guided, history=(*guided.history, new_record))
+                new_state = _replace(state, guided_session=new_guided)
+
+                # Persist state with updated guided_session in composer_meta.
+                # Preserve any existing composer_meta keys (e.g. repair_turns_used).
+                existing_meta: dict[str, Any] = {}
+                if state_record is not None and state_record.composer_meta is not None:
+                    existing_meta = dict(deep_thaw(state_record.composer_meta))
+                new_composer_meta = {**existing_meta, "guided_session": new_guided.to_dict()}
+
+                state_d = new_state.to_dict()
+                state_data = CompositionStateData(
+                    source=state_d["source"],
+                    nodes=state_d["nodes"],
+                    edges=state_d["edges"],
+                    outputs=state_d["outputs"],
+                    metadata_=state_d["metadata"],
+                    is_valid=False,
+                    validation_errors=None,
+                    composer_meta=new_composer_meta,
+                )
+                state_record_out = await service.save_composition_state(session_id, state_data)
+
+                # Emit audit event.
+                emit_turn_emitted(
+                    recorder,
+                    step=current_step,
+                    turn_type=turn_type,
+                    payload_hash=payload_hash,
+                    payload_payload_id="",  # No payload store for server-emitted turns yet.
+                    emitter="server",
+                    composition_version=new_state.version,
+                    actor=user.user_id,
+                )
+
+                # Drain recorder into the DB as role=tool audit rows.
+                tool_invocations = recorder.invocations
+                if tool_invocations:
+                    await _persist_tool_invocations(
+                        service,
+                        session_id,
+                        tool_invocations,
+                        state_record_out.id,
+                    )
+
+                guided = new_guided
+
+            # Build response.  On re-fetch the same turn is returned (deterministic
+            # rebuild) and the payload_hash matches what was recorded on first visit.
+            terminal = guided.terminal
+            return GetGuidedResponse(
+                guided_session=GuidedSessionResponse(
+                    step=guided.step.value,
+                    history=[
+                        TurnRecordResponse(
+                            step=r.step.value,
+                            turn_type=r.turn_type.value,
+                            payload_hash=r.payload_hash,
+                            response_hash=r.response_hash,
+                            emitter=r.emitter,
+                        )
+                        for r in guided.history
+                    ],
+                    terminal=TerminalStateResponse(
+                        kind=terminal.kind.value,
+                        reason=terminal.reason.value if terminal.reason is not None else None,
+                        pipeline_yaml=terminal.pipeline_yaml,
+                    )
+                    if terminal is not None
+                    else None,
+                ),
+                next_turn=TurnPayloadResponse(
+                    type=turn["type"],
+                    step_index=turn["step_index"],
+                    payload=dict(turn["payload"]),
+                ),
+                terminal=TerminalStateResponse(
+                    kind=terminal.kind.value,
+                    reason=terminal.reason.value if terminal.reason is not None else None,
+                    pipeline_yaml=terminal.pipeline_yaml,
+                )
+                if terminal is not None
+                else None,
+                composition_state=_state_response(state_record_out) if state_record_out is not None else None,
+            )
+
+    @router.post("/{session_id}/guided/respond", response_model=GuidedRespondResponse)
+    async def post_guided_respond(
+        session_id: UUID,
+        body: GuidedRespondRequest,
+        request: Request,
+        user: UserIdentity = Depends(get_current_user),  # noqa: B008
+    ) -> GuidedRespondResponse:
+        """Submit a user response to the current guided-mode turn.
+
+        **Dispatcher:** Identifies the current turn type from the last
+        ``TurnRecord`` in the session history, applies the response via
+        ``step_advance`` (pure), runs any required side-effect step handler,
+        persists the updated state, and emits audit events.
+
+        Returns the updated ``guided_session``, the next ``next_turn`` (or
+        ``None`` if the session has reached a terminal state), and the
+        ``terminal`` payload (or ``None`` while still active).
+
+        Raises 400 if the session has no ``guided_session`` attached.
+        Raises 409 if the guided session is already in a terminal state.
+        Raises 404 if the session does not exist or belong to the requesting user.
+        """
+        await _verify_session_ownership(session_id, user, request)
+        service: SessionServiceProtocol = request.app.state.session_service
+        catalog: CatalogServiceProtocol = request.app.state.catalog_service
+        recorder = BufferingRecorder()
+
+        compose_lock = await _get_session_compose_lock_registry(request).get_lock(str(session_id))
+        async with compose_lock:
+            # Load state.
+            state_record = await service.get_current_state(session_id)
+            if state_record is None:
+                state = _initial_composition_state_with_guided_session()
+            else:
+                state = _state_from_record(state_record)
+
+            if state.guided_session is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Session is not in guided mode. Use /api/sessions/{id}/messages.",
+                )
+
+            guided = state.guided_session
+
+            # Reject if session already terminal.
+            if guided.terminal is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Guided session is already in a terminal state. No further responses accepted.",
+                )
+
+            # Derive the current turn type from the last TurnRecord for the
+            # current step.  Crash if history is empty — the caller must have
+            # fetched GET /guided first (which seeds the initial TurnRecord).
+            current_step = guided.step
+            existing_record: TurnRecord | None = next(
+                (r for r in reversed(guided.history) if r.step == current_step),
+                None,
+            )
+            if existing_record is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=("No turn has been emitted for the current step. Fetch GET /api/sessions/{id}/guided first."),
+                )
+
+            current_turn_type = existing_record.turn_type
+
+            # Build the TurnResponse dict from the request body.
+            from dataclasses import replace as _replace
+
+            turn_response: TurnResponse = {
+                "chosen": body.chosen,
+                "edited_values": body.edited_values,
+                "custom_inputs": body.custom_inputs,
+                "accepted_step_index": body.accepted_step_index,
+                "edit_step_index": body.edit_step_index,
+                "control_signal": body.control_signal,
+            }
+
+            # Record the response_hash on the existing TurnRecord.
+            response_hash = stable_hash(turn_response)
+            updated_record = _replace(existing_record, response_hash=response_hash)
+            # Rebuild history tuple with response_hash stamped on this record.
+            updated_history = tuple(updated_record if r is existing_record else r for r in guided.history)
+            guided = _replace(guided, history=updated_history)
+
+            # Emit guided_turn_answered audit event.
+            emit_turn_answered(
+                recorder,
+                step=current_step,
+                turn_type=current_turn_type,
+                response_hash=response_hash,
+                response_payload_id="",
+                control_signal=body.control_signal,
+                composition_version=state.version,
+                actor=user.user_id,
+            )
+
+            # Run step_advance (pure — no I/O).
+            new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
+                guided,
+                turn_response,
+                current_turn_type=current_turn_type,
+            )
+
+            # Fan directives to emit_* helpers.
+            for directive in directives:
+                if directive.tool_name == "guided_step_advanced":
+                    args = dict(directive.arguments)
+                    emit_step_advanced(
+                        recorder,
+                        prev=GuidedStep(args["prev_step"]),
+                        next_=GuidedStep(args["next_step"]),
+                        reason=args["reason"],
+                        composition_version=state.version,
+                        actor=user.user_id,
+                    )
+                elif directive.tool_name == "guided_dropped_to_freeform":
+                    args = dict(directive.arguments)
+                    emit_dropped_to_freeform(
+                        recorder,
+                        prev=GuidedStep(args["prev_step"]),
+                        drop_reason=TerminalReason(args["drop_reason"]),
+                        validation_result=args.get("validation_result"),
+                        composition_version=state.version,
+                        actor=user.user_id,
+                    )
+
+            guided = new_guided
+            terminal = terminal_from_advance
+
+            # Run side-effect dispatcher if the session is not yet terminal.
+            # The dispatcher calls step handlers (handle_step_1_source,
+            # handle_step_2_sink, handle_step_2_5_recipe_apply) and emits
+            # the next turn based on the updated step + turn type.
+            next_turn: Any | None = None
+            settings = request.app.state.settings
+            data_dir: str | None = str(settings.data_dir) if settings.data_dir else None
+            session_engine = getattr(request.app.state, "session_engine", None)
+
+            if terminal is None:
+                state, guided, next_turn = await _dispatch_guided_respond(
+                    state=state,
+                    guided=guided,
+                    current_step=current_step,
+                    current_turn_type=current_turn_type,
+                    turn_response=turn_response,
+                    catalog=catalog,
+                    recorder=recorder,
+                    user_id=user.user_id,
+                    data_dir=data_dir,
+                    session_engine=session_engine,
+                    session_id=str(session_id),
+                )
+                terminal = guided.terminal
+
+            # Persist updated state.
+            new_state = _replace(state, guided_session=guided)
+            existing_meta: dict[str, Any] = {}
+            if state_record is not None and state_record.composer_meta is not None:
+                existing_meta = dict(deep_thaw(state_record.composer_meta))
+            new_composer_meta = {**existing_meta, "guided_session": guided.to_dict()}
+
+            state_d = new_state.to_dict()
+            state_data = CompositionStateData(
+                source=state_d["source"],
+                nodes=state_d["nodes"],
+                edges=state_d["edges"],
+                outputs=state_d["outputs"],
+                metadata_=state_d["metadata"],
+                is_valid=False,
+                validation_errors=None,
+                composer_meta=new_composer_meta,
+            )
+            state_record_out = await service.save_composition_state(session_id, state_data)
+
+            # Drain recorder.
+            tool_invocations = recorder.invocations
+            if tool_invocations:
+                await _persist_tool_invocations(
+                    service,
+                    session_id,
+                    tool_invocations,
+                    state_record_out.id,
+                )
+
+            return GuidedRespondResponse(
+                guided_session=GuidedSessionResponse(
+                    step=guided.step.value,
+                    history=[
+                        TurnRecordResponse(
+                            step=r.step.value,
+                            turn_type=r.turn_type.value,
+                            payload_hash=r.payload_hash,
+                            response_hash=r.response_hash,
+                            emitter=r.emitter,
+                        )
+                        for r in guided.history
+                    ],
+                    terminal=TerminalStateResponse(
+                        kind=terminal.kind.value,
+                        reason=terminal.reason.value if terminal.reason is not None else None,
+                        pipeline_yaml=terminal.pipeline_yaml,
+                    )
+                    if terminal is not None
+                    else None,
+                ),
+                next_turn=TurnPayloadResponse(
+                    type=next_turn["type"],
+                    step_index=next_turn["step_index"],
+                    payload=dict(next_turn["payload"]),
+                )
+                if next_turn is not None
+                else None,
+                terminal=TerminalStateResponse(
+                    kind=terminal.kind.value,
+                    reason=terminal.reason.value if terminal.reason is not None else None,
+                    pipeline_yaml=terminal.pipeline_yaml,
+                )
+                if terminal is not None
+                else None,
+                composition_state=_state_response(state_record_out),
+            )
+
     return router
+
+
+def _guided_step_index(step: Any) -> int:
+    """Map a GuidedStep to its 0-based integer index.
+
+    Mirrors ``emitters._step_index``; defined here so the route handler
+    can reconstruct a re-fetch Turn without importing the emitters module
+    just for this utility.
+    """
+    from elspeth.web.composer.guided.protocol import GuidedStep
+
+    _ORDER: tuple[GuidedStep, ...] = (
+        GuidedStep.STEP_1_SOURCE,
+        GuidedStep.STEP_2_SINK,
+        GuidedStep.STEP_2_5_RECIPE_MATCH,
+        GuidedStep.STEP_3_TRANSFORMS,
+    )
+    return _ORDER.index(step)

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -34,6 +34,7 @@ from elspeth.web.auth.models import UserIdentity
 from elspeth.web.blobs.protocol import BlobQuotaExceededError, BlobServiceProtocol
 from elspeth.web.composer import yaml_generator
 from elspeth.web.composer.audit import audit_envelope, llm_call_audit_envelope
+from elspeth.web.composer.guided.state_machine import GuidedSession
 from elspeth.web.composer.progress import (
     ComposerProgressEvent,
     ComposerProgressRegistry,
@@ -1494,6 +1495,26 @@ async def _handle_runtime_preflight_failure(
     return response_body
 
 
+def _initial_composition_state_with_guided_session() -> CompositionState:
+    """Construct a fresh CompositionState with a guided-mode session attached.
+
+    Per spec §5.2 / errata C7: new sessions default to guided. Every lazy-
+    create branch in this module must use this helper rather than building
+    CompositionState directly, so the default-guided invariant holds
+    uniformly across endpoints (send_message, recompose, the future
+    guided/respond endpoint added in Task 3.5).
+    """
+    return CompositionState(
+        source=None,
+        nodes=(),
+        edges=(),
+        outputs=(),
+        metadata=PipelineMetadata(),
+        version=1,
+        guided_session=GuidedSession.initial(),
+    )
+
+
 def create_session_router() -> APIRouter:
     """Create the session router with /api/sessions prefix."""
     router = APIRouter(prefix="/api/sessions", tags=["sessions"])
@@ -1660,14 +1681,7 @@ def create_session_router() -> APIRouter:
             #    for pre-send provenance (AD-7: user msg records what user saw).
             state_record = await service.get_current_state(session.id)
             if state_record is None:
-                state = CompositionState(
-                    source=None,
-                    nodes=(),
-                    edges=(),
-                    outputs=(),
-                    metadata=PipelineMetadata(),
-                    version=1,
-                )
+                state = _initial_composition_state_with_guided_session()
                 pre_send_state_id: UUID | None = None
             else:
                 state = _state_from_record(state_record)
@@ -2214,14 +2228,7 @@ def create_session_router() -> APIRouter:
             # Load current state
             state_record = await service.get_current_state(session.id)
             if state_record is None:
-                state = CompositionState(
-                    source=None,
-                    nodes=(),
-                    edges=(),
-                    outputs=(),
-                    metadata=PipelineMetadata(),
-                    version=1,
-                )
+                state = _initial_composition_state_with_guided_session()
                 pre_send_state_id: UUID | None = None
             else:
                 state = _state_from_record(state_record)

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -52,6 +52,7 @@ from elspeth.web.composer.guided.emitters import (
     build_step_2_single_select_turn,
     build_step_3_propose_chain_turn,
 )
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.recipe_match import match_recipe
 from elspeth.web.composer.guided.state_machine import (
@@ -4337,11 +4338,21 @@ def create_session_router() -> APIRouter:
             )
 
             # Run step_advance (pure — no I/O).
-            new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
-                guided,
-                turn_response,
-                current_turn_type=current_turn_type,
-            )
+            # InvariantError from step_advance or the downstream dispatcher
+            # indicates a server-side bug — propagate as HTTP 500 with a
+            # "Server invariant violated" prefix so it's distinguishable from
+            # client-fault HTTP 400s in dashboards and on-call runbooks.
+            try:
+                new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
+                    guided,
+                    turn_response,
+                    current_turn_type=current_turn_type,
+                )
+            except InvariantError as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Server invariant violated: {exc}",
+                ) from exc
 
             # Fan directives to emit_* helpers.
             for directive in directives:
@@ -4379,19 +4390,25 @@ def create_session_router() -> APIRouter:
             session_engine = request.app.state.session_engine
 
             if terminal is None:
-                state, guided, next_turn = await _dispatch_guided_respond(
-                    state=state,
-                    guided=guided,
-                    current_step=current_step,
-                    current_turn_type=current_turn_type,
-                    turn_response=turn_response,
-                    catalog=catalog,
-                    recorder=recorder,
-                    user_id=user.user_id,
-                    data_dir=data_dir,
-                    session_engine=session_engine,
-                    session_id=str(session_id),
-                )
+                try:
+                    state, guided, next_turn = await _dispatch_guided_respond(
+                        state=state,
+                        guided=guided,
+                        current_step=current_step,
+                        current_turn_type=current_turn_type,
+                        turn_response=turn_response,
+                        catalog=catalog,
+                        recorder=recorder,
+                        user_id=user.user_id,
+                        data_dir=data_dir,
+                        session_engine=session_engine,
+                        session_id=str(session_id),
+                    )
+                except InvariantError as exc:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Server invariant violated: {exc}",
+                    ) from exc
                 terminal = guided.terminal
 
             # Persist updated state.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -2039,7 +2039,10 @@ async def _dispatch_guided_respond(
                 composition_version=state.version,
                 actor=user_id,
             )
-            guided = _replace(guided, history=(*guided.history, new_record))
+            # Stage the offered RecipeMatch so the accept branch can verify
+            # the client-supplied recipe_name matches what was actually offered.
+            # Cleared (set to None) atomically when the acceptance is consumed.
+            guided = _replace(guided, history=(*guided.history, new_record), step_2_5_recipe_offer=recipe_match)
             return state, guided, next_turn
 
         # No recipe match — solve the chain via the LLM and emit propose_chain.
@@ -2116,16 +2119,37 @@ async def _dispatch_guided_respond(
                     status_code=400,
                     detail=(f"recipe_offer ['accept'] edited_values['slots'] must be an object; got {type(slots_raw).__name__}"),
                 )
-            # Reconstruct slots from the last RECIPE_OFFER turn's payload
-            # and overlay with user-edited values.
-            recipe_turn_record = next(
-                (r for r in reversed(guided.history) if r.step == GuidedStep.STEP_2_5_RECIPE_MATCH),
-                None,
-            )
-            if recipe_turn_record is None:
+
+            # Binding check: the client-supplied recipe_name must match the
+            # recipe that was actually offered for this step.  ``step_2_5_recipe_offer``
+            # is written by the server immediately before emitting the RECIPE_OFFER
+            # turn (Option A staging pattern, mirrors step_2_sink_intent).  A missing
+            # offer means the session was never in the recipe-offer state — the client
+            # is sending an accept without a prior offer (protocol violation or crafted
+            # request).  A mismatched recipe_name means the client is trying to accept
+            # a different recipe than the one offered — also rejected with 400.
+            #
+            # Slots are operator-editable by design (the operator fills unsatisfied
+            # required slots and may rubber-stamp / override pre-fills); the binding
+            # check does NOT compare slot values, only recipe_name.
+            offered = guided.step_2_5_recipe_offer
+            if offered is None:
                 raise HTTPException(
-                    status_code=500,
-                    detail="Dispatcher invariant: recipe_offer TurnRecord missing at step 2.5.",
+                    status_code=400,
+                    detail=(
+                        "recipe_offer ['accept'] received but no recipe was staged for this session "
+                        "(step_2_5_recipe_offer is None — the session has not reached the recipe-offer state "
+                        "or the offer was already consumed)."
+                    ),
+                )
+            if recipe_name != offered.recipe_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"recipe_offer ['accept'] recipe_name mismatch: "
+                        f"client sent {recipe_name!r} but the server offered {offered.recipe_name!r}. "
+                        "Accept must reference the recipe that was offered."
+                    ),
                 )
 
             # The slots must be passed as edited_values from the client.
@@ -2140,6 +2164,9 @@ async def _dispatch_guided_respond(
             # at apply time ``handle_step_2_5_recipe_apply`` consumes only
             # ``recipe_name`` and ``slots``, so an empty mapping is correct.
             match = _RecipeMatch(recipe_name=recipe_name, slots=slots, unsatisfied_slots={})
+            # Clear the staged offer atomically before passing to the handler
+            # so it cannot be re-read by a later step.
+            guided = _replace(guided, step_2_5_recipe_offer=None)
 
             handler_result = handle_step_2_5_recipe_apply(
                 state=state,
@@ -4151,7 +4178,23 @@ def create_session_router() -> APIRouter:
                 )
                 from dataclasses import replace as _replace
 
+                # If this is the STEP_2_5_RECIPE_MATCH step, populate
+                # step_2_5_recipe_offer so the POST /respond accept branch
+                # can verify the client-supplied recipe_name against the offer.
+                # This covers the GET-before-POST flow (user reloads the page
+                # while the session is at the recipe-offer step).
+                if (
+                    current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
+                    and guided.step_1_result is not None
+                    and guided.step_2_result is not None
+                ):
+                    staged_offer = match_recipe(guided.step_1_result, guided.step_2_result)
+                else:
+                    staged_offer = None
+
                 new_guided = _replace(guided, history=(*guided.history, new_record))
+                if staged_offer is not None:
+                    new_guided = _replace(new_guided, step_2_5_recipe_offer=staged_offer)
                 new_state = _replace(state, guided_session=new_guided)
 
                 # Persist state with updated guided_session in composer_meta.
@@ -4197,6 +4240,44 @@ def create_session_router() -> APIRouter:
                     )
 
                 guided = new_guided
+
+            # Idempotency-path repair: if the session is at STEP_2_5_RECIPE_MATCH
+            # and the staged offer is absent (persisted before the step_2_5_recipe_offer
+            # field was introduced), re-populate it and persist the repaired state so
+            # the POST /respond accept branch can verify the recipe_name.  Without this
+            # repair, sessions that reached STEP_2_5 before this field was added would
+            # always fail the accept binding check with 400.  The offer is
+            # deterministically reconstructable from (step_1_result, step_2_result).
+            if (
+                existing_record_for_step is not None
+                and current_step is GuidedStep.STEP_2_5_RECIPE_MATCH
+                and guided.step_2_5_recipe_offer is None
+                and guided.step_1_result is not None
+                and guided.step_2_result is not None
+            ):
+                recovered_offer = match_recipe(guided.step_1_result, guided.step_2_result)
+                if recovered_offer is not None:
+                    from dataclasses import replace as _replace_repair
+
+                    repaired_guided = _replace_repair(guided, step_2_5_recipe_offer=recovered_offer)
+                    repaired_state = _replace_repair(state, guided_session=repaired_guided)
+                    existing_meta_repair: dict[str, Any] = {}
+                    if state_record is not None and state_record.composer_meta is not None:
+                        existing_meta_repair = dict(deep_thaw(state_record.composer_meta))
+                    repair_meta = {**existing_meta_repair, "guided_session": repaired_guided.to_dict()}
+                    repaired_state_d = repaired_state.to_dict()
+                    repair_data = CompositionStateData(
+                        source=repaired_state_d["source"],
+                        nodes=repaired_state_d["nodes"],
+                        edges=repaired_state_d["edges"],
+                        outputs=repaired_state_d["outputs"],
+                        metadata_=repaired_state_d["metadata"],
+                        is_valid=False,
+                        validation_errors=None,
+                        composer_meta=repair_meta,
+                    )
+                    state_record_out = await service.save_composition_state(session_id, repair_data)
+                    guided = repaired_guided
 
             # Build response.  On re-fetch the same turn is returned (deterministic
             # rebuild) and the payload_hash matches what was recorded on first visit.

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -2090,15 +2090,15 @@ async def _dispatch_guided_respond(
                     # Repair also failed. Mark solver exhausted and auto-drop to freeform.
                     # Build the validation_result dict from the repair failure (Tier 1
                     # data — only real fields from ToolResult, no fabrication).
+                    # The repair always runs on the auto-drop path; validation_result is
+                    # always present per spec §9.1 (set when drop_reason="solver_exhausted").
+                    # An empty errors list is real audit data (the validator rejected without
+                    # producing structured errors), not fabrication.
                     repair_validation = repair_result.tool_result.validation
-                    validation_result_payload: dict[str, Any] | None = (
-                        {
-                            "is_valid": repair_validation.is_valid,
-                            "errors": [e.to_dict() for e in repair_validation.errors],
-                        }
-                        if repair_validation.errors
-                        else None
-                    )
+                    validation_result_payload: dict[str, Any] = {
+                        "is_valid": repair_validation.is_valid,
+                        "errors": [e.to_dict() for e in repair_validation.errors],
+                    }
 
                     new_guided, _terminal, directives = mark_solver_exhausted(
                         session=guided,

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -59,6 +59,7 @@ from elspeth.web.composer.guided.state_machine import (
     SourceResolved,
     TerminalReason,
     TurnRecord,
+    mark_solver_exhausted,
     step_advance,
 )
 from elspeth.web.composer.guided.steps import (
@@ -2043,10 +2044,80 @@ async def _dispatch_guided_respond(
                     session_id=session_id,
                 )
                 if not handler_result.tool_result.success:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Step 3 chain commit failed: {handler_result.tool_result}",
+                    # Initial commit failed. Attempt one LLM repair: feed the
+                    # validation errors back as a system-prompt addendum and
+                    # ask the LLM to produce a corrected chain.
+                    #
+                    # Validation error text is Tier 1 audit data — taken verbatim
+                    # from the ToolResult; no paraphrasing or fabrication.
+                    failed_result = handler_result.tool_result
+                    repair_context_lines = [e.message for e in failed_result.validation.errors]
+                    if not repair_context_lines and failed_result.data is not None:
+                        # No validation errors but a data-layer error message;
+                        # use it verbatim so the LLM sees the actual fault.
+                        raw_data = dict(failed_result.data)
+                        if "error" in raw_data:
+                            repair_context_lines = [str(raw_data["error"])]
+                    repair_context = "\n".join(repair_context_lines) or str(failed_result.validation)
+
+                    # Obtain source/sink from the guided session for the repair call.
+                    # Both must be non-None because Step 3 can only be reached after
+                    # Steps 1 and 2 commit successfully (dispatcher invariant).
+                    assert guided.step_1_result is not None, "repair: step_1_result missing"
+                    assert guided.step_2_result is not None, "repair: step_2_result missing"
+                    repair_proposal = await solve_chain(
+                        source=guided.step_1_result,
+                        sink=guided.step_2_result,
+                        recipe_match=None,
+                        repair_context=repair_context,
                     )
+                    repair_result = handle_step_3_chain_accept(
+                        # state is the original pre-attempt state — _execute_set_pipeline
+                        # is validate-then-mutate: on failure the state is untouched,
+                        # so handler_result.state is the same object as `state`.
+                        state=state,
+                        session=guided,
+                        proposal=repair_proposal,
+                        catalog=catalog,
+                        data_dir=data_dir,
+                        session_engine=session_engine,
+                        session_id=session_id,
+                    )
+                    if repair_result.tool_result.success:
+                        # Repair succeeded: wizard completes normally.
+                        return repair_result.state, repair_result.session, None
+
+                    # Repair also failed. Mark solver exhausted and auto-drop to freeform.
+                    # Build the validation_result dict from the repair failure (Tier 1
+                    # data — only real fields from ToolResult, no fabrication).
+                    repair_validation = repair_result.tool_result.validation
+                    validation_result_payload: dict[str, Any] | None = (
+                        {
+                            "is_valid": repair_validation.is_valid,
+                            "errors": [e.to_dict() for e in repair_validation.errors],
+                        }
+                        if repair_validation.errors
+                        else None
+                    )
+
+                    new_guided, _terminal, directives = mark_solver_exhausted(
+                        session=guided,
+                        validation_result=validation_result_payload,
+                    )
+                    for directive in directives:
+                        if directive.tool_name == "guided_dropped_to_freeform":
+                            args = dict(directive.arguments)
+                            emit_dropped_to_freeform(
+                                recorder,
+                                prev=GuidedStep(args["prev_step"]),
+                                drop_reason=TerminalReason(args["drop_reason"]),
+                                validation_result=args["validation_result"],
+                                composition_version=state.version,
+                                actor=user_id,
+                            )
+                    # Return 200 with terminal — auto-drop is a clean wizard outcome.
+                    return state, new_guided, None
+
                 # handler_result.session.terminal is COMPLETED on success.
                 return handler_result.state, handler_result.session, None
             if chosen == ["reject"]:

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -4616,12 +4616,31 @@ def create_session_router() -> APIRouter:
             # Run step_advance (pure — no I/O).
             # InvariantError indicates a server-side bug (e.g. stamped an
             # invalid turn type on a history record) — propagate as HTTP 500
-            # with a "Server invariant violated" prefix so it's distinguishable
-            # from client-fault HTTP 400s in dashboards and on-call runbooks.
+            # with a static message so the response body never carries
+            # ``str(exc)``. ``InvariantError`` raised from ``from_dict`` call
+            # sites embeds ``{d!r}`` of the corrupted Tier-1 record, which
+            # includes Tier-3 ``sample_rows`` source data. Interpolating that
+            # into the HTTP detail field would have leaked user/PII content
+            # into the JSON 500 body returned to the browser (PR #37 review
+            # finding B1).
+            #
+            # Diagnostic trace is preserved via ``slog.error`` under the
+            # audit-system-failure exemption (CLAUDE.md primacy order: when
+            # ``from_dict`` itself fails, the audit-derivation path can't be
+            # trusted to record the failure consistently). The slog event
+            # carries ``exc_class`` + ``frames`` only — never the message
+            # string, since for ``{d!r}`` -bearing InvariantErrors that text
+            # is the leak vector. Sibling helpers in this file follow the
+            # same "class + frames, no message" pattern when the exception
+            # carries Tier-bearing strings (see ``_safe_frame_strings`` docs).
+            #
             # ValueError indicates a client-supplied payload violated the
             # guided-mode protocol contract (e.g. unexpected chosen value on a
             # recipe_offer turn, or null edited_values on inspect_and_confirm)
             # — propagate as HTTP 400 so the caller can correct the request.
+            # ValueError is not raised by ``from_dict`` and does not embed
+            # ``{d!r}`` of Tier-1 records, so interpolating ``str(exc)`` here
+            # is safe.
             try:
                 new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
                     guided,
@@ -4629,9 +4648,17 @@ def create_session_router() -> APIRouter:
                     current_turn_type=current_turn_type,
                 )
             except InvariantError as exc:
+                slog.error(
+                    "guided.invariant_violated",
+                    session_id=str(session_id),
+                    user_id=user.user_id,
+                    exc_class=type(exc).__name__,
+                    site="step_advance",
+                    frames=_safe_frame_strings(exc),
+                )
                 raise HTTPException(
                     status_code=500,
-                    detail=f"Server invariant violated: {exc}",
+                    detail="Server invariant violated. See application audit log for diagnostic detail.",
                 ) from exc
             except ValueError as exc:
                 raise HTTPException(
@@ -4691,9 +4718,22 @@ def create_session_router() -> APIRouter:
                         model=settings.composer_model,
                     )
                 except InvariantError as exc:
+                    # Same B1-sanitization rationale as the step_advance
+                    # catch above: ``str(exc)`` from a ``from_dict`` site
+                    # embeds ``{d!r}`` of the corrupted Tier-1 record
+                    # including Tier-3 ``sample_rows``. Static detail; slog
+                    # carries exc_class + frames only.
+                    slog.error(
+                        "guided.invariant_violated",
+                        session_id=str(session_id),
+                        user_id=user.user_id,
+                        exc_class=type(exc).__name__,
+                        site="dispatch_guided_respond",
+                        frames=_safe_frame_strings(exc),
+                    )
                     raise HTTPException(
                         status_code=500,
-                        detail=f"Server invariant violated: {exc}",
+                        detail="Server invariant violated. See application audit log for diagnostic detail.",
                     ) from exc
                 except ValueError as exc:
                     # ValueError from inside the dispatcher indicates a

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -54,7 +54,7 @@ from elspeth.web.composer.guided.emitters import (
     build_step_3_propose_chain_turn,
 )
 from elspeth.web.composer.guided.errors import InvariantError
-from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
+from elspeth.web.composer.guided.protocol import ControlSignal, GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.recipe_match import match_recipe
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
@@ -1557,6 +1557,29 @@ def _initial_composition_state_with_guided_session() -> CompositionState:
         version=1,
         guided_session=GuidedSession.initial(),
     )
+
+
+def _validate_control_signal(raw: str | None) -> None:
+    """Validate ``control_signal`` against the closed :class:`ControlSignal` enum.
+
+    Raises :class:`HTTPException` (400) when *raw* is non-None and not a
+    recognised enum value.  Null passes through — omitting the signal is
+    the normal (non-control) path.
+
+    The ``GuidedRespondRequest`` schema keeps this field as ``str | None``
+    intentionally (see schemas.py docstring) so that stale clients carrying
+    an unknown signal value receive a clear protocol error from this guard
+    rather than a Pydantic deserialization crash.  This function is the
+    matching enforcement point on the route handler side.
+    """
+    if raw is None:
+        return
+    valid = [e.value for e in ControlSignal]
+    if raw not in valid:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Unknown control_signal: {raw!r}. Valid values: {valid}"),
+        )
 
 
 async def _dispatch_guided_respond(
@@ -4454,6 +4477,14 @@ def create_session_router() -> APIRouter:
                 )
 
             current_turn_type = existing_record.turn_type
+
+            # --- Wire-boundary validation (Codex #12) -----------------------
+            # Validates before the TurnResponse dict is assembled so that
+            # invalid requests are rejected before response_hash is computed or
+            # guided_turn_answered is emitted.
+
+            # Codex #12: validate control_signal against the ControlSignal enum.
+            _validate_control_signal(body.control_signal)
 
             # Build the TurnResponse dict from the request body.
             from dataclasses import replace as _replace

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -1973,7 +1973,40 @@ async def _dispatch_guided_respond(
         if chosen == ["accept"]:
             # User accepted the recipe. Extract the slots from edited_values
             # (user may have filled in required slots).
-            edited = turn_response["edited_values"] or {}
+            # ``edited_values`` is the wire contract for recipe_offer ['accept']:
+            # the RecipeOfferTurn widget always sends ``{"recipe_name": str,
+            # "slots": {...}}``. A missing key, a null payload, or a non-string
+            # ``recipe_name`` is a protocol violation, not a Tier-3 "user typo"
+            # we paper over with empty-string defaults — silent defaults here
+            # would surface far downstream as a misleading "unknown recipe ''"
+            # error, masking the actual contract drift. The HTTP boundary is a
+            # trust boundary, so we raise 400 with a contract-citing message.
+            edited = turn_response["edited_values"]
+            if edited is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="recipe_offer ['accept'] requires edited_values; received null.",
+                )
+            missing = {"recipe_name", "slots"} - edited.keys()
+            if missing:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"recipe_offer ['accept'] edited_values missing required keys: {sorted(missing)}; got keys: {sorted(edited.keys())}"
+                    ),
+                )
+            recipe_name = edited["recipe_name"]
+            if not isinstance(recipe_name, str) or not recipe_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"recipe_offer ['accept'] edited_values['recipe_name'] must be a non-empty string; got {recipe_name!r}"),
+                )
+            slots_raw = edited["slots"]
+            if not isinstance(slots_raw, Mapping):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"recipe_offer ['accept'] edited_values['slots'] must be an object; got {type(slots_raw).__name__}"),
+                )
             # Reconstruct slots from the last RECIPE_OFFER turn's payload
             # and overlay with user-edited values.
             recipe_turn_record = next(
@@ -1991,8 +2024,7 @@ async def _dispatch_guided_respond(
             # the rest via the recipe_offer form and sends them back in edited_values.
             from elspeth.web.composer.guided.recipe_match import RecipeMatch as _RecipeMatch
 
-            recipe_name = str(edited.get("recipe_name", ""))
-            slots = dict(edited.get("slots", {}))
+            slots = dict(slots_raw)
             # The "accept" reconstruction is post-acceptance: the operator has
             # supplied the slot values (merged into ``edited.slots`` by the
             # widget).  ``unsatisfied_slots`` was a property of the *offer*;

--- a/src/elspeth/web/sessions/routes.py
+++ b/src/elspeth/web/sessions/routes.py
@@ -4338,10 +4338,14 @@ def create_session_router() -> APIRouter:
             )
 
             # Run step_advance (pure — no I/O).
-            # InvariantError from step_advance or the downstream dispatcher
-            # indicates a server-side bug — propagate as HTTP 500 with a
-            # "Server invariant violated" prefix so it's distinguishable from
-            # client-fault HTTP 400s in dashboards and on-call runbooks.
+            # InvariantError indicates a server-side bug (e.g. stamped an
+            # invalid turn type on a history record) — propagate as HTTP 500
+            # with a "Server invariant violated" prefix so it's distinguishable
+            # from client-fault HTTP 400s in dashboards and on-call runbooks.
+            # ValueError indicates a client-supplied payload violated the
+            # guided-mode protocol contract (e.g. unexpected chosen value on a
+            # recipe_offer turn, or null edited_values on inspect_and_confirm)
+            # — propagate as HTTP 400 so the caller can correct the request.
             try:
                 new_guided, _next_turn_from_advance, terminal_from_advance, directives = step_advance(
                     guided,
@@ -4352,6 +4356,11 @@ def create_session_router() -> APIRouter:
                 raise HTTPException(
                     status_code=500,
                     detail=f"Server invariant violated: {exc}",
+                ) from exc
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Guided-mode protocol error: {exc}",
                 ) from exc
 
             # Fan directives to emit_* helpers.
@@ -4408,6 +4417,16 @@ def create_session_router() -> APIRouter:
                     raise HTTPException(
                         status_code=500,
                         detail=f"Server invariant violated: {exc}",
+                    ) from exc
+                except ValueError as exc:
+                    # ValueError from inside the dispatcher indicates a
+                    # client-supplied payload violated the guided-mode protocol
+                    # contract (e.g. unknown plugin name from chosen, null
+                    # edited_values) — propagate as HTTP 400. See Codex #8,
+                    # #11, #15 and commit message for full context.
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Guided-mode protocol error: {exc}",
                     ) from exc
                 terminal = guided.terminal
 

--- a/src/elspeth/web/sessions/schemas.py
+++ b/src/elspeth/web/sessions/schemas.py
@@ -15,6 +15,7 @@ boundary instead of being silently reinterpreted by the route layer.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 import pydantic
@@ -207,6 +208,92 @@ class RunResponse(_StrictResponse):
     finished_at: datetime | None = None
     composition_version: int
     discard_summary: DiscardSummary | None = None
+
+
+class TurnRecordResponse(_StrictResponse):
+    """Wire representation of a single TurnRecord in the guided-session history."""
+
+    step: str
+    turn_type: str
+    payload_hash: str
+    response_hash: str | None
+    emitter: str
+
+
+class TerminalStateResponse(_StrictResponse):
+    """Wire representation of a TerminalState."""
+
+    kind: str
+    reason: str | None
+    pipeline_yaml: str | None
+
+
+class GuidedSessionResponse(_StrictResponse):
+    """Wire representation of the GuidedSession attached to a CompositionState."""
+
+    step: str
+    history: list[TurnRecordResponse]
+    terminal: TerminalStateResponse | None
+
+
+class TurnPayloadResponse(_StrictResponse):
+    """Opaque turn payload — type discriminated by ``type`` at the parent level.
+
+    ``payload`` carries the raw TypedDict contents for the turn (e.g.
+    ``SingleSelectPayload``, ``InspectAndConfirmPayload``).  Pydantic strict
+    mode does not apply to ``Any``-typed fields; the route handler guarantees
+    the payload is a plain dict at construction time.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    type: str
+    step_index: int
+    payload: JsonValue
+
+
+class GetGuidedResponse(_StrictResponse):
+    """Response for GET /api/sessions/{id}/guided."""
+
+    guided_session: GuidedSessionResponse
+    next_turn: TurnPayloadResponse | None
+    terminal: TerminalStateResponse | None
+    composition_state: CompositionStateResponse | None
+
+
+class GuidedRespondRequest(_RequestModel):
+    """Request body for POST /api/sessions/{id}/guided/respond.
+
+    Carries the user's typed response to the current guided turn.  All
+    fields from ``TurnResponse`` are optional at the HTTP boundary (Pydantic
+    coerces absent keys to ``None``); the route handler validates that the
+    combination is consistent with the current turn type.
+
+    ``control_signal`` is a plain string so that stale clients sending an
+    unknown signal value fail gracefully rather than crashing at the HTTP
+    boundary.  The route handler validates the value against the closed
+    ``ControlSignal`` enum.
+    """
+
+    chosen: list[str] | None = None
+    edited_values: dict[str, Any] | None = None
+    custom_inputs: list[str] | None = None
+    accepted_step_index: int | None = None
+    edit_step_index: int | None = None
+    control_signal: str | None = None
+
+
+class GuidedRespondResponse(_StrictResponse):
+    """Response for POST /api/sessions/{id}/guided/respond.
+
+    Mirrors GET /guided response shape so the frontend can replace its
+    cached guided_session in a single pass.
+    """
+
+    guided_session: GuidedSessionResponse
+    next_turn: TurnPayloadResponse | None
+    terminal: TerminalStateResponse | None
+    composition_state: CompositionStateResponse | None
 
 
 # Forward reference resolution

--- a/tests/integration/web/composer/guided/conftest.py
+++ b/tests/integration/web/composer/guided/conftest.py
@@ -1,0 +1,121 @@
+"""Fixtures for HTTP-layer guided endpoint integration tests.
+
+Establishes SyncASGITestClient-based fixtures for testing the
+/api/sessions/{id}/guided/* endpoint routes. Replicates the pattern from
+tests/unit/web/sessions/test_fork.py: in-memory SQLite, mock auth, minimal
+FastAPI app with session router mounted.
+
+Scope: Fixtures live in this file and are available to all tests in
+tests/integration/web/composer/guided/*.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from sqlalchemy.pool import StaticPool
+
+from elspeth.web.auth.middleware import get_current_user
+from elspeth.web.auth.models import UserIdentity
+from elspeth.web.blobs.service import BlobServiceImpl
+from elspeth.web.composer.audit import BufferingRecorder
+from elspeth.web.config import WebSettings
+from elspeth.web.middleware.rate_limit import ComposerRateLimiter
+from elspeth.web.sessions.engine import create_session_engine
+from elspeth.web.sessions.routes import create_session_router
+from elspeth.web.sessions.schema import initialize_session_schema
+from elspeth.web.sessions.service import SessionServiceImpl
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+
+@pytest.fixture
+def composer_test_client(tmp_path: Path) -> Iterator[TestClient]:
+    """Yields a TestClient wrapping a minimal FastAPI app with session router.
+
+    App state includes:
+    - session_service (SessionServiceImpl with in-memory SQLite)
+    - blob_service (BlobServiceImpl)
+    - auth override: all requests authenticated as "alice"
+    - rate_limiter (ComposerRateLimiter)
+    - settings (WebSettings with test defaults)
+    - audit_recorder (BufferingRecorder for test inspection)
+
+    The app has create_session_router() mounted so POST /api/sessions routes
+    are available for fixture smoke tests and guided endpoint tests.
+
+    Usage:
+        def test_something(composer_test_client):
+            resp = composer_test_client.post("/api/sessions", json={"title": "x"})
+            assert resp.status_code == 201
+    """
+    # Create in-memory session database with schema initialized
+    engine = create_session_engine(
+        "sqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    initialize_session_schema(engine)
+
+    # Session and blob services
+    session_service = SessionServiceImpl(engine)
+    blob_service = BlobServiceImpl(engine, tmp_path)
+
+    # FastAPI app
+    app = FastAPI()
+
+    # Mock auth: all requests authenticated as "alice"
+    identity = UserIdentity(user_id="alice", username="alice")
+
+    async def mock_user() -> UserIdentity:
+        return identity
+
+    app.dependency_overrides[get_current_user] = mock_user
+
+    # App state: minimal set required by session router
+    app.state.session_service = session_service
+    app.state.blob_service = blob_service
+    app.state.settings = WebSettings(
+        data_dir=tmp_path,
+        composer_max_composition_turns=15,
+        composer_max_discovery_turns=10,
+        composer_timeout_seconds=85.0,
+        composer_rate_limit_per_minute=10,
+    )
+    app.state.composer_service = None  # Not used in session router
+    app.state.rate_limiter = ComposerRateLimiter(limit=100)
+
+    # Audit recorder for test inspection (Phase 3 Task 3.4 will wire this)
+    app.state.composer_recorder = BufferingRecorder()
+
+    # Mount session router
+    router = create_session_router()
+    app.include_router(router)
+
+    # Wrap in TestClient and yield
+    client = TestClient(app)
+    yield client
+
+
+@pytest.fixture
+def audit_recorder(composer_test_client: TestClient) -> BufferingRecorder:
+    """Yields the BufferingRecorder from the app state.
+
+    Lets test code inspect emitted ComposerToolInvocation records during
+    a request. The recorder is accessible via the app's state.
+
+    Usage:
+        def test_something(composer_test_client, audit_recorder):
+            # Make a request that triggers composer operations
+            resp = composer_test_client.post(...)
+            # Inspect recorded invocations
+            invocations = audit_recorder.invocations
+            assert len(invocations) > 0
+            assert invocations[0].tool_name == "..."
+    """
+    # Extract recorder from the test client's app state
+    app = composer_test_client.app
+    recorder: BufferingRecorder = app.state.composer_recorder
+    return recorder

--- a/tests/integration/web/composer/guided/conftest.py
+++ b/tests/integration/web/composer/guided/conftest.py
@@ -20,9 +20,11 @@ from sqlalchemy.pool import StaticPool
 
 from elspeth.web.auth.middleware import get_current_user
 from elspeth.web.auth.models import UserIdentity
+from elspeth.web.blobs.routes import create_blobs_router
 from elspeth.web.blobs.service import BlobServiceImpl
 from elspeth.web.composer.audit import BufferingRecorder
 from elspeth.web.config import WebSettings
+from elspeth.web.dependencies import create_catalog_service
 from elspeth.web.middleware.rate_limit import ComposerRateLimiter
 from elspeth.web.sessions.engine import create_session_engine
 from elspeth.web.sessions.routes import create_session_router
@@ -76,6 +78,7 @@ def composer_test_client(tmp_path: Path) -> Iterator[TestClient]:
 
     # App state: minimal set required by session router
     app.state.session_service = session_service
+    app.state.session_engine = engine  # for guided step-2.5 recipe application
     app.state.blob_service = blob_service
     app.state.settings = WebSettings(
         data_dir=tmp_path,
@@ -86,13 +89,18 @@ def composer_test_client(tmp_path: Path) -> Iterator[TestClient]:
     )
     app.state.composer_service = None  # Not used in session router
     app.state.rate_limiter = ComposerRateLimiter(limit=100)
+    app.state.catalog_service = create_catalog_service()
 
     # Audit recorder for test inspection (Phase 3 Task 3.4 will wire this)
     app.state.composer_recorder = BufferingRecorder()
 
-    # Mount session router
+    # Mount session router (sessions + guided endpoints)
     router = create_session_router()
     app.include_router(router)
+
+    # Mount blobs router so tests can upload blobs via /api/sessions/{id}/blobs/inline
+    blobs_router = create_blobs_router()
+    app.include_router(blobs_router)
 
     # Wrap in TestClient and yield
     client = TestClient(app)

--- a/tests/integration/web/composer/guided/test_audit_emission.py
+++ b/tests/integration/web/composer/guided/test_audit_emission.py
@@ -28,6 +28,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import pytest
+
 from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
 
 # ---------------------------------------------------------------------------
@@ -529,3 +531,236 @@ class TestAutoDropAuditEmission:
         assert len(guided_invocations["guided_turn_answered"]) >= 1, (
             f"expected at least one guided_turn_answered event on auto-drop path; got none. All guided events: {guided_invocations}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Rejection-path audit drain (PR-review B3 regression pin)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionPathAuditDrain:
+    """Pin the PR-review B3 invariant: handler-level recorders are drained on
+    every exit path, including ``raise HTTPException`` rejections.
+
+    Before the B3 fix, ``post_guided_respond`` created a ``BufferingRecorder``,
+    wrote ``guided_turn_answered`` to it, and then only persisted on the
+    success path.  Every 400/409/500 raised between the emit and the
+    success-path drain silently dropped buffered audit events — a CLAUDE.md
+    auditability violation ("rejected requests are facts worth recording").
+
+    These tests verify:
+
+    1. **The load-bearing pin** — a 400 raised AFTER ``emit_turn_answered``
+       still persists the buffered event.  Concretely: POST a malformed
+       ``INSPECT_AND_CONFIRM`` response (``edited_values=None``), which
+       triggers ``ValueError`` inside ``step_advance`` → HTTP 400.  The
+       ``guided_turn_answered`` event for this rejected attempt must land
+       in the audit DB so an auditor can reconstruct "this client tried
+       to advance with payload X and was rejected."
+
+    2. **The 409 path** — terminal-state rejection fires BEFORE
+       ``emit_turn_answered``, so the recorder is empty on this exit.  The
+       drain must still be a clean no-op (no crash from draining an empty
+       buffer).
+
+    3. **The GET 400 path** — freeform-session rejection in ``get_guided``
+       fires immediately after recorder construction, before any emit.
+       The drain must be a clean no-op.
+
+    4. **Audit-persist failure does NOT suppress the original HTTPException**
+       — if ``_persist_tool_invocations`` itself raises inside ``finally``,
+       Python's default behaviour would let the inner exception replace
+       the in-flight 400/409.  The inner ``try/except`` around the persist
+       call prevents that.  The audit-persist failure is logged via
+       ``slog.error`` under the audit-system-failure exemption (CLAUDE.md
+       primacy order, matching the B1 convention).
+    """
+
+    def test_post_guided_respond_400_persists_prior_emits(self, composer_test_client: TestClient) -> None:
+        """A 400 raised AFTER ``emit_turn_answered`` still persists the buffered event.
+
+        Drives the wizard to the INSPECT_AND_CONFIRM turn (after ``chosen=["csv"]``),
+        then sends ``edited_values=None`` which ``step_advance`` rejects with
+        ``ValueError`` → HTTP 400.  Asserts the recorder's
+        ``guided_turn_answered`` event landed in the audit DB despite the
+        rejection.
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        # Advance past STEP_1 SINGLE_SELECT → INSPECT_AND_CONFIRM turn.
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        # Snapshot the answered-event count BEFORE the rejected request so
+        # we can prove the rejected request added exactly one more.
+        baseline = len(_extract_guided_invocations(composer_test_client, session_id)["guided_turn_answered"])
+
+        # Send a malformed INSPECT_AND_CONFIRM response: edited_values=None.
+        # step_advance raises ValueError("inspect_and_confirm response must
+        # carry edited_values; got None") which the handler maps to 400.
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": None},
+        )
+        assert resp.status_code == 400, resp.json()
+
+        # The load-bearing assertion: the guided_turn_answered emitted before
+        # the rejection must be in the audit DB.  The 400 fires either from
+        # ``step_advance`` (state-machine guard) or from the step-1 handler
+        # (handle_step_1_source / dispatcher ValueError), both of which run
+        # AFTER ``emit_turn_answered``.  Either way the buffered event
+        # must persist.
+        post_reject = _extract_guided_invocations(composer_test_client, session_id)["guided_turn_answered"]
+        assert len(post_reject) == baseline + 1, (
+            f"PR-review B3 regression: the guided_turn_answered event for "
+            f"the rejected INSPECT_AND_CONFIRM turn was dropped on the 400 "
+            f"path. baseline={baseline} post_reject={len(post_reject)} "
+            f"(expected baseline+1). Response body: {resp.json()}"
+        )
+
+    def test_post_guided_respond_409_terminal_drains_cleanly(self, composer_test_client: TestClient) -> None:
+        """The 409 terminal-state path drains a clean (empty-or-prior-only) recorder.
+
+        The 409 is raised BEFORE ``emit_turn_answered`` for this request — see
+        the handler: terminal-state rejection sits between
+        ``service.get_current_state`` and the emit.  So the recorder has no
+        new event from this rejected request; the test simply verifies that
+        the drain doesn't crash (i.e. empty drains are safe and the original
+        HTTPException is not masked).
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        # Exit immediately so the next respond hits the 409 terminal guard.
+        _respond(composer_test_client, session_id, control_signal="exit_to_freeform")
+
+        # Second respond on the now-terminal session: 409.
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"]},
+        )
+        assert resp.status_code == 409, resp.json()
+
+    def test_get_guided_400_freeform_session_drains_empty_recorder(self, composer_test_client: TestClient) -> None:
+        """GET /guided on a freeform session drains an empty recorder without crashing.
+
+        Constructs a session with composition state that has no
+        ``guided_session`` attached (a freeform session), then GETs /guided.
+        The handler raises 400 immediately after recorder construction —
+        no audit emit has occurred, so the recorder is empty.  The finally
+        block must drain it without crashing, and the 400 must reach the
+        client (not be replaced by a finally-block exception).
+        """
+        import asyncio
+        from uuid import UUID
+
+        # Build a freeform session: create then overwrite the composition
+        # state with one whose composer_meta has no ``guided_session`` key.
+        session_id = _create_session(composer_test_client)
+        service = composer_test_client.app.state.session_service
+
+        # Persist a freeform composition state directly.
+        from elspeth.web.sessions.protocol import CompositionStateData
+
+        freeform_state = CompositionStateData(
+            source=None,
+            nodes=(),
+            edges=(),
+            outputs=(),
+            metadata_={"name": "Untitled Pipeline", "description": ""},
+            is_valid=False,
+            validation_errors=None,
+            composer_meta={},  # No guided_session key → freeform.
+        )
+        asyncio.run(service.save_composition_state(UUID(session_id), freeform_state))
+
+        resp = composer_test_client.get(f"/api/sessions/{session_id}/guided")
+        assert resp.status_code == 400, resp.json()
+        assert "not in guided mode" in resp.json()["detail"]
+
+    def test_audit_persist_failure_does_not_suppress_http_exception(
+        self,
+        composer_test_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If ``_persist_tool_invocations`` raises inside finally, the
+        original HTTPException must still surface.  The inner
+        ``try/except`` in the finally block prevents Python's default
+        behaviour (the inner raise replaces the outer) from masking the
+        intended 400/409.
+
+        Concretely: drive to INSPECT_AND_CONFIRM, then patch
+        ``_persist_tool_invocations`` to raise.  Send a malformed payload
+        that triggers the 400 path.  Assert the response is still 400 —
+        not 500 from the persist failure.
+        """
+        from elspeth.web.sessions import routes as routes_mod
+
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        async def _raising_persist(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated audit-system failure")
+
+        monkeypatch.setattr(routes_mod, "_persist_tool_invocations", _raising_persist)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": None},
+        )
+
+        # The original 400 must surface — NOT a 500 from the persist failure.
+        assert resp.status_code == 400, (
+            f"PR-review B3 regression: audit-persist failure inside finally "
+            f"replaced the original HTTPException. Expected 400, got "
+            f"{resp.status_code}: {resp.json()}"
+        )
+
+    def test_audit_persist_failure_logs_via_slog(
+        self,
+        composer_test_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The audit-persist failure is logged via slog.error under the
+        audit-system-failure exemption.  Pins the
+        ``guided.audit_persist_failed_during_exception_handling`` event
+        name and confirms the failure is observable to operators.
+
+        Uses ``structlog.testing.capture_logs`` because the project uses
+        structlog (not stdlib logging) for ``slog.error``; ``caplog``
+        does not see structlog events unless the logger is bridged.
+        """
+        from structlog.testing import capture_logs
+
+        from elspeth.web.sessions import routes as routes_mod
+
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        async def _raising_persist(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated audit-system failure")
+
+        monkeypatch.setattr(routes_mod, "_persist_tool_invocations", _raising_persist)
+
+        with capture_logs() as cap_logs:
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"edited_values": None},
+            )
+            # Original HTTPException still surfaces.
+            assert resp.status_code == 400
+
+        matches = [entry for entry in cap_logs if entry.get("event") == "guided.audit_persist_failed_during_exception_handling"]
+        assert matches, f"expected the audit-persist-failure slog event; got entries: {cap_logs}"
+
+        # Match the B1 convention: exc_class + frames + site + session_id +
+        # user_id, never str(exc) or exc_info.  Pin the field set so a
+        # future refactor that swaps in str(exc) is caught immediately.
+        entry = matches[0]
+        assert entry["exc_class"] == "RuntimeError", entry
+        assert entry["site"] == "post_guided_respond", entry
+        assert "frames" in entry and isinstance(entry["frames"], tuple), entry
+        # No raw exception message field — that's the leak vector the B1
+        # convention forbids.
+        forbidden_keys = {"exc_message", "exception", "exc_info"}
+        assert not (forbidden_keys & entry.keys()), f"slog entry has forbidden message/exc_info field: {entry}"

--- a/tests/integration/web/composer/guided/test_audit_emission.py
+++ b/tests/integration/web/composer/guided/test_audit_emission.py
@@ -184,28 +184,21 @@ def _drive_to_recipe_offer(client: TestClient, session_id: str) -> tuple[dict, s
         client,
         session_id,
         edited_values={
-            "path": output_path,
-            "schema": {"mode": "observed"},
-            "collision_policy": "auto_increment",
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
         },
     )
     body = _respond(
         client,
         session_id,
-        edited_values={
-            "outputs": [
-                {
-                    "plugin": "json",
-                    "options": {
-                        "path": output_path,
-                        "schema": {"mode": "observed"},
-                        "collision_policy": "auto_increment",
-                    },
-                    "required_fields": ["text", "category"],
-                    "schema_mode": "observed",
-                }
-            ]
-        },
+        chosen=["text", "category"],
+        custom_inputs=[],
     )
     return body, blob_id
 
@@ -238,28 +231,21 @@ def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple
         client,
         session_id,
         edited_values={
-            "path": output_path,
-            "schema": {"mode": "observed"},
-            "collision_policy": "auto_increment",
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
         },
     )
     body = _respond(
         client,
         session_id,
-        edited_values={
-            "outputs": [
-                {
-                    "plugin": "json",
-                    "options": {
-                        "path": output_path,
-                        "schema": {"mode": "observed"},
-                        "collision_policy": "auto_increment",
-                    },
-                    "required_fields": ["text"],
-                    "schema_mode": "observed",
-                }
-            ]
-        },
+        chosen=["text"],
+        custom_inputs=[],
     )
     return body, blob_id, output_path
 

--- a/tests/integration/web/composer/guided/test_audit_emission.py
+++ b/tests/integration/web/composer/guided/test_audit_emission.py
@@ -1,0 +1,545 @@
+"""Integration tests for Phase 5 Task 5.3: full-session audit emission contract.
+
+Asserts that spec §9.1 audit events appear (or do NOT appear) across two
+complete session lifecycles:
+
+1. Recipe-match happy path:
+   - guided_turn_emitted fires at least once
+   - guided_turn_answered fires at least once
+   - guided_step_advanced fires at least once
+   - guided_dropped_to_freeform fires ZERO times
+
+2. Auto-drop path (chain solver exhausted):
+   - guided_dropped_to_freeform fires at least once
+   - The drop event's ``drop_reason == "solver_exhausted"``
+   - The drop event's ``prev_step == "step_3_transforms"``
+   - The drop event carries a ``validation_result`` field (spec §9.1 MUST)
+
+These tests cover the audit-emission contract, not HTTP response semantics;
+for response-shape tests see test_respond.py and test_auto_drop.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Guided audit discriminators (spec §9.1)
+# ---------------------------------------------------------------------------
+
+_GUIDED_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "guided_turn_emitted",
+        "guided_turn_answered",
+        "guided_step_advanced",
+        "guided_dropped_to_freeform",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Low-level helpers (mirrors test_auto_drop.py — no cross-file imports)
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    resp = client.post("/api/sessions", json={"title": "audit-emission-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    resp = client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _seed_blob(client: TestClient, session_id: str) -> tuple[str, str]:
+    """Seed a CSV blob for recipe-match path.  Returns (blob_id, storage_path).
+
+    Uses ``text`` + ``category`` columns so the ``classify-rows-llm-jsonl``
+    recipe predicate is satisfied when the user declares ``category`` as a
+    required field (the classify keyword is a substring of "category").
+    """
+    content = "text,category\nHello world,greeting\nGoodbye,farewell\n"
+    resp = client.post(
+        f"/api/sessions/{session_id}/blobs/inline",
+        json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+    )
+    assert resp.status_code == 201, resp.json()
+    blob_id = resp.json()["id"]
+    blob_service = client.app.state.blob_service
+    record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+    return blob_id, record.storage_path
+
+
+def _seed_blob_no_recipe(client: TestClient, session_id: str) -> tuple[str, str]:
+    """Seed a CSV blob for the auto-drop path (no recipe match).
+
+    Uses ``text`` + ``note`` columns — ``note`` does not satisfy any
+    classify/label/category keyword, so no recipe matches and the
+    chain-solver path fires.
+    """
+    content = "text,note\nHello world,greeting\nGoodbye,farewell\n"
+    resp = client.post(
+        f"/api/sessions/{session_id}/blobs/inline",
+        json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+    )
+    assert resp.status_code == 201, resp.json()
+    blob_id = resp.json()["id"]
+    blob_service = client.app.state.blob_service
+    record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+    return blob_id, record.storage_path
+
+
+def _outputs_path(client: TestClient, filename: str) -> str:
+    data_dir: Path = client.app.state.settings.data_dir
+    outputs_dir = data_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    return str(outputs_dir / filename)
+
+
+# ---------------------------------------------------------------------------
+# Audit-extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_tool_messages(client: TestClient, session_id: str) -> list:
+    """Return all role=tool messages for this session from the session service."""
+    service = client.app.state.session_service
+    msgs = asyncio.run(service.get_messages(UUID(session_id), limit=None))
+    return [m for m in msgs if m.role == "tool"]
+
+
+def _extract_guided_invocations(client: TestClient, session_id: str) -> dict[str, list[dict]]:
+    """Return a mapping of guided-mode tool_name → list of parsed argument payloads.
+
+    Filters to the four guided-mode discriminators from spec §9.1.  Other tool
+    names (``set_source``, ``set_output``, ``apply_pipeline_recipe``, etc.) are
+    excluded so callers only see guided-protocol events.
+
+    Returns:
+        A dict keyed by tool_name, each value a list of parsed argument dicts
+        (``arguments_canonical`` decoded from JSON).  Missing keys indicate zero
+        events of that type.
+    """
+    tool_messages = _get_tool_messages(client, session_id)
+    result: dict[str, list[dict]] = {name: [] for name in _GUIDED_TOOL_NAMES}
+    for msg in tool_messages:
+        if not msg.tool_calls:
+            continue
+        for tc in msg.tool_calls:
+            invocation = tc.get("invocation", {})
+            tool_name = invocation.get("tool_name")
+            if tool_name not in _GUIDED_TOOL_NAMES:
+                continue
+            args_canonical = invocation.get("arguments_canonical", "{}")
+            result[tool_name].append(json.loads(args_canonical))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Scenario drivers
+# ---------------------------------------------------------------------------
+
+
+def _drive_to_recipe_offer(client: TestClient, session_id: str) -> tuple[dict, str]:
+    """Drive the wizard to the Step 2.5 RECIPE_OFFER state.
+
+    Uses ``text`` + ``category`` columns with the JSON sink so the
+    ``classify-rows-llm-jsonl`` recipe predicate is satisfied.
+
+    Returns (last_response_body, blob_id).  ``blob_id`` is needed for the
+    recipe-accept slots where ``_resolve_source_blob`` reads the session DB.
+    """
+    blob_id, storage_path = _seed_blob(client, session_id)
+    output_path = _outputs_path(client, "out_recipe.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "category"],
+            "sample_rows": [{"text": "Hello", "category": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "path": output_path,
+            "schema": {"mode": "observed"},
+            "collision_policy": "auto_increment",
+        },
+    )
+    body = _respond(
+        client,
+        session_id,
+        edited_values={
+            "outputs": [
+                {
+                    "plugin": "json",
+                    "options": {
+                        "path": output_path,
+                        "schema": {"mode": "observed"},
+                        "collision_policy": "auto_increment",
+                    },
+                    "required_fields": ["text", "category"],
+                    "schema_mode": "observed",
+                }
+            ]
+        },
+    )
+    return body, blob_id
+
+
+def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple[dict, str, str]:
+    """Drive the wizard to the Step 3 ``propose_chain`` turn (no recipe).
+
+    Uses ``required_fields=["text"]`` (no classify/label/category keyword) so
+    no recipe matches and the chain-solver entry seam fires.
+
+    Returns (response_body_at_step_3, blob_id, output_path).
+    """
+    blob_id, storage_path = _seed_blob_no_recipe(client, session_id)
+    output_path = _outputs_path(client, "out_drop.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "note"],
+            "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "path": output_path,
+            "schema": {"mode": "observed"},
+            "collision_policy": "auto_increment",
+        },
+    )
+    body = _respond(
+        client,
+        session_id,
+        edited_values={
+            "outputs": [
+                {
+                    "plugin": "json",
+                    "options": {
+                        "path": output_path,
+                        "schema": {"mode": "observed"},
+                        "collision_policy": "auto_increment",
+                    },
+                    "required_fields": ["text"],
+                    "schema_mode": "observed",
+                }
+            ]
+        },
+    )
+    return body, blob_id, output_path
+
+
+def _fake_llm_bad_plugin() -> SimpleNamespace:
+    """LiteLLM-shaped response proposing a nonexistent plugin (validation will fail)."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "definitely_not_a_real_plugin_xyzzy",
+                                                    "options": {},
+                                                    "rationale": "stub: guaranteed to fail validation",
+                                                }
+                                            ],
+                                            "why": "stub that forces preview_pipeline failure",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Recipe-match happy path audit emission
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeMatchAuditEmission:
+    """Assert spec §9.1 audit events fire (and don't fire) across the recipe-match happy path.
+
+    The happy path terminates at Step 2.5 RECIPE_MATCH via recipe-accept.
+    The chain solver is never invoked.  No LLM patches needed.
+    """
+
+    def test_recipe_accept_emits_turn_emitted_events(self, composer_test_client: TestClient) -> None:
+        """guided_turn_emitted fires at least once across the full recipe-accept lifecycle."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = _drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out_recipe.jsonl")
+
+        assert recipe_body["next_turn"]["type"] == "recipe_offer"
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        assert len(guided_invocations["guided_turn_emitted"]) >= 1, (
+            f"expected at least one guided_turn_emitted event; got none. All guided events: {guided_invocations}"
+        )
+
+    def test_recipe_accept_emits_turn_answered_events(self, composer_test_client: TestClient) -> None:
+        """guided_turn_answered fires at least once across the full recipe-accept lifecycle."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = _drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out_recipe.jsonl")
+
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        assert len(guided_invocations["guided_turn_answered"]) >= 1, (
+            f"expected at least one guided_turn_answered event; got none. All guided events: {guided_invocations}"
+        )
+
+    def test_recipe_accept_emits_step_advanced_events(self, composer_test_client: TestClient) -> None:
+        """guided_step_advanced fires at least once across the full recipe-accept lifecycle."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = _drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out_recipe.jsonl")
+
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        assert len(guided_invocations["guided_step_advanced"]) >= 1, (
+            f"expected at least one guided_step_advanced event; got none. All guided events: {guided_invocations}"
+        )
+
+    def test_recipe_accept_emits_no_drop_events(self, composer_test_client: TestClient) -> None:
+        """guided_dropped_to_freeform fires ZERO times on the recipe-accept happy path."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = _drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out_recipe.jsonl")
+
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        final_body = _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        # Confirm this is actually the COMPLETED terminal (not a drop).
+        assert final_body["terminal"] is not None
+        assert final_body["terminal"]["kind"] == "completed", f"expected terminal.kind=completed, got: {final_body['terminal']}"
+
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        assert guided_invocations["guided_dropped_to_freeform"] == [], (
+            f"expected no guided_dropped_to_freeform events on happy path; got: {guided_invocations['guided_dropped_to_freeform']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Auto-drop path audit emission
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDropAuditEmission:
+    """Assert spec §9.1 audit events fire correctly on the solver-exhausted auto-drop path.
+
+    Both the initial chain-solver call and the repair call propose an
+    invalid plugin name.  The wizard auto-drops to freeform after the
+    repair fails.
+    """
+
+    def test_auto_drop_emits_drop_event_with_correct_fields(self, composer_test_client: TestClient) -> None:
+        """guided_dropped_to_freeform fires with required fields on solver-exhausted path.
+
+        Asserts:
+        - At least one guided_dropped_to_freeform event is present.
+        - drop_reason == "solver_exhausted"
+        - prev_step == "step_3_transforms"
+        - validation_result is present (spec §9.1 MUST when drop_reason=solver_exhausted)
+        - validation_result.is_valid is False
+        - validation_result.errors is present (may be empty list, not absent)
+        """
+        session_id = _create_session(composer_test_client)
+
+        # Drive Steps 1 + 2 to PROPOSE_CHAIN with a bad LLM response.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        # Accept the (bad) chain — initial commit fails, repair also fails → auto-drop.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=[_fake_llm_bad_plugin()],
+        ):
+            final_resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        assert final_resp.status_code == 200, final_resp.json()
+        body = final_resp.json()
+
+        # Confirm the session actually dropped (not a different terminal).
+        terminal = body.get("terminal")
+        assert terminal is not None, f"expected terminal in response body, got: {body}"
+        assert terminal["kind"] == "exited_to_freeform", f"expected terminal.kind=exited_to_freeform, got: {terminal}"
+
+        # Extract guided-mode audit events.
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        drop_events = guided_invocations["guided_dropped_to_freeform"]
+
+        assert len(drop_events) >= 1, (
+            f"expected at least one guided_dropped_to_freeform audit event; got none. All guided events: {guided_invocations}"
+        )
+
+        drop_args = drop_events[0]
+
+        assert drop_args["drop_reason"] == "solver_exhausted", f"expected drop_reason=solver_exhausted; got: {drop_args}"
+
+        assert drop_args["prev_step"] == "step_3_transforms", f"expected prev_step=step_3_transforms; got: {drop_args}"
+
+        assert "validation_result" in drop_args, (
+            f"spec §9.1 requires validation_result on solver_exhausted drops; field is absent. Drop event payload: {drop_args}"
+        )
+
+        validation_result = drop_args["validation_result"]
+        assert isinstance(validation_result, dict), f"validation_result must be a dict; got {type(validation_result)}: {validation_result}"
+        assert validation_result["is_valid"] is False, (
+            f"validation_result.is_valid must be False (pipeline was invalid); got: {validation_result}"
+        )
+        assert "errors" in validation_result, f"validation_result must have an 'errors' key; got: {validation_result}"
+
+    def test_auto_drop_also_emits_turn_answered_events(self, composer_test_client: TestClient) -> None:
+        """guided_turn_answered fires at least once on the auto-drop path (responds were made)."""
+        session_id = _create_session(composer_test_client)
+
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=[_fake_llm_bad_plugin()],
+        ):
+            composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        guided_invocations = _extract_guided_invocations(composer_test_client, session_id)
+        assert len(guided_invocations["guided_turn_answered"]) >= 1, (
+            f"expected at least one guided_turn_answered event on auto-drop path; got none. All guided events: {guided_invocations}"
+        )

--- a/tests/integration/web/composer/guided/test_auto_drop.py
+++ b/tests/integration/web/composer/guided/test_auto_drop.py
@@ -347,3 +347,302 @@ class TestRepairSucceeds:
         # No guided_dropped_to_freeform audit event emitted.
         drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
         assert drop_invocations == [], f"unexpected drop event in repair-succeeds path: {drop_invocations}"
+
+
+# ---------------------------------------------------------------------------
+# I2: transient LLM failure at solve_chain sites → auto-drop (200), not 500.
+# ---------------------------------------------------------------------------
+#
+# Three sites in ``_dispatch_guided_respond`` await ``solve_chain``:
+#   1. step_2_sink_initial_solve      (no recipe match path)
+#   2. step_2_5_build_manually_solve  (recipe offer → build_manually)
+#   3. step_3_repair_solve            (Step 3 repair re-solve)
+#
+# Pre-I2, all three were unwrapped: a LiteLLM API/auth error, timeout, or
+# malformed-response shape (IndexError on empty ``choices``) escaped as an
+# unstructured 500 — bypassing ``mark_solver_exhausted`` and leaving the
+# session wedged mid-step with no ``guided_dropped_to_freeform`` audit
+# record.  These tests pin the new contract from
+# ``_solve_chain_or_auto_drop``.
+
+
+def _drive_to_step_2_sink_initial_solve_pre_call(client: TestClient, session_id: str) -> str:
+    """Drive to the request that triggers site 1 (step_2_sink_initial_solve).
+
+    Returns ``session_id`` after Steps 1 and 2 SINGLE_SELECT + SCHEMA_FORM
+    have been answered. The NEXT respond (MULTI_SELECT chosen=['text'])
+    triggers ``solve_chain`` at site 1.
+    """
+    _blob_id, storage_path = _seed_blob(client, session_id)
+    output_path = _outputs_path(client, "out.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "note"],
+            "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
+        },
+    )
+    return session_id
+
+
+def _post_step_2_sink_intent(client: TestClient, session_id: str) -> object:
+    """Post the MULTI_SELECT response that triggers site 1's solve_chain call."""
+    return client.post(
+        f"/api/sessions/{session_id}/guided/respond",
+        json={"chosen": ["text"], "custom_inputs": []},
+    )
+
+
+class TestI2ChainSolverTransientFailure:
+    """Pin: transient LLM failure at each solve_chain site auto-drops cleanly.
+
+    Patches ``chain_solver._litellm_acompletion`` (the seam the existing
+    auto-drop tests use) to raise transient exception classes from the
+    project canonical set. Asserts:
+      - HTTP 200 (not 500) with terminal=exited_to_freeform / solver_exhausted.
+      - ``guided_dropped_to_freeform`` audit emitted exactly once with the
+        ``validation_result`` payload mandated by spec §9.1.
+      - No exception ``str(exc)`` leaks into the response body.
+      - ``InvariantError`` from chain_solver (e.g. emit-shape contract
+        violations) still propagates as 500 — real bugs must crash.
+    """
+
+    def test_step_2_sink_initial_solve_api_error_auto_drops(self, composer_test_client: TestClient) -> None:
+        """Site 1: a LiteLLM APIError at the no-recipe initial solve auto-drops."""
+        from litellm.exceptions import APIError as LiteLLMAPIError
+
+        session_id = _create_session(composer_test_client)
+        _drive_to_step_2_sink_initial_solve_pre_call(composer_test_client, session_id)
+
+        api_err = LiteLLMAPIError(
+            status_code=500,
+            message="upstream auth failure: SECRET_API_KEY=sk-leaks-here",
+            llm_provider="openai",
+            model="gpt-4o",
+        )
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=api_err,
+        ):
+            resp = _post_step_2_sink_intent(composer_test_client, session_id)
+
+        # Must be 200 (auto-drop is a clean wizard outcome) not 500.
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+
+        terminal = body.get("terminal")
+        assert terminal is not None, f"expected terminal in body, got: {body}"
+        assert terminal["kind"] == "exited_to_freeform"
+        assert terminal["reason"] == "solver_exhausted"
+
+        # No-leak invariant: the LiteLLM error message embedded a fake
+        # secret-shaped string. The response body must not echo it.
+        body_text = json.dumps(body)
+        assert "SECRET_API_KEY" not in body_text, "exc str leaked into response body"
+        assert "sk-leaks-here" not in body_text, "exc str leaked into response body"
+
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert len(drop_invocations) == 1, f"expected exactly one drop audit event; got {drop_invocations}"
+        drop_args = drop_invocations[0]
+        assert drop_args["drop_reason"] == "solver_exhausted"
+        validation_result = drop_args["validation_result"]
+        assert isinstance(validation_result, dict)
+        assert validation_result["is_valid"] is False
+        errors = validation_result["errors"]
+        assert isinstance(errors, list) and len(errors) == 1
+        # The error message names the exception class only — no str(exc).
+        assert errors[0]["message"] == "Chain solver failed: APIError", errors
+
+    def test_step_2_5_build_manually_timeout_auto_drops(self, composer_test_client: TestClient) -> None:
+        """Site 2: a TimeoutError at build_manually solve auto-drops.
+
+        Routes recipe-match by configuring source with a classifier keyword
+        so a recipe IS offered, then sends ['build_manually'] which triggers
+        ``solve_chain`` at site 2.
+        """
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "note"],
+                "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+            },
+        )
+        _respond(composer_test_client, session_id, chosen=["json"])
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
+            },
+        )
+        # Use a classifier keyword (``category``) to force a recipe match →
+        # recipe_offer. See ``_CLASSIFY_KEYWORDS`` in
+        # ``composer/guided/recipe_match.py`` for the closed list.
+        sink_resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["text", "category"], "custom_inputs": []},
+        )
+        assert sink_resp.status_code == 200, sink_resp.json()
+        # Confirm we got a recipe_offer turn (sanity check; the test fails
+        # informatively if recipe matching is reconfigured).
+        next_turn = sink_resp.json().get("next_turn")
+        if next_turn is None or next_turn.get("type") != "recipe_offer":
+            import pytest
+
+            pytest.skip(
+                f"site-2 test requires a recipe_offer to fire; recipe matching may have been reconfigured (got next_turn={next_turn})."
+            )
+
+        # Now build_manually triggers solve_chain at site 2.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError("timeout calling upstream"),
+        ):
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["build_manually"]},
+            )
+
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+        terminal = body.get("terminal")
+        assert terminal is not None
+        assert terminal["kind"] == "exited_to_freeform"
+        assert terminal["reason"] == "solver_exhausted"
+
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert len(drop_invocations) == 1
+        errors = drop_invocations[0]["validation_result"]["errors"]
+        assert errors[0]["message"] == "Chain solver failed: TimeoutError", errors
+
+    def test_step_3_repair_solve_malformed_response_auto_drops(self, composer_test_client: TestClient) -> None:
+        """Site 3: an IndexError (empty choices) on the repair re-solve auto-drops.
+
+        Repair is already attempt #2; a transient on repair means we are done
+        trying. Asserts the single-drop short-circuit — no double-emit through
+        the downstream ``mark_solver_exhausted`` at the bottom of the repair block.
+        """
+        session_id = _create_session(composer_test_client)
+
+        # Drive to PROPOSE_CHAIN with a bad-plugin initial proposal.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        # Accept the bad chain → handler fails → repair call → empty choices
+        # array → solve_chain raises IndexError at ``response.choices[0]``.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(choices=[]),
+        ):
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+        terminal = body.get("terminal")
+        assert terminal is not None
+        assert terminal["kind"] == "exited_to_freeform"
+        assert terminal["reason"] == "solver_exhausted"
+
+        # Exactly one drop event — the wrapper's short-circuit prevents the
+        # downstream mark_solver_exhausted from firing a second one.
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert len(drop_invocations) == 1, (
+            f"site-3 transient must emit exactly one drop event (no double-emit "
+            f"through the downstream repair-failure path); got {len(drop_invocations)}"
+        )
+        errors = drop_invocations[0]["validation_result"]["errors"]
+        assert errors[0]["message"] == "Chain solver failed: IndexError", errors
+
+    def test_chain_solver_invariant_error_still_propagates_to_500(self, composer_test_client: TestClient) -> None:
+        """Class B: InvariantError from chain_solver must propagate as 500.
+
+        ``chain_solver.py`` raises ``InvariantError`` at lines 97 / 99 / 116
+        when the LLM returns a tool name / turn_type / tool_calls shape that
+        violates the solver's emit contract. Per the I2 design, these are
+        Class B (programming bug → 500) — the wrapper must NOT absorb them.
+        """
+        session_id = _create_session(composer_test_client)
+        _drive_to_step_2_sink_initial_solve_pre_call(composer_test_client, session_id)
+
+        # Construct a LiteLLM response with a tool_call name OTHER than
+        # ``emit_turn`` — this triggers ``raise InvariantError`` at
+        # chain_solver.py:97 from inside ``solve_chain``.
+        wrong_name_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        tool_calls=[
+                            SimpleNamespace(
+                                function=SimpleNamespace(
+                                    name="not_emit_turn",
+                                    arguments="{}",
+                                )
+                            )
+                        ],
+                    )
+                )
+            ]
+        )
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=wrong_name_response,
+        ):
+            resp = _post_step_2_sink_intent(composer_test_client, session_id)
+
+        # Must NOT be absorbed into the auto-drop path. The outer
+        # ``except InvariantError`` handler returns 500 with the B1-sanitized
+        # static detail (no exc str).
+        assert resp.status_code == 500, resp.json()
+        detail = resp.json().get("detail", "")
+        assert "invariant" in detail.lower(), detail
+        # No drop event must have been emitted.
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert drop_invocations == [], f"InvariantError must not trigger guided_dropped_to_freeform; got {drop_invocations}"

--- a/tests/integration/web/composer/guided/test_auto_drop.py
+++ b/tests/integration/web/composer/guided/test_auto_drop.py
@@ -272,7 +272,12 @@ class TestAutoDropOnSolverExhausted:
         )
         drop_args = drop_invocations[0]
         assert drop_args["drop_reason"] == "solver_exhausted"
-        assert drop_args["step_index"] == "step_3_transforms"
+        assert drop_args["prev_step"] == "step_3_transforms"
+        assert "validation_result" in drop_args, f"spec §9.1 requires validation_result on solver_exhausted drops; got: {drop_args}"
+        validation_result = drop_args["validation_result"]
+        assert isinstance(validation_result, dict)
+        assert validation_result["is_valid"] is False
+        assert "errors" in validation_result  # may be empty list, not absent
 
     def test_no_next_turn_after_auto_drop(self, composer_test_client: TestClient) -> None:
         """After auto-drop the next_turn must be None — wizard is terminal."""

--- a/tests/integration/web/composer/guided/test_auto_drop.py
+++ b/tests/integration/web/composer/guided/test_auto_drop.py
@@ -1,0 +1,351 @@
+"""Integration tests for Phase 5 Task 5.1: auto-drop to freeform on solver-exhausted.
+
+Drives a full session through Steps 1 + 2 + Step 3 PROPOSE_CHAIN and then
+exercises the repair-then-drop flow:
+
+- Both-fail test: first LLM call proposes a chain that fails preview, second
+  (repair) also fails → HTTP 200 with terminal kind=exited_to_freeform,
+  reason=solver_exhausted; audit record for guided_dropped_to_freeform emitted.
+
+- Repair-succeeds test: first LLM call proposes a bad chain, second proposes a
+  working passthrough chain → HTTP 200 with terminal kind=completed; no drop
+  event emitted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_step_3_e2e.py — kept local; no cross-file imports)
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    resp = client.post("/api/sessions", json={"title": "auto-drop-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    resp = client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _seed_blob(client: TestClient, session_id: str) -> tuple[str, str]:
+    content = "text,note\nHello world,greeting\nGoodbye,farewell\n"
+    resp = client.post(
+        f"/api/sessions/{session_id}/blobs/inline",
+        json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+    )
+    assert resp.status_code == 201, resp.json()
+    blob_id = resp.json()["id"]
+    blob_service = client.app.state.blob_service
+    record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+    return blob_id, record.storage_path
+
+
+def _outputs_path(client: TestClient, filename: str) -> str:
+    data_dir: Path = client.app.state.settings.data_dir
+    outputs_dir = data_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    return str(outputs_dir / filename)
+
+
+def _fake_llm_response_for_bad_plugin() -> SimpleNamespace:
+    """LiteLLM-shaped response proposing a nonexistent plugin.
+
+    ``definitely_not_a_real_plugin_xyzzy`` causes ``_validate_plugin_name`` to
+    fail in ``_execute_set_pipeline``, making ``handle_step_3_chain_accept``
+    return success=False — the failure mode exercised by the repair flow.
+    """
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "definitely_not_a_real_plugin_xyzzy",
+                                                    "options": {},
+                                                    "rationale": "stub: guaranteed to fail validation",
+                                                }
+                                            ],
+                                            "why": "stub that forces preview_pipeline failure",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
+def _fake_llm_response_for_passthrough() -> SimpleNamespace:
+    """LiteLLM-shaped response proposing a valid passthrough chain (will succeed)."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "passthrough",
+                                                    "options": {"schema": {"mode": "observed"}},
+                                                    "rationale": "pass rows through unchanged",
+                                                }
+                                            ],
+                                            "why": "source rows already match sink schema",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
+def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple[dict, str, str]:
+    """Drive the wizard to the Step 3 ``propose_chain`` turn.
+
+    Returns (response_body_at_step_3, blob_id, output_path).
+    Uses ``required_fields=["text"]`` (no classifier keyword) so no recipe
+    matches and the chain-solver entry seam fires.
+    """
+    blob_id, storage_path = _seed_blob(client, session_id)
+    output_path = _outputs_path(client, "out.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "note"],
+            "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "path": output_path,
+            "schema": {"mode": "observed"},
+            "collision_policy": "auto_increment",
+        },
+    )
+    body = _respond(
+        client,
+        session_id,
+        edited_values={
+            "outputs": [
+                {
+                    "plugin": "json",
+                    "options": {
+                        "path": output_path,
+                        "schema": {"mode": "observed"},
+                        "collision_policy": "auto_increment",
+                    },
+                    "required_fields": ["text"],
+                    "schema_mode": "observed",
+                }
+            ]
+        },
+    )
+    return body, blob_id, output_path
+
+
+def _get_tool_messages(client: TestClient, session_id: str) -> list:
+    """Return all role=tool messages for this session from the session service."""
+    service = client.app.state.session_service
+    msgs = asyncio.run(service.get_messages(UUID(session_id), limit=None))
+    return [m for m in msgs if m.role == "tool"]
+
+
+def _extract_guided_drop_invocations(client: TestClient, session_id: str) -> list[dict]:
+    """Return all guided_dropped_to_freeform invocation payloads for this session."""
+    tool_messages = _get_tool_messages(client, session_id)
+    drop_invocations = []
+    for msg in tool_messages:
+        if not msg.tool_calls:
+            continue
+        for tc in msg.tool_calls:
+            invocation = tc.get("invocation", {})
+            if invocation.get("tool_name") == "guided_dropped_to_freeform":
+                # arguments_canonical is the JSON-encoded payload dict
+                args_canonical = invocation.get("arguments_canonical", "{}")
+                drop_invocations.append(json.loads(args_canonical))
+    return drop_invocations
+
+
+# ---------------------------------------------------------------------------
+# Test: both initial and repair attempts fail → auto-drop to freeform (200)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDropOnSolverExhausted:
+    def test_both_attempts_fail_returns_200_with_terminal_exited_to_freeform(self, composer_test_client: TestClient) -> None:
+        """Both chain-solver attempts fail validation → HTTP 200, terminal=exited_to_freeform."""
+        session_id = _create_session(composer_test_client)
+
+        # Drive Steps 1 + 2 to reach PROPOSE_CHAIN.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        # Accept the (bad) chain. The initial commit fails, triggering one LLM
+        # repair call (also a bad plugin).  Both fail → auto-drop.
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=[_fake_llm_response_for_bad_plugin()],
+        ) as mock_llm:
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        # 1. Status code must be 200 — auto-drop is a clean wizard outcome.
+        assert resp.status_code == 200, resp.json()
+
+        body = resp.json()
+
+        # 2. Terminal in body must carry exited_to_freeform / solver_exhausted.
+        terminal = body.get("terminal")
+        assert terminal is not None, f"expected terminal in body, got: {body}"
+        assert terminal["kind"] == "exited_to_freeform", f"unexpected kind: {terminal}"
+        assert terminal["reason"] == "solver_exhausted", f"unexpected reason: {terminal}"
+        assert terminal["pipeline_yaml"] is None
+
+        # 3. GuidedSession terminal also set correctly.
+        gs = body["guided_session"]
+        assert gs["terminal"]["kind"] == "exited_to_freeform"
+        assert gs["terminal"]["reason"] == "solver_exhausted"
+
+        # 4. Repair call was made exactly once (one repair attempt).
+        assert mock_llm.call_count == 1
+
+        # 5. Audit record for guided_dropped_to_freeform must be present.
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert len(drop_invocations) == 1, (
+            f"expected exactly one guided_dropped_to_freeform audit record, got {len(drop_invocations)}: {drop_invocations}"
+        )
+        drop_args = drop_invocations[0]
+        assert drop_args["drop_reason"] == "solver_exhausted"
+        assert drop_args["step_index"] == "step_3_transforms"
+
+    def test_no_next_turn_after_auto_drop(self, composer_test_client: TestClient) -> None:
+        """After auto-drop the next_turn must be None — wizard is terminal."""
+        session_id = _create_session(composer_test_client)
+
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=[_fake_llm_response_for_bad_plugin()],
+        ):
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["next_turn"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test: first attempt fails, repair succeeds → COMPLETED (no drop event)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairSucceeds:
+    def test_first_fails_repair_succeeds_returns_completed(self, composer_test_client: TestClient) -> None:
+        """First chain fails, second (repair) succeeds → HTTP 200, terminal=completed."""
+        session_id = _create_session(composer_test_client)
+
+        # Drive Steps 1 + 2 to reach PROPOSE_CHAIN (initial solve: bad plugin).
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_bad_plugin(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+        # Accept. Initial commit fails → repair attempt returns passthrough (valid).
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            side_effect=[_fake_llm_response_for_passthrough()],
+        ) as mock_llm:
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"]},
+            )
+
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+
+        # Terminal must be COMPLETED with rendered YAML.
+        terminal = body.get("terminal")
+        assert terminal is not None
+        assert terminal["kind"] == "completed", f"unexpected kind: {terminal}"
+        assert terminal["reason"] is None
+        assert terminal["pipeline_yaml"] is not None
+        assert "passthrough" in terminal["pipeline_yaml"]
+
+        # next_turn is None — wizard is complete.
+        assert body["next_turn"] is None
+
+        # Exactly one repair call made.
+        assert mock_llm.call_count == 1
+
+        # No guided_dropped_to_freeform audit event emitted.
+        drop_invocations = _extract_guided_drop_invocations(composer_test_client, session_id)
+        assert drop_invocations == [], f"unexpected drop event in repair-succeeds path: {drop_invocations}"

--- a/tests/integration/web/composer/guided/test_auto_drop.py
+++ b/tests/integration/web/composer/guided/test_auto_drop.py
@@ -166,28 +166,21 @@ def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple
         client,
         session_id,
         edited_values={
-            "path": output_path,
-            "schema": {"mode": "observed"},
-            "collision_policy": "auto_increment",
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
         },
     )
     body = _respond(
         client,
         session_id,
-        edited_values={
-            "outputs": [
-                {
-                    "plugin": "json",
-                    "options": {
-                        "path": output_path,
-                        "schema": {"mode": "observed"},
-                        "collision_policy": "auto_increment",
-                    },
-                    "required_fields": ["text"],
-                    "schema_mode": "observed",
-                }
-            ]
-        },
+        chosen=["text"],
+        custom_inputs=[],
     )
     return body, blob_id, output_path
 

--- a/tests/integration/web/composer/guided/test_chain_solver.py
+++ b/tests/integration/web/composer/guided/test_chain_solver.py
@@ -1,0 +1,82 @@
+"""Tests for guided-mode chain solver (stubbed LLM only).
+
+The real-LLM gated test lives in Task 4.6 closure once the real_llm marker
+is registered.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_returns_chain_proposal() -> None:
+    from elspeth.web.composer.guided.chain_solver import solve_chain
+    from elspeth.web.composer.guided.state_machine import (
+        SinkOutputResolved,
+        SinkResolved,
+        SourceResolved,
+    )
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "type_coerce",
+                                                    "options": {"fields": [{"name": "price", "type": "float"}]},
+                                                    "rationale": "price is str; downstream needs float",
+                                                }
+                                            ],
+                                            "why": "bridge str→float for arithmetic",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+    with patch(
+        "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+        new_callable=AsyncMock,
+        return_value=fake_response,
+    ):
+        proposal = await solve_chain(
+            source=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("price",),
+                sample_rows=({"price": "1.99"},),
+            ),
+            sink=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={},
+                        required_fields=("price",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+        )
+
+    assert len(proposal.steps) == 1
+    assert proposal.steps[0]["plugin"] == "type_coerce"
+    assert proposal.why == "bridge str→float for arithmetic"

--- a/tests/integration/web/composer/guided/test_chain_solver.py
+++ b/tests/integration/web/composer/guided/test_chain_solver.py
@@ -13,6 +13,40 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+def _make_propose_chain_response(plugin: str = "type_coerce") -> SimpleNamespace:
+    """Build a LiteLLM-shaped propose_chain response for the given plugin."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": plugin,
+                                                    "options": {"fields": [{"name": "price", "type": "float"}]},
+                                                    "rationale": "test rationale",
+                                                }
+                                            ],
+                                            "why": "bridge str→float for arithmetic",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
 @pytest.mark.asyncio
 async def test_returns_chain_proposal() -> None:
     from elspeth.web.composer.guided.chain_solver import solve_chain
@@ -80,3 +114,104 @@ async def test_returns_chain_proposal() -> None:
     assert len(proposal.steps) == 1
     assert proposal.steps[0]["plugin"] == "type_coerce"
     assert proposal.why == "bridge str→float for arithmetic"
+
+
+@pytest.mark.asyncio
+async def test_repair_context_appears_in_system_prompt() -> None:
+    """solve_chain with repair_context= appends the repair addendum to the system prompt.
+
+    Verifies that the repair context is visible in the messages passed to
+    _litellm_acompletion — proving the addendum reaches the LLM.
+    """
+    from elspeth.web.composer.guided.chain_solver import solve_chain
+    from elspeth.web.composer.guided.state_machine import (
+        SinkOutputResolved,
+        SinkResolved,
+        SourceResolved,
+    )
+
+    repair_error = "plugin 'bad_plugin' not found in catalogue"
+
+    fake_response = _make_propose_chain_response()
+
+    captured_calls: list = []
+
+    async def _capture(**kwargs):  # type: ignore[no-untyped-def]
+        captured_calls.append(kwargs)
+        return fake_response
+
+    with patch(
+        "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+        side_effect=_capture,
+    ):
+        await solve_chain(
+            source=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("price",),
+                sample_rows=({"price": "1.99"},),
+            ),
+            sink=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={},
+                        required_fields=("price",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+            repair_context=repair_error,
+        )
+
+    assert len(captured_calls) == 1
+    messages = captured_calls[0]["messages"]
+    system_content = messages[0]["content"]
+    # The repair addendum must be present verbatim.
+    assert "REPAIR ATTEMPT" in system_content
+    assert repair_error in system_content
+
+
+@pytest.mark.asyncio
+async def test_solve_chain_without_repair_context_has_no_repair_section() -> None:
+    """solve_chain without repair_context= does not add a REPAIR ATTEMPT section."""
+    from elspeth.web.composer.guided.chain_solver import solve_chain
+    from elspeth.web.composer.guided.state_machine import (
+        SinkOutputResolved,
+        SinkResolved,
+        SourceResolved,
+    )
+
+    fake_response = _make_propose_chain_response()
+    captured_calls: list = []
+
+    async def _capture(**kwargs):  # type: ignore[no-untyped-def]
+        captured_calls.append(kwargs)
+        return fake_response
+
+    with patch(
+        "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+        side_effect=_capture,
+    ):
+        await solve_chain(
+            source=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("price",),
+                sample_rows=({"price": "1.99"},),
+            ),
+            sink=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={},
+                        required_fields=("price",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+        )
+
+    assert len(captured_calls) == 1
+    system_content = captured_calls[0]["messages"][0]["content"]
+    assert "REPAIR ATTEMPT" not in system_content

--- a/tests/integration/web/composer/guided/test_chain_solver.py
+++ b/tests/integration/web/composer/guided/test_chain_solver.py
@@ -93,6 +93,7 @@ async def test_returns_chain_proposal() -> None:
         return_value=fake_response,
     ):
         proposal = await solve_chain(
+            model="anthropic/claude-3-opus",
             source=SourceResolved(
                 plugin="csv",
                 options={},
@@ -145,6 +146,7 @@ async def test_repair_context_appears_in_system_prompt() -> None:
         side_effect=_capture,
     ):
         await solve_chain(
+            model="anthropic/claude-3-opus",
             source=SourceResolved(
                 plugin="csv",
                 options={},
@@ -194,6 +196,7 @@ async def test_solve_chain_without_repair_context_has_no_repair_section() -> Non
         side_effect=_capture,
     ):
         await solve_chain(
+            model="anthropic/claude-3-opus",
             source=SourceResolved(
                 plugin="csv",
                 options={},
@@ -215,3 +218,58 @@ async def test_solve_chain_without_repair_context_has_no_repair_section() -> Non
     assert len(captured_calls) == 1
     system_content = captured_calls[0]["messages"][0]["content"]
     assert "REPAIR ATTEMPT" not in system_content
+
+
+@pytest.mark.asyncio
+async def test_model_and_temperature_passed_to_litellm() -> None:
+    """solve_chain passes the supplied model and temperature=0.0 to _litellm_acompletion.
+
+    Asymmetry probe: if model=model is reverted to a hard-coded string, the
+    ``captured_calls[0]["model"] == TEST_MODEL`` assertion fails.
+    """
+    from elspeth.web.composer.guided.chain_solver import solve_chain
+    from elspeth.web.composer.guided.state_machine import (
+        SinkOutputResolved,
+        SinkResolved,
+        SourceResolved,
+    )
+
+    TEST_MODEL = "openai/gpt-4o-mini"
+
+    fake_response = _make_propose_chain_response()
+    captured_calls: list = []
+
+    async def _capture(**kwargs):  # type: ignore[no-untyped-def]
+        captured_calls.append(kwargs)
+        return fake_response
+
+    with patch(
+        "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+        side_effect=_capture,
+    ):
+        await solve_chain(
+            model=TEST_MODEL,
+            source=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("price",),
+                sample_rows=({"price": "1.99"},),
+            ),
+            sink=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={},
+                        required_fields=("price",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+        )
+
+    assert len(captured_calls) == 1
+    call = captured_calls[0]
+    # Model must be the caller-supplied value, not any hard-coded string.
+    assert call["model"] == TEST_MODEL
+    # Temperature must match the composer constant (0.0) for deterministic output.
+    assert call["temperature"] == 0.0

--- a/tests/integration/web/composer/guided/test_default_guided.py
+++ b/tests/integration/web/composer/guided/test_default_guided.py
@@ -1,0 +1,48 @@
+"""Verify default-guided invariant: fresh sessions get GuidedSession.initial()
+attached on first lazy-create in any endpoint.
+
+Per errata C7 / spec §5.2 — new sessions default to guided mode. The route
+layer's lazy-create branch is the only place fresh CompositionState is
+built (SessionServiceImpl.create_session does not eagerly persist state);
+the _initial_composition_state_with_guided_session helper applied
+uniformly enforces the invariant.
+
+HTTP-level test (driving lazy-create via send_message or recompose) is
+deferred to Task 3.5, which mounts the /guided/respond endpoint and will
+have a natural trigger for state lazy-create. The unit test of the helper
+is sufficient for Task 3.4's acceptance criterion.
+"""
+
+from __future__ import annotations
+
+from elspeth.web.composer.guided.protocol import GuidedStep
+
+
+def test_helper_attaches_initial_guided_session() -> None:
+    """The factory helper returns CompositionState with GuidedSession.initial()."""
+    from elspeth.web.sessions.routes import _initial_composition_state_with_guided_session
+
+    state = _initial_composition_state_with_guided_session()
+
+    assert state.source is None
+    assert state.nodes == ()
+    assert state.edges == ()
+    assert state.outputs == ()
+    assert state.version == 1
+    assert state.guided_session is not None
+    assert state.guided_session.step is GuidedStep.STEP_1_SOURCE
+    assert state.guided_session.terminal is None
+    assert state.guided_session.history == ()
+
+
+def test_helper_is_deterministic() -> None:
+    """Two calls produce equal (but distinct) GuidedSession instances."""
+    from elspeth.web.sessions.routes import _initial_composition_state_with_guided_session
+
+    a = _initial_composition_state_with_guided_session()
+    b = _initial_composition_state_with_guided_session()
+
+    # Equal: same shape, same step
+    assert a.guided_session == b.guided_session
+    # Distinct CompositionState instances (no shared state)
+    assert a is not b

--- a/tests/integration/web/composer/guided/test_error_paths.py
+++ b/tests/integration/web/composer/guided/test_error_paths.py
@@ -1,0 +1,238 @@
+"""Integration tests for POST /api/sessions/{id}/guided/respond — error paths.
+
+Covers:
+  - exit_to_freeform control signal terminates the guided session (§5.3)
+  - POST /guided/respond after terminal state returns 409 (§9.4)
+  - POST /guided/respond before GET /guided (no TurnRecord) returns 400
+  - POST /guided/respond on a session not in guided mode returns 400
+
+HTTP transport: SyncASGITestClient (in-process, synchronous — same pattern
+as test_respond.py).
+
+Per spec §5.3, §9.4:
+  - Any control_signal="exit_to_freeform" → terminal.kind="exited_to_freeform",
+    terminal.reason="user_pressed_exit", next_turn=None
+  - Any respond after terminal → 409 Conflict
+"""
+
+from __future__ import annotations
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated from test_respond.py — these are self-contained tests
+# that must not import from another test module to avoid coupling)
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    """Create a session and return its string id."""
+    resp = client.post("/api/sessions", json={"title": "error-path-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    """Fetch GET /guided and assert 200."""
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _respond_raw(client: TestClient, session_id: str, **kwargs) -> object:
+    """POST /guided/respond and return the raw response (any status)."""
+    return client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+
+
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    """POST /guided/respond and assert 200."""
+    resp = _respond_raw(client, session_id, **kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# exit_to_freeform — §5.3 manual exit
+# ---------------------------------------------------------------------------
+
+
+class TestExitToFreeform:
+    def test_exit_from_step_1_terminates(self, composer_test_client: TestClient) -> None:
+        """exit_to_freeform from step 1 (SINGLE_SELECT) terminates with user_pressed_exit."""
+        session_id = _create_session(composer_test_client)
+        # Seed the first TurnRecord by fetching GET /guided.
+        _get_guided(composer_test_client, session_id)
+
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            control_signal="exit_to_freeform",
+        )
+
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+
+        # Top-level terminal field.
+        assert body["terminal"] is not None
+        assert body["terminal"]["kind"] == "exited_to_freeform"
+        assert body["terminal"]["reason"] == "user_pressed_exit"
+        assert body["terminal"]["pipeline_yaml"] is None
+
+        # guided_session.terminal is also set.
+        gs = body["guided_session"]
+        assert gs["terminal"] is not None
+        assert gs["terminal"]["kind"] == "exited_to_freeform"
+        assert gs["terminal"]["reason"] == "user_pressed_exit"
+
+        # No further turn is emitted — wizard is done.
+        assert body["next_turn"] is None
+
+    def test_exit_from_step_1_intra_step_terminates(self, composer_test_client: TestClient) -> None:
+        """exit_to_freeform works from within an intra-step turn (SCHEMA_FORM).
+
+        Drives step 1 to SCHEMA_FORM (after SINGLE_SELECT response), then exits.
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        # Advance to SCHEMA_FORM.
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        # Now exit from the SCHEMA_FORM turn.
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            control_signal="exit_to_freeform",
+        )
+
+        assert resp.status_code == 200, resp.json()
+        body = resp.json()
+        assert body["terminal"]["kind"] == "exited_to_freeform"
+        assert body["terminal"]["reason"] == "user_pressed_exit"
+        assert body["next_turn"] is None
+
+    def test_exit_terminal_is_persisted(self, composer_test_client: TestClient) -> None:
+        """After exit_to_freeform, GET /guided reflects the terminal state."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        _respond(
+            composer_test_client,
+            session_id,
+            control_signal="exit_to_freeform",
+        )
+
+        # Fetch guided state again — terminal must be persisted.
+        resp = composer_test_client.get(f"/api/sessions/{session_id}/guided")
+        assert resp.status_code == 200, resp.json()
+        guided = resp.json()["guided_session"]
+        assert guided["terminal"] is not None
+        assert guided["terminal"]["kind"] == "exited_to_freeform"
+
+
+# ---------------------------------------------------------------------------
+# 409 after terminal — §9.4 error matrix
+# ---------------------------------------------------------------------------
+
+
+class TestRespondAfterTerminal:
+    def _drive_to_terminal(self, client: TestClient, session_id: str) -> None:
+        """Drive the session to terminal via exit_to_freeform."""
+        _get_guided(client, session_id)
+        resp = _respond(client, session_id, control_signal="exit_to_freeform")
+        assert resp["terminal"] is not None
+
+    def test_respond_after_exit_returns_409(self, composer_test_client: TestClient) -> None:
+        """A second POST /guided/respond after terminal returns 409 Conflict."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_terminal(composer_test_client, session_id)
+
+        # Any subsequent respond must be rejected.
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            chosen=["csv"],
+        )
+
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "terminal" in detail.lower()
+
+    def test_respond_after_exit_returns_409_regardless_of_payload(self, composer_test_client: TestClient) -> None:
+        """409 is returned even if the payload would be otherwise valid."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_terminal(composer_test_client, session_id)
+
+        # Try another exit_to_freeform — still 409.
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            control_signal="exit_to_freeform",
+        )
+
+        assert resp.status_code == 409
+
+    def test_repeated_409_responses_are_stable(self, composer_test_client: TestClient) -> None:
+        """Multiple responds after terminal all return 409, not 500 (idempotent rejection)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_terminal(composer_test_client, session_id)
+
+        for _ in range(3):
+            resp = _respond_raw(
+                composer_test_client,
+                session_id,
+                chosen=["csv"],
+            )
+            assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Pre-condition violations — respond without prior GET /guided
+# ---------------------------------------------------------------------------
+
+
+class TestRespondPreconditions:
+    def test_respond_without_prior_get_guided_returns_400(self, composer_test_client: TestClient) -> None:
+        """POST /guided/respond before GET /guided (no TurnRecord) returns 400.
+
+        The route requires at least one TurnRecord to exist for the current
+        step — it cannot infer the turn type without one.  Callers must always
+        fetch GET /guided first to seed the initial turn.
+        """
+        session_id = _create_session(composer_test_client)
+        # Do NOT call _get_guided — no TurnRecord exists yet.
+
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            chosen=["csv"],
+        )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        # Should mention fetching GET /guided.
+        assert "guided" in detail.lower()
+
+    def test_respond_on_non_guided_session_returns_400(self, composer_test_client: TestClient) -> None:
+        """POST /guided/respond on a session with no guided_session returns 400.
+
+        Sessions only enter guided mode when created with guided=True (or when
+        the default guided session is initialised by the first GET /guided call).
+        A bare POST /api/sessions without the guided flag has no guided_session
+        and must be rejected with 400, not 500.
+
+        NOTE: In the current implementation, GET /guided auto-initialises the
+        guided session on first call, so this test creates a session and
+        bypasses the guided initialisation entirely by calling respond
+        against the initial empty state.
+        """
+        session_id = _create_session(composer_test_client)
+        # Do not call GET /guided — guided_session is None in initial state.
+
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            chosen=["csv"],
+        )
+
+        # Either 400 (no guided mode) or 400 (no TurnRecord) are acceptable —
+        # both indicate the call was rejected before doing any state mutation.
+        assert resp.status_code == 400

--- a/tests/integration/web/composer/guided/test_error_paths.py
+++ b/tests/integration/web/composer/guided/test_error_paths.py
@@ -358,3 +358,94 @@ class TestInvariantError500DetailIsSanitized:
         assert self._SENTINEL not in body_text
         assert "sample_rows" not in body_text
         assert "malformed record" not in body_text
+
+
+# ---------------------------------------------------------------------------
+# Server-invariant gates raise InvariantError (PR #37 review finding I1)
+#
+# Four sites previously raised ``RuntimeError`` for server-bug invariant
+# conditions (Step-3 repair guards + post-compose impossible-state guards).
+# RuntimeError lands at FastAPI's default 500 handler with no structured log
+# and no audit-system-failure exemption record. Converting to ``InvariantError``
+# routes the failure through the B1 sanitized handler: static 500 detail +
+# ``guided.invariant_violated`` slog event that on-call dashboards filter on.
+# ---------------------------------------------------------------------------
+
+
+class TestI1InvariantErrorStructuredLogging:
+    """Pin that the 4 sites converted in I1 fire the structured slog event
+    when the invariant is violated, not a generic FastAPI 500.
+
+    The B1 static-detail pin in ``TestInvariantError500DetailIsSanitized``
+    proves the response body is sanitized; this class proves the parallel
+    requirement — that the failure is observable via the structured log
+    channel keyed on ``guided.invariant_violated``.
+    """
+
+    _STATIC_DETAIL = "Server invariant violated. See application audit log for diagnostic detail."
+
+    def test_dispatcher_invariant_emits_structured_slog_event(
+        self,
+        composer_test_client: TestClient,
+        monkeypatch,
+    ) -> None:
+        """When ``_dispatch_guided_respond`` raises ``InvariantError`` (the
+        class the Step-3 repair guards at routes.py:~2396/2398 now raise),
+        the route emits a ``guided.invariant_violated`` slog event with the
+        B1-convention field set (``exc_class`` + ``frames`` + ``site``, no
+        raw exception message).
+
+        Without the RuntimeError → InvariantError conversion, the guard
+        would escape as a plain RuntimeError to FastAPI's default 500 with
+        no structured log — operators would see only "Internal Server
+        Error" with no audit-derivation trail.
+        """
+        from structlog.testing import capture_logs
+
+        from elspeth.web.composer.guided.errors import InvariantError
+        from elspeth.web.sessions import routes as routes_module
+
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        # Reproduce the exact text the converted Step-3 repair site raises.
+        # The site is unreachable from a well-formed client (Step 3 can only
+        # be entered after Steps 1+2 commit), so we patch the dispatcher to
+        # synthesise the InvariantError shape that ``raise InvariantError(...)``
+        # at routes.py:~2396 now produces.
+        async def _raise_invariant_in_dispatcher(*args, **kwargs):
+            raise InvariantError("repair: step_1_result is None — STEP_3 unreachable without Step 1 commit")
+
+        monkeypatch.setattr(routes_module, "_dispatch_guided_respond", _raise_invariant_in_dispatcher)
+
+        with capture_logs() as cap_logs:
+            resp = _respond_raw(
+                composer_test_client,
+                session_id,
+                chosen=["csv"],
+            )
+
+        # The dispatcher's outer except InvariantError handler converts to
+        # a sanitized 500 with the B1 static detail.
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == self._STATIC_DETAIL
+
+        # The structured slog event must be emitted under the B1 convention.
+        matches = [entry for entry in cap_logs if entry.get("event") == "guided.invariant_violated"]
+        assert matches, f"expected guided.invariant_violated slog event for converted dispatcher InvariantError; got entries: {cap_logs}"
+        entry = matches[0]
+
+        # Field-set pin. B1 convention: exc_class + frames + site +
+        # session_id + user_id. Never str(exc) or exc_info.
+        assert entry["exc_class"] == "InvariantError", entry
+        assert entry["site"] == "dispatch_guided_respond", entry
+        assert "frames" in entry, entry
+        assert "session_id" in entry, entry
+        assert "user_id" in entry, entry
+
+        # Forbidden keys: any field carrying the raw exception message is
+        # a B1 leak vector. The Step-3 repair message itself is harmless,
+        # but the dispatcher might one day raise an InvariantError whose
+        # message embeds {d!r} (cf. ``from_dict`` callers).
+        forbidden_keys = {"exc_message", "exception", "exc_info"}
+        assert not (forbidden_keys & entry.keys()), f"slog entry must not carry the raw exception message under the B1 convention: {entry}"

--- a/tests/integration/web/composer/guided/test_error_paths.py
+++ b/tests/integration/web/composer/guided/test_error_paths.py
@@ -236,3 +236,125 @@ class TestRespondPreconditions:
         # Either 400 (no guided mode) or 400 (no TurnRecord) are acceptable —
         # both indicate the call was rejected before doing any state mutation.
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Security — InvariantError 500 detail must not leak corrupted-record content
+# (PR #37 review finding B1)
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantError500DetailIsSanitized:
+    """Pin the B1 fix: the InvariantError → 500 catch must NOT interpolate
+    ``str(exc)`` into the HTTP response body.
+
+    Several ``from_dict`` raise sites in ``state_machine.py`` build their
+    message as ``f"...: malformed record {d!r}"`` — and ``d`` for
+    ``GuidedSession.from_dict`` / ``SourceResolved.from_dict`` contains
+    the Tier-3 ``sample_rows`` payload from the source plugin.  Echoing
+    that into the HTTP detail would surface user/PII content (e.g. CSV
+    cell values such as customer SSNs) to the browser-side JSON 500 body.
+
+    The catch sites at ``routes.py:`` (step_advance / dispatch_guided_respond)
+    now use a static detail message and route diagnostic content through
+    ``slog`` under the audit-system-failure exemption.
+    """
+
+    _SENTINEL = "AAA-BB-CCCC-SENTINEL-DO-NOT-LEAK"
+    _STATIC_DETAIL = "Server invariant violated. See application audit log for diagnostic detail."
+
+    def _seed_guided_session(self, client: TestClient, session_id: str) -> None:
+        """Seed the initial Step 1 SINGLE_SELECT TurnRecord so the respond
+        handler will load the session and reach ``step_advance``.
+        """
+        _get_guided(client, session_id)
+
+    def test_step_advance_invariant_does_not_leak_to_response(
+        self,
+        composer_test_client: TestClient,
+        monkeypatch,
+    ) -> None:
+        """When ``step_advance`` raises ``InvariantError`` with a sentinel
+        message, the HTTP 500 body contains the static detail and **not**
+        the sentinel content nor the field name ``sample_rows``.
+        """
+        from elspeth.web.composer.guided.errors import InvariantError
+        from elspeth.web.sessions import routes as routes_module
+
+        session_id = _create_session(composer_test_client)
+        self._seed_guided_session(composer_test_client, session_id)
+
+        # Replace ``step_advance`` as the route module imported it (top-level
+        # ``from ... import step_advance``).  The patched function builds a
+        # message shaped like ``GuidedSession.from_dict``'s ``{d!r}`` repr so
+        # this test reproduces the leak vector the unpatched code would have
+        # surfaced into ``detail``.
+        leaky_record_repr = "{'sample_rows': [{'ssn': '" + self._SENTINEL + "', 'name': 'Alice'}], 'step': 'step_1_source'}"
+
+        def _raise_invariant_with_leak(*args, **kwargs):
+            raise InvariantError(f"GuidedSession.from_dict: malformed record {leaky_record_repr}")
+
+        monkeypatch.setattr(routes_module, "step_advance", _raise_invariant_with_leak)
+
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            chosen=["csv"],
+        )
+
+        assert resp.status_code == 500
+        body = resp.json()
+        detail = body["detail"]
+
+        # Static-detail pin.
+        assert detail == self._STATIC_DETAIL, f"InvariantError 500 detail must be the static B1 message; got {detail!r}"
+
+        # Negative pins: neither the sentinel nor structural leak markers
+        # may appear anywhere in the serialised body.  Using the full body
+        # text (not just ``detail``) catches accidental leaks via response
+        # headers or auxiliary fields.
+        body_text = resp.text
+        assert self._SENTINEL not in body_text, "B1 leak: sentinel content escaped into the 500 response body"
+        assert "sample_rows" not in body_text, "B1 leak: structural field name 'sample_rows' surfaced in the 500 response body"
+        assert "malformed record" not in body_text, "B1 leak: from_dict error prefix surfaced in the 500 response body"
+
+    def test_dispatcher_invariant_does_not_leak_to_response(
+        self,
+        composer_test_client: TestClient,
+        monkeypatch,
+    ) -> None:
+        """When the dispatcher path raises ``InvariantError`` with a sentinel
+        message, the HTTP 500 body contains the static detail and **not**
+        the sentinel content.
+
+        Exercises the second catch site (after ``step_advance`` succeeds but
+        ``_dispatch_guided_respond`` raises).  Patches the dispatcher
+        directly to inject the leaky message.
+        """
+        from elspeth.web.composer.guided.errors import InvariantError
+        from elspeth.web.sessions import routes as routes_module
+
+        session_id = _create_session(composer_test_client)
+        self._seed_guided_session(composer_test_client, session_id)
+
+        leaky_record_repr = "{'sample_rows': [{'ssn': '" + self._SENTINEL + "', 'name': 'Bob'}], 'plugin': 'csv'}"
+
+        async def _raise_invariant_in_dispatcher(*args, **kwargs):
+            raise InvariantError(f"SourceResolved.from_dict: malformed record {leaky_record_repr}")
+
+        monkeypatch.setattr(routes_module, "_dispatch_guided_respond", _raise_invariant_in_dispatcher)
+
+        resp = _respond_raw(
+            composer_test_client,
+            session_id,
+            chosen=["csv"],
+        )
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert detail == self._STATIC_DETAIL, f"Dispatcher InvariantError 500 detail must be the static B1 message; got {detail!r}"
+
+        body_text = resp.text
+        assert self._SENTINEL not in body_text
+        assert "sample_rows" not in body_text
+        assert "malformed record" not in body_text

--- a/tests/integration/web/composer/guided/test_fixture_smoke.py
+++ b/tests/integration/web/composer/guided/test_fixture_smoke.py
@@ -6,6 +6,7 @@ properly configured and the session creation endpoint works end-to-end.
 
 from __future__ import annotations
 
+from elspeth.web.composer.audit import BufferingRecorder
 from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
 
 
@@ -26,15 +27,12 @@ class TestFixtureSmoke:
 
     def test_audit_recorder_is_present(self, composer_test_client: TestClient) -> None:
         """App state has composer_recorder fixture."""
-        app = composer_test_client.app
-        assert hasattr(app.state, "composer_recorder")
-        assert app.state.composer_recorder is not None
+        recorder = composer_test_client.app.state.composer_recorder
+        assert recorder is not None
 
-    def test_audit_recorder_fixture_accessible(self, audit_recorder) -> None:
-        """audit_recorder fixture yields a BufferingRecorder."""
-        from elspeth.web.composer.audit import BufferingRecorder
-
-        assert isinstance(audit_recorder, BufferingRecorder)
+    def test_audit_recorder_fixture_accessible(self, audit_recorder: BufferingRecorder) -> None:
+        """audit_recorder fixture yields a BufferingRecorder with empty initial state."""
+        assert audit_recorder.invocations == ()
 
     def test_session_list_works(self, composer_test_client: TestClient) -> None:
         """GET /api/sessions returns list of sessions."""

--- a/tests/integration/web/composer/guided/test_fixture_smoke.py
+++ b/tests/integration/web/composer/guided/test_fixture_smoke.py
@@ -1,0 +1,54 @@
+"""Smoke test for composer guided fixtures.
+
+Verifies that the composer_test_client and audit_recorder fixtures are
+properly configured and the session creation endpoint works end-to-end.
+"""
+
+from __future__ import annotations
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+
+class TestFixtureSmoke:
+    """Verify that fixtures are properly wired."""
+
+    def test_session_creation_works(self, composer_test_client: TestClient) -> None:
+        """POST /api/sessions creates a session and returns 201."""
+        resp = composer_test_client.post(
+            "/api/sessions",
+            json={"title": "Test Session"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "id" in body
+        assert body["title"] == "Test Session"
+        assert body["user_id"] == "alice"
+
+    def test_audit_recorder_is_present(self, composer_test_client: TestClient) -> None:
+        """App state has composer_recorder fixture."""
+        app = composer_test_client.app
+        assert hasattr(app.state, "composer_recorder")
+        assert app.state.composer_recorder is not None
+
+    def test_audit_recorder_fixture_accessible(self, audit_recorder) -> None:
+        """audit_recorder fixture yields a BufferingRecorder."""
+        from elspeth.web.composer.audit import BufferingRecorder
+
+        assert isinstance(audit_recorder, BufferingRecorder)
+
+    def test_session_list_works(self, composer_test_client: TestClient) -> None:
+        """GET /api/sessions returns list of sessions."""
+        # Create a session first
+        create_resp = composer_test_client.post(
+            "/api/sessions",
+            json={"title": "Session 1"},
+        )
+        assert create_resp.status_code == 201
+
+        # List sessions
+        list_resp = composer_test_client.get("/api/sessions")
+        assert list_resp.status_code == 200
+        body = list_resp.json()
+        assert isinstance(body, list)
+        assert len(body) > 0
+        assert body[0]["title"] == "Session 1"

--- a/tests/integration/web/composer/guided/test_get_guided.py
+++ b/tests/integration/web/composer/guided/test_get_guided.py
@@ -45,6 +45,13 @@ def _get_guided(client: TestClient, session_id: str) -> dict:
     return resp.json()
 
 
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    """POST /guided/respond and assert 200."""
+    resp = client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -228,3 +235,132 @@ class TestGetGuidedNotFound:
         fake_id = "00000000-0000-0000-0000-000000000000"
         resp = composer_test_client.get(f"/api/sessions/{fake_id}/guided")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# M2: GET /guided after step advance returns step-2 turn, not step-1
+# ---------------------------------------------------------------------------
+
+
+class TestGetGuidedAfterStepAdvance:
+    """M2: Verifies C1 fix — GET /guided dispatches per-step, not unconditionally step-1.
+
+    Before the fix, GET /guided always called build_initial_step_1_turn regardless
+    of guided.step.  A session advanced to step 2 would receive a step-1
+    single_select (listing source plugins) instead of the step-2 single_select
+    (listing sink plugins).  The test drives through step 1 via POST /respond and
+    then GETs /guided, asserting the response reflects step 2.
+    """
+
+    def _seed_blob(self, client: TestClient, session_id: str) -> tuple[str, str]:
+        """Seed a CSV blob and return (blob_id, storage_path)."""
+        import asyncio
+        from uuid import UUID
+
+        content = "col_a,col_b\n1,x\n2,y\n"
+        resp = client.post(
+            f"/api/sessions/{session_id}/blobs/inline",
+            json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+        )
+        assert resp.status_code == 201, resp.json()
+        blob_id = resp.json()["id"]
+        blob_service = client.app.state.blob_service
+        record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+        return blob_id, record.storage_path
+
+    def _outputs_path(self, client: TestClient, filename: str) -> str:
+        """Return an absolute path under {data_dir}/outputs/."""
+        from pathlib import Path
+
+        data_dir: Path = client.app.state.settings.data_dir
+        outputs_dir = data_dir / "outputs"
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+        return str(outputs_dir / filename)
+
+    def test_get_guided_after_step_1_advance_returns_step_2_turn(self, composer_test_client: TestClient) -> None:
+        """GET /guided after step-1 → step-2 advance returns a step-2 next_turn.
+
+        Sequence:
+        1. Create session.
+        2. GET /guided → step-1 single_select.
+        3. POST /respond chosen=["csv"] → intra-step schema_form.
+        4. POST /respond edited_values={plugin, options, ...} → advance to step 2.
+        5. GET /guided → must return step-2 single_select (sink plugins), NOT step-1.
+
+        Distinguishes step-1 from step-2 single_select via step_index (0 vs 1)
+        and payload.question text; both must indicate step 2 (index=1, sink list).
+        """
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = self._seed_blob(composer_test_client, session_id)
+
+        # Step 1: initialise
+        get1 = _get_guided(composer_test_client, session_id)
+        assert get1["next_turn"]["type"] == "single_select"
+        assert get1["next_turn"]["step_index"] == 0  # STEP_1_SOURCE
+
+        # Step 1: pick csv source
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        # Step 1: submit schema_form → advances to step 2
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["col_a", "col_b"],
+                "sample_rows": [],
+            },
+        )
+
+        # GET /guided after step advance must reflect step 2, not step 1.
+        get2 = _get_guided(composer_test_client, session_id)
+
+        assert get2["guided_session"]["step"] == "step_2_sink", (
+            f"guided_session.step should be step_2_sink but got {get2['guided_session']['step']!r}"
+        )
+        assert get2["next_turn"] is not None, "next_turn must not be None at step 2"
+        # step_index must be 1 (STEP_2_SINK), not 0 (STEP_1_SOURCE).
+        assert get2["next_turn"]["step_index"] == 1, (
+            f"Expected step_index=1 (STEP_2_SINK) but got {get2['next_turn']['step_index']!r} — "
+            "C1 regression: GET /guided returned step-1 turn after step advance"
+        )
+        # Turn type must be single_select listing sink plugins (not source plugins).
+        assert get2["next_turn"]["type"] == "single_select"
+        option_ids = [o["id"] for o in get2["next_turn"]["payload"]["options"]]
+        # Step-1 single_select lists source plugins (e.g. "csv").
+        # Step-2 single_select lists sink plugins (e.g. "json").
+        assert "json" in option_ids, f"Sink plugin 'json' missing from options — may be getting step-1 source list: {option_ids}"
+
+    def test_get_guided_after_step_advance_is_idempotent(self, composer_test_client: TestClient) -> None:
+        """Re-fetching GET /guided at step 2 returns the same turn (idempotency).
+
+        After step 1 advances to step 2, the first GET /guided at step 2 emits a
+        TurnRecord and persists it.  A second GET must return the same step_index
+        and turn type without appending a new record.
+        """
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = self._seed_blob(composer_test_client, session_id)
+
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["col_a"],
+                "sample_rows": [],
+            },
+        )
+
+        get_a = _get_guided(composer_test_client, session_id)
+        get_b = _get_guided(composer_test_client, session_id)
+
+        # Both fetches must return the same step-2 turn.
+        assert get_a["next_turn"]["step_index"] == get_b["next_turn"]["step_index"] == 1
+        assert get_a["next_turn"]["type"] == get_b["next_turn"]["type"] == "single_select"
+        # Idempotency: second fetch must not append an extra TurnRecord at step 2.
+        step_2_records = [r for r in get_b["guided_session"]["history"] if r["step"] == "step_2_sink"]
+        assert len(step_2_records) == 1, f"Expected exactly 1 step_2_sink TurnRecord on re-fetch, got {len(step_2_records)}"

--- a/tests/integration/web/composer/guided/test_get_guided.py
+++ b/tests/integration/web/composer/guided/test_get_guided.py
@@ -1,0 +1,230 @@
+"""Integration tests for GET /api/sessions/{id}/guided.
+
+Verifies:
+- First fetch emits a turn, persists a TurnRecord to guided_session.history,
+  and saves the updated state via save_composition_state.
+- Re-fetch is idempotent: same payload_hash returned, no second TurnRecord
+  appended, no second audit event persisted.
+- Audit message (role=tool) is persisted after first fetch.
+- 400 on freeform sessions (no guided_session attached — not currently
+  exercised since all new sessions default to guided per spec §5.2).
+
+HTTP transport: SyncASGITestClient (in-process, synchronous — same pattern
+as test_fixture_smoke.py).  The full roundtrip exercises:
+  - route handler lock + load-or-create branch
+  - emitters.build_initial_step_1_turn (single_select)
+  - GuidedSession serialisation into composer_meta
+  - state_from_record restoring guided_session
+  - audit drain via _persist_tool_invocations
+
+Per spec §5.2 / errata C7: all fresh sessions default to guided mode.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    """Create a session and return its id."""
+    resp = client.post("/api/sessions", json={"title": "guided-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    """Call GET /api/sessions/{id}/guided."""
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetGuidedFirstFetch:
+    def test_returns_200_with_guided_session(self, composer_test_client: TestClient) -> None:
+        """GET /guided on a fresh session returns HTTP 200 with guided_session."""
+        session_id = _create_session(composer_test_client)
+        body = _get_guided(composer_test_client, session_id)
+
+        assert "guided_session" in body
+        assert body["guided_session"]["step"] == "step_1_source"
+
+    def test_next_turn_is_single_select(self, composer_test_client: TestClient) -> None:
+        """Without a blob, next_turn is a single_select over source plugins."""
+        session_id = _create_session(composer_test_client)
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "single_select"
+        payload = body["next_turn"]["payload"]
+        assert "options" in payload
+        assert len(payload["options"]) > 0  # at least one source plugin registered
+        # CSV plugin must be listed (canonical source for test data)
+        option_ids = [o["id"] for o in payload["options"]]
+        assert "csv" in option_ids, f"csv not in option_ids: {option_ids}"
+
+    def test_history_has_one_record_after_first_fetch(self, composer_test_client: TestClient) -> None:
+        """After first fetch, guided_session.history contains exactly one TurnRecord."""
+        session_id = _create_session(composer_test_client)
+        body = _get_guided(composer_test_client, session_id)
+
+        history = body["guided_session"]["history"]
+        assert len(history) == 1
+        record = history[0]
+        assert record["step"] == "step_1_source"
+        assert record["turn_type"] == "single_select"
+        assert record["emitter"] == "server"
+        assert record["payload_hash"]  # non-empty hash string
+        assert record["response_hash"] is None
+
+    def test_payload_hash_matches_deterministic_turn(self, composer_test_client: TestClient) -> None:
+        """payload_hash is the stable_hash of the turn payload."""
+        from elspeth.core.canonical import stable_hash
+
+        session_id = _create_session(composer_test_client)
+        body = _get_guided(composer_test_client, session_id)
+
+        recorded_hash = body["guided_session"]["history"][0]["payload_hash"]
+        returned_payload = body["next_turn"]["payload"]
+        expected_hash = stable_hash(returned_payload)
+        assert recorded_hash == expected_hash
+
+
+class TestGetGuidedIdempotency:
+    def test_second_fetch_returns_same_payload_hash(self, composer_test_client: TestClient) -> None:
+        """Re-fetching the same session returns the identical payload_hash."""
+        session_id = _create_session(composer_test_client)
+
+        body1 = _get_guided(composer_test_client, session_id)
+        body2 = _get_guided(composer_test_client, session_id)
+
+        hash1 = body1["guided_session"]["history"][0]["payload_hash"]
+        hash2 = body2["guided_session"]["history"][0]["payload_hash"]
+        assert hash1 == hash2
+
+    def test_second_fetch_does_not_append_extra_record(self, composer_test_client: TestClient) -> None:
+        """Re-fetching does not grow the history — idempotent."""
+        session_id = _create_session(composer_test_client)
+
+        _get_guided(composer_test_client, session_id)
+        body2 = _get_guided(composer_test_client, session_id)
+
+        assert len(body2["guided_session"]["history"]) == 1
+
+    def test_second_fetch_has_same_turn_type(self, composer_test_client: TestClient) -> None:
+        """Re-fetching returns the same turn type as the first fetch."""
+        session_id = _create_session(composer_test_client)
+
+        body1 = _get_guided(composer_test_client, session_id)
+        body2 = _get_guided(composer_test_client, session_id)
+
+        assert body1["next_turn"]["type"] == body2["next_turn"]["type"]
+
+
+class TestGetGuidedStatePersistence:
+    def test_guided_session_survives_roundtrip(self, composer_test_client: TestClient) -> None:
+        """guided_session restored from DB on second fetch is equal to first-fetch state.
+
+        This is the key Tier 1 round-trip test: the GuidedSession serialised
+        into composer_meta on first fetch must deserialise identically on
+        second fetch.  In-process identity is not sufficient — state_from_record
+        must reconstruct the same GuidedSession.
+
+        The test verifies the history length and record fields to catch
+        serialisation gaps (missing field, type drift, enum coercion failure).
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)  # first fetch: saves state
+        body2 = _get_guided(composer_test_client, session_id)  # second: loads from DB
+
+        # Restored session must have history.
+        history = body2["guided_session"]["history"]
+        assert len(history) == 1
+        r = history[0]
+        assert r["step"] == "step_1_source"
+        assert r["turn_type"] == "single_select"
+        assert r["emitter"] == "server"
+        assert r["response_hash"] is None
+
+    def test_composition_state_returned_after_first_fetch(self, composer_test_client: TestClient) -> None:
+        """composition_state in response is non-None after first fetch."""
+        session_id = _create_session(composer_test_client)
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["composition_state"] is not None
+
+
+class TestGetGuidedAuditTrail:
+    def _get_tool_messages(self, client: TestClient, session_id: str) -> list:
+        """Query chat messages from service layer directly (bypasses API filter).
+
+        Audit messages (role=tool, _kind=audit) are deliberately excluded from
+        the public GET /messages API response — they are internal audit rows,
+        not conversation turns.  Query the service layer directly to verify
+        persistence.
+
+        Uses ``asyncio.run()`` since SyncASGITestClient runs in a thread pool
+        that may not have an active event loop.
+        """
+        import asyncio
+
+        app = client.app
+        service = app.state.session_service
+
+        msgs = asyncio.run(service.get_messages(UUID(session_id), limit=None))
+        return [m for m in msgs if m.role == "tool"]
+
+    def test_audit_message_persisted_after_first_fetch(self, composer_test_client: TestClient) -> None:
+        """An audit role=tool message is persisted after the first GET /guided call.
+
+        Verifies that _persist_tool_invocations was called with the recorder's
+        contents.
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        tool_messages = self._get_tool_messages(composer_test_client, session_id)
+        assert len(tool_messages) >= 1, f"Expected at least one role=tool audit message, got {len(tool_messages)}"
+
+        # Verify guided_turn_emitted is present.
+        def _has_guided_turn_emitted(msg) -> bool:
+            tool_calls = msg.tool_calls
+            if not tool_calls:
+                return False
+            for tc in tool_calls:
+                invocation = tc.get("invocation", {})
+                if invocation.get("tool_name") == "guided_turn_emitted":
+                    return True
+            return False
+
+        assert any(_has_guided_turn_emitted(m) for m in tool_messages), (
+            f"No guided_turn_emitted found in tool messages: {[m.tool_calls for m in tool_messages]}"
+        )
+
+    def test_no_second_audit_message_on_refetch(self, composer_test_client: TestClient) -> None:
+        """Re-fetching does not add a second role=tool audit message."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)  # first
+        _get_guided(composer_test_client, session_id)  # re-fetch
+
+        tool_messages = self._get_tool_messages(composer_test_client, session_id)
+        # Only one guided_turn_emitted audit message — re-fetch must not re-emit.
+        assert len(tool_messages) == 1
+
+
+class TestGetGuidedNotFound:
+    def test_returns_404_for_unknown_session(self, composer_test_client: TestClient) -> None:
+        """GET /guided on a non-existent session returns 404."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        resp = composer_test_client.get(f"/api/sessions/{fake_id}/guided")
+        assert resp.status_code == 404

--- a/tests/integration/web/composer/guided/test_get_guided.py
+++ b/tests/integration/web/composer/guided/test_get_guided.py
@@ -8,6 +8,12 @@ Verifies:
 - Audit message (role=tool) is persisted after first fetch.
 - 400 on freeform sessions (no guided_session attached — not currently
   exercised since all new sessions default to guided per spec §5.2).
+- M3: GET /guided rebuilds Step 3 propose_chain from staged step_3_proposal
+  (Codex #5 fix — previously returned next_turn: null at STEP_3_TRANSFORMS).
+- M4: GET /guided rebuilds intra-step Step 2 turns from staged fields
+  (Codex #10 fix — previously always returned the initial SINGLE_SELECT).
+- M5: GET /guided passes blob inspection facts to build_initial_step_1_turn
+  when step_1_source_intent is set (Codex #14 fix — previously passed None).
 
 HTTP transport: SyncASGITestClient (in-process, synchronous — same pattern
 as test_fixture_smoke.py).  The full roundtrip exercises:
@@ -22,6 +28,7 @@ Per spec §5.2 / errata C7: all fresh sessions default to guided mode.
 
 from __future__ import annotations
 
+import asyncio
 from uuid import UUID
 
 from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
@@ -364,3 +371,254 @@ class TestGetGuidedAfterStepAdvance:
         # Idempotency: second fetch must not append an extra TurnRecord at step 2.
         step_2_records = [r for r in get_b["guided_session"]["history"] if r["step"] == "step_2_sink"]
         assert len(step_2_records) == 1, f"Expected exactly 1 step_2_sink TurnRecord on re-fetch, got {len(step_2_records)}"
+
+
+# ---------------------------------------------------------------------------
+# M3/M4/M5: GET /guided full-state rebuild (Codex #5, #10, #14)
+#
+# These tests seed GuidedSession state directly via save_composition_state
+# to place the session at a specific intra-step position, then verify that
+# GET /guided returns the correct turn for that position.
+# ---------------------------------------------------------------------------
+
+
+def _seed_guided_session(client: TestClient, session_id: str, guided_session_dict: dict) -> None:
+    """Persist a pre-built guided session dict into composer_meta.
+
+    Seeds state directly via save_composition_state — the same pattern used
+    by test_respond._seed_inspect_and_confirm_history.  This bypasses the
+    normal POST /respond flow so tests can place the session at arbitrary
+    intra-step positions without driving the full wizard sequence.
+    """
+    from elspeth.contracts.freeze import deep_thaw
+    from elspeth.web.sessions.converters import state_from_record
+    from elspeth.web.sessions.protocol import CompositionStateData
+    from elspeth.web.sessions.routes import _initial_composition_state_with_guided_session
+
+    service = client.app.state.session_service
+    session_uuid = UUID(session_id)
+    state_record = asyncio.run(service.get_current_state(session_uuid))
+
+    if state_record is None:
+        state = _initial_composition_state_with_guided_session()
+        existing_meta: dict = {}
+    else:
+        state = state_from_record(state_record)
+        existing_meta = dict(deep_thaw(state_record.composer_meta)) if state_record.composer_meta else {}
+
+    new_composer_meta = {**existing_meta, "guided_session": guided_session_dict}
+    state_d = state.to_dict()
+    state_data = CompositionStateData(
+        source=state_d["source"],
+        nodes=state_d["nodes"],
+        edges=state_d["edges"],
+        outputs=state_d["outputs"],
+        metadata_=state_d["metadata"],
+        is_valid=False,
+        validation_errors=None,
+        composer_meta=new_composer_meta,
+    )
+    asyncio.run(service.save_composition_state(session_uuid, state_data))
+
+
+class TestGetGuidedFullStateRebuild:
+    """M3/M4/M5: GET /guided correctly rebuilds turn state for all intra-step positions.
+
+    Codex #5  (P1): STEP_3_TRANSFORMS returns next_turn: null before fix.
+    Codex #10 (P2): STEP_2_SINK always rebuilds initial SINGLE_SELECT before fix.
+    Codex #14 (P2): STEP_1_SOURCE never reaches INSPECT_AND_CONFIRM before fix.
+    """
+
+    def _make_source_resolved_dict(self) -> dict:
+        return {
+            "plugin": "csv",
+            "options": {"path": "/data/in.csv", "schema": {"mode": "observed"}},
+            "observed_columns": ["col_a", "col_b"],
+            "sample_rows": [{"col_a": "x", "col_b": "1"}],
+        }
+
+    def _make_sink_resolved_dict(self) -> dict:
+        return {
+            "outputs": [
+                {
+                    "plugin": "json",
+                    "options": {"path": "/data/out.jsonl", "schema": {"mode": "observed"}},
+                    "required_fields": ["col_a"],
+                    "schema_mode": "observed",
+                }
+            ]
+        }
+
+    # ------------------------------------------------------------------
+    # M3: Step 3 propose_chain rebuild (Codex #5)
+    # ------------------------------------------------------------------
+
+    def test_step_3_with_proposal_returns_propose_chain_turn(self, composer_test_client: TestClient) -> None:
+        """GET /guided at STEP_3_TRANSFORMS with step_3_proposal returns propose_chain.
+
+        Codex #5 fix: before the fix this returned next_turn=null and the
+        frontend fell back to freeform UI despite the guided session being
+        non-terminal.  The seeded proposal must appear in the response.
+        """
+        session_id = _create_session(composer_test_client)
+
+        proposal_dict = {
+            "steps": [{"plugin": "rename", "options": {"mappings": {}}, "rationale": "normalise names"}],
+            "why": "Normalise column names before JSON output.",
+        }
+        guided_dict = {
+            "step": "step_3_transforms",
+            "history": [],
+            "step_1_result": self._make_source_resolved_dict(),
+            "step_2_result": self._make_sink_resolved_dict(),
+            "step_3_proposal": proposal_dict,
+            "terminal": None,
+            "transition_consumed": False,
+            "step_1_source_intent": None,
+            "step_2_sink_intent": None,
+            "step_2_5_recipe_offer": None,
+            "step_2_chosen_plugin": None,
+        }
+        _seed_guided_session(composer_test_client, session_id, guided_dict)
+
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["guided_session"]["step"] == "step_3_transforms"
+        assert body["next_turn"] is not None, (
+            "next_turn must not be null at STEP_3_TRANSFORMS when step_3_proposal is set — "
+            "Codex #5 regression: GET /guided returned null instead of propose_chain"
+        )
+        assert body["next_turn"]["type"] == "propose_chain", f"Expected propose_chain but got {body['next_turn']['type']!r}"
+        assert body["next_turn"]["step_index"] == 3  # STEP_3_TRANSFORMS index
+        payload = body["next_turn"]["payload"]
+        assert payload["why"] == proposal_dict["why"]
+        assert len(payload["steps"]) == 1
+        assert payload["steps"][0]["plugin"] == "rename"
+
+    # ------------------------------------------------------------------
+    # M4: Step 2 intra-step rebuild (Codex #10)
+    # ------------------------------------------------------------------
+
+    def test_step_2_with_chosen_plugin_returns_schema_form(self, composer_test_client: TestClient) -> None:
+        """GET /guided at STEP_2_SINK with step_2_chosen_plugin returns schema_form.
+
+        Codex #10 fix: before the fix, GET /guided always returned the initial
+        SINGLE_SELECT regardless of intra-step position.  When the user had
+        already picked a plugin, refresh would force them back to step start.
+        """
+        session_id = _create_session(composer_test_client)
+
+        guided_dict = {
+            "step": "step_2_sink",
+            "history": [],
+            "step_1_result": self._make_source_resolved_dict(),
+            "step_2_result": None,
+            "step_3_proposal": None,
+            "terminal": None,
+            "transition_consumed": False,
+            "step_1_source_intent": None,
+            "step_2_sink_intent": None,
+            "step_2_5_recipe_offer": None,
+            # Placed in the SINGLE_SELECT→SCHEMA_FORM window.
+            "step_2_chosen_plugin": "json",
+        }
+        _seed_guided_session(composer_test_client, session_id, guided_dict)
+
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["guided_session"]["step"] == "step_2_sink"
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "schema_form", (
+            f"Expected schema_form but got {body['next_turn']['type']!r} — "
+            "Codex #10 regression: GET /guided returned single_select instead of schema_form"
+        )
+        assert body["next_turn"]["payload"]["plugin"] == "json"
+
+    def test_step_2_with_sink_intent_returns_multi_select(self, composer_test_client: TestClient) -> None:
+        """GET /guided at STEP_2_SINK with step_2_sink_intent returns multi_select_with_custom.
+
+        Codex #10 fix: after the SCHEMA_FORM was submitted (step_2_sink_intent is
+        set), GET /guided must return multi_select_with_custom so the client can
+        complete the field-selection step, not the initial single_select.
+        """
+        session_id = _create_session(composer_test_client)
+
+        guided_dict = {
+            "step": "step_2_sink",
+            "history": [],
+            "step_1_result": self._make_source_resolved_dict(),
+            "step_2_result": None,
+            "step_3_proposal": None,
+            "terminal": None,
+            "transition_consumed": False,
+            "step_1_source_intent": None,
+            # Placed in the SCHEMA_FORM→MULTI_SELECT window.
+            "step_2_sink_intent": {
+                "plugin": "json",
+                "options": {"path": "/data/out.jsonl", "schema": {"mode": "observed"}},
+            },
+            "step_2_5_recipe_offer": None,
+            "step_2_chosen_plugin": None,
+        }
+        _seed_guided_session(composer_test_client, session_id, guided_dict)
+
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["guided_session"]["step"] == "step_2_sink"
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "multi_select_with_custom", (
+            f"Expected multi_select_with_custom but got {body['next_turn']['type']!r} — "
+            "Codex #10 regression: GET /guided returned single_select instead of multi_select"
+        )
+        # default_chosen should include the columns from step_1_result.
+        payload = body["next_turn"]["payload"]
+        assert "col_a" in payload["default_chosen"]
+        assert "col_b" in payload["default_chosen"]
+
+    # ------------------------------------------------------------------
+    # M5: Step 1 INSPECT_AND_CONFIRM rebuild (Codex #14)
+    # ------------------------------------------------------------------
+
+    def test_step_1_with_source_intent_returns_inspect_and_confirm(self, composer_test_client: TestClient) -> None:
+        """GET /guided at STEP_1_SOURCE with step_1_source_intent returns inspect_and_confirm.
+
+        Codex #14 fix: before the fix, build_initial_step_1_turn was called with
+        blob_inspection=None unconditionally, making INSPECT_AND_CONFIRM unreachable
+        via GET.  When step_1_source_intent is set, the server must rebuild the
+        inspect_and_confirm turn from the staged observed columns.
+        """
+        session_id = _create_session(composer_test_client)
+
+        guided_dict = {
+            "step": "step_1_source",
+            "history": [],
+            "step_1_result": None,
+            "step_2_result": None,
+            "step_3_proposal": None,
+            "terminal": None,
+            "transition_consumed": False,
+            # The SCHEMA_FORM was submitted — source intent is staged.
+            "step_1_source_intent": {
+                "plugin": "csv",
+                "options": {"path": "/data/in.csv", "schema": {"mode": "observed"}},
+                "observed_columns": ["col_a", "col_b"],
+                "sample_rows": [{"col_a": "x", "col_b": "1"}],
+            },
+            "step_2_sink_intent": None,
+            "step_2_5_recipe_offer": None,
+            "step_2_chosen_plugin": None,
+        }
+        _seed_guided_session(composer_test_client, session_id, guided_dict)
+
+        body = _get_guided(composer_test_client, session_id)
+
+        assert body["guided_session"]["step"] == "step_1_source"
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "inspect_and_confirm", (
+            f"Expected inspect_and_confirm but got {body['next_turn']['type']!r} — "
+            "Codex #14 regression: GET /guided returned single_select instead of inspect_and_confirm"
+        )
+        # The observed columns from step_1_source_intent must appear in the payload.
+        observed = body["next_turn"]["payload"]["observed"]
+        assert "col_a" in observed["columns"]
+        assert "col_b" in observed["columns"]

--- a/tests/integration/web/composer/guided/test_progressive_disclosure.py
+++ b/tests/integration/web/composer/guided/test_progressive_disclosure.py
@@ -247,6 +247,18 @@ def _send_message(client: TestClient, session_id: str, content: str) -> dict:
     return resp.json()
 
 
+def _seed_user_message(client: TestClient, session_id: str, content: str = "retry this") -> None:
+    """Insert a user message directly so recompose finds a valid last-user-turn."""
+    service: SessionServiceImpl = client.app.state.session_service
+    asyncio.run(service.add_message(UUID(session_id), "user", content))
+
+
+def _recompose(client: TestClient, session_id: str) -> dict:
+    resp = client.post(f"/api/sessions/{session_id}/recompose")
+    assert resp.status_code == 200, f"recompose failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
 # ---------------------------------------------------------------------------
 # Test: first freeform turn after exit uses transition prompt
 # ---------------------------------------------------------------------------
@@ -369,3 +381,97 @@ class TestTransitionPromptAfterCompletedTerminal:
         assert "## Mode Transition" in system_content, f"COMPLETED terminal must trigger transition prompt. Got: {system_content[:500]}"
         assert "completed_pipeline" in system_content, "COMPLETED terminal must use 'completed_pipeline' reason string"
         assert "LIFTED" in system_content
+
+
+# ---------------------------------------------------------------------------
+# Tests: recompose path mirrors send_message for progressive disclosure
+# ---------------------------------------------------------------------------
+
+
+class TestRecomposeTransitionPrompt:
+    """Recompose is a retried freeform chat call — spec §5.5 progressive
+    disclosure fires on the same semantics as send_message."""
+
+    def test_recompose_uses_transition_prompt_on_first_freeform_turn(self, composer_freeform_client: TestClient) -> None:
+        """First recompose after guided_session.terminal is set uses the layered prompt."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+        # Recompose requires the last conversation message to be a user turn.
+        _seed_user_message(composer_freeform_client, session_id, "try again after exit")
+
+        captured_messages: list[list[dict]] = []
+
+        async def _fake_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            _recompose(composer_freeform_client, session_id)
+
+        assert len(captured_messages) >= 1, "LLM should have been called once"
+        messages = captured_messages[0]
+        system_messages = [m for m in messages if m["role"] == "system"]
+        assert system_messages, "No system messages found"
+        system_content = system_messages[0]["content"]
+
+        assert "## Mode Transition" in system_content, f"Expected transition header in recompose system prompt, got: {system_content[:500]}"
+        assert "LIFTED" in system_content
+        assert "user_pressed_exit" in system_content
+
+    def test_recompose_persists_transition_consumed(self, composer_freeform_client: TestClient) -> None:
+        """After recompose fires the transition prompt, transition_consumed=True is persisted."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+        _seed_user_message(composer_freeform_client, session_id, "try again")
+
+        async def _fake_acompletion(**kwargs):
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            _recompose(composer_freeform_client, session_id)
+
+        gs_dict = _get_current_guided_session(composer_freeform_client, session_id)
+        assert gs_dict.get("transition_consumed") is True, f"transition_consumed not set to True after recompose. GuidedSession: {gs_dict}"
+
+    def test_recompose_guided_session_persisted_in_composer_meta(self, composer_freeform_client: TestClient) -> None:
+        """guided_session is included in composer_meta after recompose, not silently dropped."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+        _seed_user_message(composer_freeform_client, session_id, "persist check")
+
+        async def _fake_acompletion(**kwargs):
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            _recompose(composer_freeform_client, session_id)
+
+        gs_dict = _get_current_guided_session(composer_freeform_client, session_id)
+        assert gs_dict, "guided_session must be present in composer_meta after recompose"
+        assert "terminal" in gs_dict, "guided_session must retain terminal after recompose"

--- a/tests/integration/web/composer/guided/test_progressive_disclosure.py
+++ b/tests/integration/web/composer/guided/test_progressive_disclosure.py
@@ -173,9 +173,7 @@ def _seed_terminal_guided_session(
 ) -> None:
     """Directly persist a GuidedSession with the given terminal into the DB.
 
-    Mirrors the pattern in the guided endpoints (routes.py:3857) without
-    driving through the wizard UI. Faster and more deterministic than
-    driving 8+ wizard steps.
+    Faster and more deterministic than driving 8+ wizard steps.
     """
     service: SessionServiceImpl = client.app.state.session_service
     session_uuid = UUID(session_id)

--- a/tests/integration/web/composer/guided/test_progressive_disclosure.py
+++ b/tests/integration/web/composer/guided/test_progressive_disclosure.py
@@ -1,0 +1,371 @@
+"""Integration tests for Phase 5 Task 5.2: progressive-disclosure mode-transition prompt.
+
+After guided_session.terminal is set (any reason, including COMPLETED), the first
+subsequent freeform chat turn uses a layered system prompt:
+
+    [guided_pipeline.md content]
+    ## Mode Transition — Guided → Freeform
+    ...reason...
+    LIFTED
+    [pipeline_composer.md content]
+
+Subsequent freeform turns use the freeform skill alone.
+``transition_consumed=True`` is persisted after the first layered turn.
+
+Tests exercise two terminal paths:
+  1. ``exited_to_freeform`` (reason=user_pressed_exit via manual terminal seeding)
+  2. ``completed`` (terminal kind=completed with pipeline_yaml set)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from sqlalchemy.pool import StaticPool
+
+from elspeth.web.auth.middleware import get_current_user
+from elspeth.web.auth.models import UserIdentity
+from elspeth.web.blobs.routes import create_blobs_router
+from elspeth.web.blobs.service import BlobServiceImpl
+from elspeth.web.composer.audit import BufferingRecorder
+from elspeth.web.composer.guided.state_machine import (
+    TerminalKind,
+    TerminalReason,
+    TerminalState,
+)
+from elspeth.web.composer.progress import ComposerProgressRegistry
+from elspeth.web.composer.service import ComposerServiceImpl
+from elspeth.web.config import WebSettings
+from elspeth.web.dependencies import create_catalog_service
+from elspeth.web.middleware.rate_limit import ComposerRateLimiter
+from elspeth.web.sessions.converters import state_from_record
+from elspeth.web.sessions.engine import create_session_engine
+from elspeth.web.sessions.protocol import CompositionStateData
+from elspeth.web.sessions.routes import create_session_router
+from elspeth.web.sessions.schema import initialize_session_schema
+from elspeth.web.sessions.service import SessionServiceImpl
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Fake LLM response: pure-chat, no tool calls
+# ---------------------------------------------------------------------------
+
+
+def _fake_chat_response(text: str = "Hello from freeform mode!") -> SimpleNamespace:
+    """LiteLLM-shaped response with no tool calls (pure chat reply)."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=None,
+                    content=text,
+                )
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+        model="test-model",
+        id="test-id",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture: composer_with_freeform_client
+#
+# Extends the base composer_test_client by wiring a real ComposerServiceImpl
+# so that POST /api/sessions/{id}/messages is exercisable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def composer_freeform_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """TestClient with both guided and freeform endpoints wired.
+
+    Differs from composer_test_client (in conftest.py) by setting
+    ``app.state.composer_service`` to a real ``ComposerServiceImpl`` and
+    adding ``app.state.scoped_secret_resolver = None``.  The composer
+    service has ``_litellm_acompletion`` patched to avoid real LLM calls.
+
+    A fake ``OPENAI_API_KEY`` env var is set so the service's boot-time
+    availability check passes without a real API key.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key-for-integration-tests")
+
+    engine = create_session_engine(
+        "sqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    initialize_session_schema(engine)
+
+    session_service = SessionServiceImpl(engine)
+    blob_service = BlobServiceImpl(engine, tmp_path)
+
+    settings = WebSettings(
+        data_dir=tmp_path,
+        composer_model="gpt-4o-mini",
+        composer_max_composition_turns=5,
+        composer_max_discovery_turns=5,
+        composer_timeout_seconds=30.0,
+        composer_rate_limit_per_minute=100,
+    )
+    catalog = create_catalog_service()
+    composer_service = ComposerServiceImpl(
+        catalog=catalog,
+        settings=settings,
+        session_engine=engine,
+    )
+
+    app = FastAPI()
+    identity = UserIdentity(user_id="alice", username="alice")
+
+    async def mock_user() -> UserIdentity:
+        return identity
+
+    app.dependency_overrides[get_current_user] = mock_user
+
+    app.state.session_service = session_service
+    app.state.session_engine = engine
+    app.state.blob_service = blob_service
+    app.state.settings = settings
+    app.state.composer_service = composer_service
+    app.state.scoped_secret_resolver = None
+    app.state.rate_limiter = ComposerRateLimiter(limit=100)
+    app.state.catalog_service = catalog
+    app.state.composer_recorder = BufferingRecorder()
+    app.state.composer_progress_registry = ComposerProgressRegistry()
+
+    router = create_session_router()
+    app.include_router(router)
+
+    blobs_router = create_blobs_router()
+    app.include_router(blobs_router)
+
+    client = TestClient(app)
+    yield client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    resp = client.post("/api/sessions", json={"title": "progressive-disclosure-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _seed_terminal_guided_session(
+    client: TestClient,
+    session_id: str,
+    terminal: TerminalState,
+) -> None:
+    """Directly persist a GuidedSession with the given terminal into the DB.
+
+    Mirrors the pattern in the guided endpoints (routes.py:3857) without
+    driving through the wizard UI. Faster and more deterministic than
+    driving 8+ wizard steps.
+    """
+    service: SessionServiceImpl = client.app.state.session_service
+    session_uuid = UUID(session_id)
+
+    # Load or create current state
+    state_record = asyncio.run(service.get_current_state(session_uuid))
+
+    if state_record is None:
+        # No state yet — build minimal CompositionState
+        from dataclasses import replace
+
+        from elspeth.web.sessions.routes import _initial_composition_state_with_guided_session
+
+        state = _initial_composition_state_with_guided_session()
+        # Attach the desired terminal
+        new_guided = replace(state.guided_session, terminal=terminal)
+        state = replace(state, guided_session=new_guided)
+        existing_meta: dict = {}
+    else:
+        from dataclasses import replace
+
+        from elspeth.contracts.freeze import deep_thaw
+
+        state = state_from_record(state_record)
+        existing_meta = dict(deep_thaw(state_record.composer_meta)) if state_record.composer_meta else {}
+        if state.guided_session is None:
+            # Attach a fresh initial guided session with the terminal
+            from elspeth.web.composer.guided.state_machine import GuidedSession
+
+            guided = GuidedSession.initial()
+            guided = replace(guided, terminal=terminal)
+        else:
+            guided = replace(state.guided_session, terminal=terminal)
+        state = replace(state, guided_session=guided)
+
+    new_composer_meta = {**existing_meta, "guided_session": state.guided_session.to_dict()}
+    state_d = state.to_dict()
+    state_data = CompositionStateData(
+        source=state_d["source"],
+        nodes=state_d["nodes"],
+        edges=state_d["edges"],
+        outputs=state_d["outputs"],
+        metadata_=state_d["metadata"],
+        is_valid=False,
+        validation_errors=None,
+        composer_meta=new_composer_meta,
+    )
+    asyncio.run(service.save_composition_state(session_uuid, state_data))
+
+
+def _get_current_guided_session(client: TestClient, session_id: str) -> dict:
+    """Load the current GuidedSession dict from the DB (bypasses HTTP)."""
+    service: SessionServiceImpl = client.app.state.session_service
+    state_record = asyncio.run(service.get_current_state(UUID(session_id)))
+    if state_record is None:
+        return {}
+    from elspeth.contracts.freeze import deep_thaw
+
+    meta = deep_thaw(state_record.composer_meta) if state_record.composer_meta else {}
+    return dict(meta.get("guided_session") or {})
+
+
+def _send_message(client: TestClient, session_id: str, content: str) -> dict:
+    resp = client.post(
+        f"/api/sessions/{session_id}/messages",
+        json={"content": content},
+    )
+    assert resp.status_code == 200, f"send_message failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Test: first freeform turn after exit uses transition prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFirstFreeformTurnAfterExit:
+    def test_first_turn_uses_transition_prompt(self, composer_freeform_client: TestClient) -> None:
+        """First freeform chat turn after an exited_to_freeform terminal uses the layered prompt."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+
+        captured_messages: list[list[dict]] = []
+
+        async def _fake_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            _send_message(composer_freeform_client, session_id, "what can you do?")
+
+        assert len(captured_messages) >= 1, "LLM should have been called once"
+        messages = captured_messages[0]
+
+        # First message must be the system prompt
+        system_messages = [m for m in messages if m["role"] == "system"]
+        assert system_messages, "No system messages found"
+        system_content = system_messages[0]["content"]
+
+        assert "## Mode Transition" in system_content, f"Expected transition header in system prompt, got: {system_content[:500]}"
+        assert "LIFTED" in system_content
+        assert "user_pressed_exit" in system_content
+
+
+class TestSecondFreeformTurnAfterTransition:
+    def test_second_turn_uses_freeform_only_prompt(self, composer_freeform_client: TestClient) -> None:
+        """After the first (transition) turn, subsequent turns use freeform-only prompt."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.PROTOCOL_VIOLATION,
+            pipeline_yaml=None,
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+
+        all_captured_messages: list[list[dict]] = []
+
+        async def _fake_acompletion(**kwargs):
+            all_captured_messages.append(kwargs["messages"])
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            # First freeform turn — should use transition prompt
+            _send_message(composer_freeform_client, session_id, "first message")
+
+        # After first turn, transition_consumed should be persisted as True
+        gs_dict = _get_current_guided_session(composer_freeform_client, session_id)
+        assert gs_dict.get("transition_consumed") is True, f"transition_consumed not set to True after first turn. GuidedSession: {gs_dict}"
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            # Second freeform turn — must NOT use transition prompt
+            _send_message(composer_freeform_client, session_id, "second message")
+
+        assert len(all_captured_messages) == 2, f"Expected exactly 2 LLM calls, got {len(all_captured_messages)}"
+
+        # First call: transition prompt present
+        first_system = next(m for m in all_captured_messages[0] if m["role"] == "system")
+        assert "## Mode Transition" in first_system["content"]
+
+        # Second call: transition prompt absent
+        second_system = next(m for m in all_captured_messages[1] if m["role"] == "system")
+        assert "## Mode Transition" not in second_system["content"], "Second turn should NOT contain the transition header"
+
+
+class TestTransitionPromptAfterCompletedTerminal:
+    def test_completed_terminal_uses_transition_prompt(self, composer_freeform_client: TestClient) -> None:
+        """After COMPLETED terminal, the first freeform turn uses the layered prompt with 'completed_pipeline'."""
+        session_id = _create_session(composer_freeform_client)
+
+        terminal = TerminalState(
+            kind=TerminalKind.COMPLETED,
+            reason=None,
+            pipeline_yaml="# stub pipeline yaml",
+        )
+        _seed_terminal_guided_session(composer_freeform_client, session_id, terminal)
+
+        captured_messages: list[list[dict]] = []
+
+        async def _fake_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _fake_chat_response()
+
+        with patch(
+            "elspeth.web.composer.service._litellm_acompletion",
+            side_effect=_fake_acompletion,
+        ):
+            _send_message(composer_freeform_client, session_id, "actually change the sink to CSV")
+
+        assert len(captured_messages) >= 1
+        messages = captured_messages[0]
+        system_messages = [m for m in messages if m["role"] == "system"]
+        assert system_messages
+        system_content = system_messages[0]["content"]
+
+        assert "## Mode Transition" in system_content, f"COMPLETED terminal must trigger transition prompt. Got: {system_content[:500]}"
+        assert "completed_pipeline" in system_content, "COMPLETED terminal must use 'completed_pipeline' reason string"
+        assert "LIFTED" in system_content

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -654,6 +654,542 @@ class TestStep25RecipeAccept:
 
 
 # ---------------------------------------------------------------------------
+# Step 1 SCHEMA_FORM — contract-violation negative tests (Pair 4)
+# ---------------------------------------------------------------------------
+# Defends against silent ``.get()``-with-default and bare ``str()`` coercion
+# rewriting a malformed Step-1 SCHEMA_FORM ``edited_values`` payload into
+# bogus-but-shape-valid data. The SchemaFormTurn widget contract is
+# ``{"plugin": str, "options": Mapping, "observed_columns": list,
+# "sample_rows": list}``; any deviation MUST surface as an HTTP 400 with
+# the contract cited in the message — not flow downstream into
+# ``SourceResolved`` and fail far away in handle_step_1_source as a
+# misleading plugin-not-found or schema-mismatch error.
+
+
+class TestStep1SchemaFormAccept:
+    def _drive_to_schema_form(self, client: TestClient, session_id: str) -> dict:
+        """Drive to the Step 1 SCHEMA_FORM state. Returns the last /respond body."""
+        _get_guided(client, session_id)
+        return _respond(client, session_id, chosen=["csv"])
+
+    def test_step_1_schema_form_null_edited_values_returns_400(self, composer_test_client: TestClient) -> None:
+        """``edited_values=null`` at Step 1 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": None},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form" in detail
+        assert "step 1" in detail
+        assert "null" in detail
+
+    def test_step_1_schema_form_missing_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``plugin`` key is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"options": {}, "observed_columns": [], "sample_rows": []}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's missing-keys guard
+        # against any downstream 400 that might also mention "plugin".
+        assert "schema_form response at step 1" in detail
+        assert "missing required keys" in detail
+        assert "'plugin'" in detail
+
+    def test_step_1_schema_form_missing_options_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``options`` key is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "csv", "observed_columns": [], "sample_rows": []}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 1" in detail
+        assert "missing required keys" in detail
+        assert "'options'" in detail
+
+    def test_step_1_schema_form_missing_observed_columns_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``observed_columns`` key is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "csv", "options": {}, "sample_rows": []}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 1" in detail
+        assert "missing required keys" in detail
+        assert "'observed_columns'" in detail
+
+    def test_step_1_schema_form_missing_sample_rows_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``sample_rows`` key is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "csv", "options": {}, "observed_columns": []}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 1" in detail
+        assert "missing required keys" in detail
+        assert "'sample_rows'" in detail
+
+    def test_step_1_schema_form_empty_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Empty-string ``plugin`` is a protocol violation (HTTP 400).
+
+        Defends specifically against the silent ``str(edited["plugin"])`` pattern
+        that would have stringified ``""`` and routed it into ``SourceResolved``,
+        failing far downstream as a misleading "plugin not registered: ''" error.
+        """
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "",
+                    "options": {},
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Assert the boundary-message marker, not a bare substring — the bare
+        # substring "plugin" matches the downstream ToolResult repr (which
+        # echoes the offending value into a "plugin not registered" error),
+        # so a pre-validator code path would also satisfy ``"plugin" in detail``.
+        # Only the dispatcher's contract-citing 400 emits "must be a non-empty
+        # string", which mechanically distinguishes pre/post-validation paths.
+        assert "schema_form response at step 1" in detail
+        assert "must be a non-empty string" in detail
+        assert "''" in detail  # the offending empty-string value is echoed in the detail
+
+    def test_step_1_schema_form_non_string_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-string ``plugin`` is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": 42,
+                    "options": {},
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher 400 against the
+        # downstream ToolResult repr that also contains "plugin".
+        assert "schema_form response at step 1" in detail
+        assert "must be a non-empty string" in detail
+        assert "42" in detail  # the offending integer value is echoed in the detail
+
+    def test_step_1_schema_form_non_mapping_options_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-Mapping ``options`` is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": ["not", "a", "mapping"],
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's Mapping-guard against
+        # any downstream 400 that may also mention "options" in its repr.
+        assert "schema_form response at step 1" in detail
+        assert "must be an object" in detail
+        assert "list" in detail  # the offending type is named in the detail
+
+    def test_step_1_schema_form_non_list_observed_columns_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-list ``observed_columns`` is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {},
+                    "observed_columns": "abc",
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's list-guard.
+        assert "schema_form response at step 1" in detail
+        assert "must be a list" in detail
+        assert "str" in detail  # offending type is named
+
+    def test_step_1_schema_form_non_list_sample_rows_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-list ``sample_rows`` is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {},
+                    "observed_columns": [],
+                    "sample_rows": {"not": "a list"},
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 1" in detail
+        assert "must be a list" in detail
+        assert "dict" in detail  # offending type is named
+
+
+# ---------------------------------------------------------------------------
+# Step 2 SCHEMA_FORM — contract-violation negative tests (Pair 4)
+# ---------------------------------------------------------------------------
+# Defends the Step-2 (sink) SCHEMA_FORM dispatcher branch. The SchemaFormTurn
+# widget contract is identical to Step 1 — ``{"plugin": str, "options": Mapping,
+# "observed_columns": list, "sample_rows": list}`` — but Step 2 only consumes
+# ``plugin`` + ``options`` for ``step_2_sink_intent``. The dispatcher still
+# rejects missing/wrong-typed ``plugin`` and ``options`` with HTTP 400.
+# ``observed_columns`` and ``sample_rows`` are not validated at Step 2 (they
+# are payload-shape echo, not consumed for sink state).
+
+
+class TestStep2SchemaFormAccept:
+    def _drive_to_step_2_schema_form(self, client: TestClient, session_id: str) -> None:
+        """Drive to the Step 2 SCHEMA_FORM state (post-sink-pick)."""
+        _get_guided(client, session_id)
+        _respond(client, session_id, chosen=["csv"])
+        _blob_id, storage_path = _seed_blob(client, session_id)
+        _respond(
+            client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "label"],
+                "sample_rows": [],
+            },
+        )
+        _respond(client, session_id, chosen=["json"])
+
+    def test_step_2_schema_form_null_edited_values_returns_400(self, composer_test_client: TestClient) -> None:
+        """``edited_values=null`` at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": None},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form" in detail
+        assert "step 2" in detail
+        assert "null" in detail
+
+    def test_step_2_schema_form_missing_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``plugin`` key at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"options": {}}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's missing-keys guard.
+        assert "schema_form response at step 2" in detail
+        assert "missing required keys" in detail
+        assert "'plugin'" in detail
+
+    def test_step_2_schema_form_missing_options_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``options`` key at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "json"}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 2" in detail
+        assert "missing required keys" in detail
+        assert "'options'" in detail
+
+    def test_step_2_schema_form_empty_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Empty-string ``plugin`` at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "", "options": {}}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 2" in detail
+        assert "must be a non-empty string" in detail
+        assert "''" in detail
+
+    def test_step_2_schema_form_non_string_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-string ``plugin`` at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": 42, "options": {}}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 2" in detail
+        assert "must be a non-empty string" in detail
+        assert "42" in detail
+
+    def test_step_2_schema_form_non_mapping_options_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-Mapping ``options`` at Step 2 SCHEMA_FORM is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"edited_values": {"plugin": "json", "options": "not a mapping"}},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "schema_form response at step 2" in detail
+        assert "must be an object" in detail
+        assert "str" in detail  # offending type is named
+
+
+# ---------------------------------------------------------------------------
+# Step 1 INSPECT_AND_CONFIRM — contract-violation negative tests (Pair 4)
+# ---------------------------------------------------------------------------
+# The INSPECT_AND_CONFIRM dispatcher branch (routes.py STEP_1 → STEP_2 path)
+# is currently HTTP-unreachable in normal flow because ``get_guided`` always
+# passes ``blob_inspection=None`` — the server never emits an
+# INSPECT_AND_CONFIRM turn (see emitters.build_initial_step_1_turn).  The
+# dispatch branch is exercised here via state injection (the same pattern
+# used by test_progressive_disclosure._seed_terminal_state at line 170): a
+# TurnRecord with turn_type=INSPECT_AND_CONFIRM is seeded into
+# guided.history before POST /respond fires.
+#
+# Shadowing note:
+#   ``_advance_step_1`` in state_machine.py runs BEFORE the dispatcher and
+#   itself raises ValueError on null ``edited_values`` and KeyError on missing
+#   required keys.  Those errors propagate as HTTP 500, not site-2's HTTP 400.
+#   The dispatcher's null/missing-key guards remain as defense-in-depth (and
+#   are documented in the dispatcher comment) but cannot be asserted as 400
+#   via normal HTTP; the unit-level test_state_machine suite pins them at the
+#   ValueError/KeyError boundary.
+#
+#   The validators that ARE HTTP-reachable as 400 are those where step_advance's
+#   ``str()``/``tuple()`` coercion passes the raw value through:
+#     - non-string plugin (str(42) → "42" passes; isinstance(42,str)=False fires)
+#     - empty plugin     (str("")=""    passes; ``not plugin_name`` fires)
+#     - non-list observed_columns (tuple("abc")=('a','b','c') passes; isinstance fires)
+#   These three are tested below.
+
+
+class TestStep1InspectAndConfirmAccept:
+    def _seed_inspect_and_confirm_history(
+        self,
+        client: TestClient,
+        session_id: str,
+    ) -> None:
+        """Seed an INSPECT_AND_CONFIRM TurnRecord into the session's guided history.
+
+        This bypasses GET /guided because the server-side initial-turn builder
+        passes blob_inspection=None unconditionally and so never emits an
+        inspect_and_confirm turn.  We inject the state directly via
+        save_composition_state — the same pattern used by
+        test_progressive_disclosure._seed_terminal_state (line 170).
+        """
+        from dataclasses import replace
+
+        from elspeth.contracts.freeze import deep_thaw
+        from elspeth.web.composer.guided.protocol import TurnType
+        from elspeth.web.composer.guided.state_machine import (
+            GuidedSession,
+            GuidedStep,
+            TurnRecord,
+        )
+        from elspeth.web.sessions.converters import state_from_record
+        from elspeth.web.sessions.protocol import CompositionStateData
+        from elspeth.web.sessions.routes import _initial_composition_state_with_guided_session
+
+        service = client.app.state.session_service
+        session_uuid = UUID(session_id)
+        state_record = asyncio.run(service.get_current_state(session_uuid))
+
+        if state_record is None:
+            state = _initial_composition_state_with_guided_session()
+            existing_meta: dict = {}
+        else:
+            state = state_from_record(state_record)
+            existing_meta = dict(deep_thaw(state_record.composer_meta)) if state_record.composer_meta else {}
+
+        # Build the GuidedSession with an INSPECT_AND_CONFIRM TurnRecord
+        # at STEP_1_SOURCE so the dispatcher's current_turn_type read picks
+        # it up on POST /respond.
+        guided = state.guided_session if state.guided_session is not None else GuidedSession.initial()
+        record = TurnRecord(
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.INSPECT_AND_CONFIRM,
+            payload_hash="seed-payload-hash",
+            response_hash=None,
+            emitter="server",
+        )
+        guided = replace(guided, history=(*guided.history, record))
+        state = replace(state, guided_session=guided)
+
+        new_composer_meta = {**existing_meta, "guided_session": guided.to_dict()}
+        state_d = state.to_dict()
+        state_data = CompositionStateData(
+            source=state_d["source"],
+            nodes=state_d["nodes"],
+            edges=state_d["edges"],
+            outputs=state_d["outputs"],
+            metadata_=state_d["metadata"],
+            is_valid=False,
+            validation_errors=None,
+            composer_meta=new_composer_meta,
+        )
+        asyncio.run(service.save_composition_state(session_uuid, state_data))
+
+    def test_inspect_and_confirm_empty_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Empty-string ``plugin`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
+
+        Site 2's ``isinstance(plugin_name, str) or not plugin_name`` check
+        fires the 400 on the raw empty-string value (replacing the previous
+        silent ``str(edited["plugin"])`` coercion).
+        """
+        session_id = _create_session(composer_test_client)
+        self._seed_inspect_and_confirm_history(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "",
+                    "options": {},
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Assert the boundary-message marker, not a bare substring — without
+        # the dispatcher guard, ``""`` would flow through ``handle_step_1_source``
+        # and the resulting 400 ``"Step 1 source commit failed: ToolResult(...)"``
+        # repr contains the word "plugin", so ``"inspect_and_confirm" in detail``
+        # / ``"plugin" in detail`` would BOTH pass against the unguarded path
+        # (the dispatcher's own 400 message starts ``"inspect_and_confirm
+        # response at step 1 ..."``, and the downstream commit-failure 400
+        # carries the dispatched ToolResult which echoes "plugin"). Only the
+        # contract-citing message "must be a non-empty string" mechanically
+        # pins this test to the dispatcher's guard.
+        assert "inspect_and_confirm response at step 1" in detail
+        assert "must be a non-empty string" in detail
+        assert "''" in detail  # the offending empty-string value is echoed in the detail
+
+    def test_inspect_and_confirm_non_string_plugin_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-string ``plugin`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
+
+        Site 2's ``isinstance(plugin_name, str)`` check fires the 400 on the
+        raw integer value (replacing the previous silent ``str(42)="42"``
+        coercion).
+        """
+        session_id = _create_session(composer_test_client)
+        self._seed_inspect_and_confirm_history(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": 42,
+                    "options": {},
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's 400 against the
+        # downstream ToolResult-repr 400 that also contains "plugin".
+        assert "inspect_and_confirm response at step 1" in detail
+        assert "must be a non-empty string" in detail
+        assert "42" in detail  # the offending integer value is echoed in the detail
+
+    def test_inspect_and_confirm_non_list_observed_columns_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-list ``observed_columns`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
+
+        Site 2's ``isinstance(observed_columns_raw, list)`` check fires the
+        400 on the raw scalar value (replacing the previous silent
+        ``tuple("abc")=('a','b','c')`` coercion that would have yielded a
+        character-wise tuple).
+        """
+        session_id = _create_session(composer_test_client)
+        self._seed_inspect_and_confirm_history(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {},
+                    "observed_columns": "abc",
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Boundary-message marker pins the dispatcher's list-guard.
+        assert "inspect_and_confirm response at step 1" in detail
+        assert "must be a list" in detail
+        assert "str" in detail  # offending type is named
+
+
+# ---------------------------------------------------------------------------
 # Error paths: 400 on no GET /guided first, 404 unknown session
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -346,9 +346,11 @@ class TestStep2IntraStep:
             "model",
             "api_key_secret",
         }
+        # ``required`` is absent from the wire shape: the RecipeMatch invariant
+        # guarantees every entry is required, so the field would be dead information.
         for entry in payload["unsatisfied_slots"]:
-            assert set(entry.keys()) == {"name", "slot_type", "description", "required"}
-            assert entry["required"] is True
+            assert set(entry.keys()) == {"name", "slot_type", "description"}
+            assert "required" not in entry
 
     def test_multi_select_response_commits_sink_to_state(self, composer_test_client: TestClient) -> None:
         """M1: MULTI_SELECT_WITH_CUSTOM → step 2.5 transition commits sink to composition_state.outputs.

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -654,6 +654,77 @@ class TestStep25RecipeAccept:
         assert resp.status_code == 400, resp.json()
         assert "recipe_name" in resp.json()["detail"]
 
+    # ---- Binding check: accept must reference the offered recipe -----------
+
+    def test_recipe_accept_wrong_recipe_name_returns_400(self, composer_test_client: TestClient) -> None:
+        """Accepting with a recipe_name that differs from the offered one is rejected.
+
+        The server offers ``classify-rows-llm-jsonl``; the client sends
+        ``split-by-numeric-threshold``. The binding check must surface this as
+        HTTP 400 naming both the offered and the client-supplied recipe_name.
+
+        Asymmetry probe: removing the binding check from the accept branch
+        causes this test to fail — the wrong recipe is accepted and produces
+        a 400 from ``_execute_apply_pipeline_recipe`` with a recipe-not-found
+        or slot-mismatch error, not the binding-violation message.
+        """
+        session_id = _create_session(composer_test_client)
+        _recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "chosen": ["accept"],
+                "edited_values": {
+                    "recipe_name": "split-by-numeric-threshold",  # wrong — was offered classify
+                    "slots": {
+                        "source_blob_id": blob_id,
+                        "classifier_template": "Classify: {{ row['text'] }}",
+                        "model": "anthropic/claude-3.5-sonnet",
+                        "api_key_secret": "OPENROUTER_API_KEY",
+                        "label_field": "category",
+                        "output_path": output_path,
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Detail must name both the offered recipe and the client-supplied recipe.
+        assert "classify-rows-llm-jsonl" in detail, f"offered recipe absent from: {detail}"
+        assert "split-by-numeric-threshold" in detail, f"client recipe absent from: {detail}"
+        assert "mismatch" in detail.lower(), f"binding message absent from: {detail}"
+
+    def test_recipe_accept_without_prior_offer_returns_400(self, composer_test_client: TestClient) -> None:
+        """Accepting a recipe when no recipe was ever offered is rejected with 400.
+
+        Drives only to Step 1 (source), then sends a crafted accept directly
+        targeting STEP_2_5.  With no step_2_5_recipe_offer staged, the server
+        must return 400 with a message explaining the session has not reached
+        the recipe-offer state.
+        """
+        session_id = _create_session(composer_test_client)
+        # Drive to Step 1 SCHEMA_FORM only — no sink, no recipe offer.
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+
+        # Crafted accept sent while session is still at STEP_1_SOURCE / SCHEMA_FORM.
+        # The dispatcher has no step_2_5_recipe_offer; the bind check fires.
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "chosen": ["accept"],
+                "edited_values": {
+                    "recipe_name": "classify-rows-llm-jsonl",
+                    "slots": {"source_blob_id": "fake-blob", "classifier_template": "x"},
+                },
+            },
+        )
+        # The response may be 400 from the binding check or from a step-mismatch
+        # guard earlier in the dispatcher.  Either way it must not be 200.
+        assert resp.status_code in (400, 422), resp.json()
+
 
 # ---------------------------------------------------------------------------
 # Step 1 SCHEMA_FORM — contract-violation negative tests (Pair 4)

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -1161,3 +1161,148 @@ class TestRespondErrorPaths:
             json={"chosen": ["csv"]},
         )
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Codex #8, #11, #15 — ValueError → HTTP 400 mapping in guided dispatcher
+#
+# S3 (commit f2478b6b) added `except InvariantError → 500` to distinguish
+# server bugs from client faults.  The symmetric `except ValueError → 400`
+# was missing; these tests verify it is now present at both catch sites.
+#
+# Site A: step_advance() ValueError — unexpected ``chosen`` on recipe_offer
+#   turn (state_machine._advance_step_2_5 line 700).  Fires at the
+#   step_advance try/except in post_guided_respond.
+#
+# Site B: solve_chain() — chain_solver raises only InvariantError (server
+#   bugs); no client-fault ValueError path exists there.  The new catch
+#   provides defence-in-depth but has no direct client trigger.
+#
+# Site C: build_step_1/2_schema_form_turn() — catalog.get_schema() raises
+#   ValueError for unknown plugin names (service.py line 114).  Fires inside
+#   _dispatch_guided_respond, caught by the dispatcher try/except.
+# ---------------------------------------------------------------------------
+
+
+class TestValueErrorMappedTo400:
+    """ValueError from step_advance or the dispatcher maps to HTTP 400 (Codex #8, #15)."""
+
+    def _drive_to_recipe_offer(self, client: TestClient, session_id: str) -> None:
+        """Drive session to the RECIPE_OFFER state (step 2.5)."""
+        _blob_id, storage_path = _seed_blob(client, session_id)
+        output_path = _outputs_path(client, "out_ve400.jsonl")
+
+        _get_guided(client, session_id)
+        _respond(client, session_id, chosen=["csv"])
+        _respond(
+            client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "category"],
+                "sample_rows": [{"text": "Hello", "category": "greeting"}],
+            },
+        )
+        _respond(client, session_id, chosen=["json"])
+        _respond(
+            client,
+            session_id,
+            edited_values={
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
+            },
+        )
+        _respond(client, session_id, chosen=["text", "category"], custom_inputs=[])
+
+    def test_site_a_unexpected_chosen_on_recipe_offer_returns_400(
+        self,
+        composer_test_client: TestClient,
+    ) -> None:
+        """Site A (Codex #8): unexpected ``chosen`` on recipe_offer maps to HTTP 400.
+
+        state_machine._advance_step_2_5 raises ValueError for any chosen value
+        other than ``["accept"]`` or ``["build_manually"]``.  The step_advance
+        try/except must catch this and re-raise as HTTPException(400), not let
+        the framework return 500.
+
+        Asymmetry probe: this test is the one used to verify the catch is
+        load-bearing — see task report for revert evidence.
+        """
+        session_id = _create_session(composer_test_client)
+        self._drive_to_recipe_offer(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["not_a_valid_choice"]},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # Detail must cite the guided-mode protocol contract (not a naked traceback).
+        assert "Guided-mode protocol error" in detail
+        assert "not_a_valid_choice" in detail
+
+    def test_site_c_unknown_source_plugin_returns_400(
+        self,
+        composer_test_client: TestClient,
+    ) -> None:
+        """Site C (Codex #15): unknown source plugin name in chosen maps to HTTP 400.
+
+        The step-1 SINGLE_SELECT handler calls build_step_1_schema_form_turn,
+        which calls catalog.get_schema("source", plugin_name).  For an unknown
+        plugin name that raises ValueError (service.py line 114).  The
+        dispatcher try/except must catch this and re-raise as HTTPException(400).
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["nonexistent_source_plugin_xyz"]},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "Guided-mode protocol error" in detail
+        assert "nonexistent_source_plugin_xyz" in detail
+
+    def test_site_c_unknown_sink_plugin_returns_400(
+        self,
+        composer_test_client: TestClient,
+    ) -> None:
+        """Site C mirror (Codex #15): unknown sink plugin name in chosen maps to HTTP 400.
+
+        The step-2 SINGLE_SELECT handler calls build_step_2_schema_form_turn,
+        which calls catalog.get_schema("sink", plugin_name).  For an unknown
+        plugin name that raises ValueError (service.py line 114).  The
+        dispatcher try/except must catch this and re-raise as HTTPException(400).
+        """
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+
+        _get_guided(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["csv"])
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text"],
+                "sample_rows": [],
+            },
+        )
+        # Now at step 2 SINGLE_SELECT — send a bogus sink plugin name.
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["nonexistent_sink_plugin_xyz"]},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "Guided-mode protocol error" in detail
+        assert "nonexistent_sink_plugin_xyz" in detail

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -1377,3 +1377,98 @@ class TestValueErrorMappedTo400:
         detail = resp.json()["detail"]
         assert "Guided-mode protocol error" in detail
         assert "nonexistent_sink_plugin_xyz" in detail
+
+
+# ---------------------------------------------------------------------------
+# Wire-validation tests — Codex #12 (control_signal enum validation)
+# ---------------------------------------------------------------------------
+
+
+class TestCodex12ControlSignalValidation:
+    """Codex #12: control_signal validated against the ControlSignal enum at
+    the wire boundary.
+
+    ``GuidedRespondRequest`` stores control_signal as str | None
+    intentionally; this guard is the route handler's enforcement point.
+    """
+
+    def test_unknown_control_signal_returns_400(self, composer_test_client: TestClient) -> None:
+        """An unknown string value for control_signal -> 400 with valid-values message."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": "invalid_value"},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "Unknown control_signal" in detail
+        assert "invalid_value" in detail
+        assert "exit_to_freeform" in detail  # valid values listed
+
+    def test_null_control_signal_passes_through(self, composer_test_client: TestClient) -> None:
+        """control_signal=null is the normal path -- guard must not reject it."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        # null control_signal + valid chosen -> normal step-1 advance -> 200
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": None},
+        )
+        assert resp.status_code == 200, resp.json()
+
+    def test_exit_to_freeform_is_accepted(self, composer_test_client: TestClient) -> None:
+        """exit_to_freeform is a valid ControlSignal value -> guard passes, step_advance runs."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": "exit_to_freeform"},
+        )
+        # step_advance handles exit_to_freeform by dropping to freeform terminal.
+        # The guard must not reject it; the response may be 200 or 4xx depending on
+        # the step_advance / dispatcher logic, but not due to our validation guard.
+        # We only assert it is NOT a 400 caused by "Unknown control_signal".
+        if resp.status_code == 400:
+            assert "Unknown control_signal" not in resp.json().get("detail", "")
+
+    def test_reject_signal_is_accepted(self, composer_test_client: TestClient) -> None:
+        """reject is a valid ControlSignal value -> guard passes."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": "reject"},
+        )
+        # Guard must not return "Unknown control_signal".
+        if resp.status_code == 400:
+            assert "Unknown control_signal" not in resp.json().get("detail", "")
+
+    def test_request_advisor_signal_is_accepted(self, composer_test_client: TestClient) -> None:
+        """request_advisor is a valid ControlSignal value -> guard passes."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": "request_advisor"},
+        )
+        if resp.status_code == 400:
+            assert "Unknown control_signal" not in resp.json().get("detail", "")
+
+    def test_typo_in_known_signal_returns_400(self, composer_test_client: TestClient) -> None:
+        """Asymmetry probe: a near-miss typo is rejected -- exact-value matching only."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "control_signal": "exit_to_freeform_"},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "Unknown control_signal" in detail

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -30,7 +30,10 @@ Error paths (exit_to_freeform, 409 after terminal) live in test_error_paths.py
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
@@ -1576,3 +1579,189 @@ class TestCodex16SampleRowsElementValidation:
             },
         )
         assert resp.status_code == 200, resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Wire-validation tests — Codex #7 (step-index validation)
+# ---------------------------------------------------------------------------
+
+# Helpers for driving to Step 3 (mirrors test_step_3_e2e.py pattern).
+
+
+def _fake_llm_passthrough_for_step_index_tests() -> SimpleNamespace:
+    """Single-step passthrough proposal stub."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "passthrough",
+                                                    "options": {"schema": {"mode": "observed"}},
+                                                    "rationale": "identity chain",
+                                                }
+                                            ],
+                                            "why": "rows already match sink schema",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
+def _drive_to_step_3_propose_chain_for_step_idx(
+    client: TestClient,
+    session_id: str,
+) -> None:
+    """Drive to the Step 3 PROPOSE_CHAIN turn (no-recipe path)."""
+    _blob_id, storage_path = _seed_blob(client, session_id)
+    output_path = _outputs_path(client, "out_idx.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "note"],
+            "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
+        },
+    )
+    # Non-classifier required field -> no recipe match -> chain solver fires.
+    _respond(client, session_id, chosen=["text"], custom_inputs=[])
+
+
+class TestCodex7StepIndexValidation:
+    """Codex #7: accepted_step_index / edit_step_index validated against the
+    current proposal at the wire boundary.
+
+    Guards fire before response_hash computation and audit emission, so an
+    invalid request returns 400 without recording a partial event.
+    """
+
+    def test_accepted_step_index_minus_one_returns_400(self, composer_test_client: TestClient) -> None:
+        """Negative accepted_step_index is out of range -> 400."""
+        session_id = _create_session(composer_test_client)
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_passthrough_for_step_index_tests(),
+        ):
+            _drive_to_step_3_propose_chain_for_step_idx(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["accept"], "accepted_step_index": -1},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "accepted_step_index" in detail
+        assert "out of range" in detail
+
+    def test_accepted_step_index_beyond_end_returns_400(self, composer_test_client: TestClient) -> None:
+        """accepted_step_index=999 is far beyond proposal length -> 400."""
+        session_id = _create_session(composer_test_client)
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_passthrough_for_step_index_tests(),
+        ):
+            _drive_to_step_3_propose_chain_for_step_idx(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["accept"], "accepted_step_index": 999},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "accepted_step_index" in detail
+        assert "out of range" in detail
+
+    def test_edit_step_index_out_of_range_returns_400(self, composer_test_client: TestClient) -> None:
+        """edit_step_index=999 is out of range -> 400."""
+        session_id = _create_session(composer_test_client)
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_passthrough_for_step_index_tests(),
+        ):
+            _drive_to_step_3_propose_chain_for_step_idx(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["accept"], "edit_step_index": 999},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "edit_step_index" in detail
+        assert "out of range" in detail
+
+    def test_valid_accepted_step_index_zero_is_accepted(self, composer_test_client: TestClient) -> None:
+        """Asymmetry probe: accepted_step_index=0 is valid for a 1-step proposal (no error).
+
+        The guard must not reject valid indices. accepted_step_index is not
+        consumed by the accept handler (the dispatcher uses the full proposal),
+        so the request reaches its normal path and returns 200.
+        """
+        session_id = _create_session(composer_test_client)
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_passthrough_for_step_index_tests(),
+        ):
+            _drive_to_step_3_propose_chain_for_step_idx(composer_test_client, session_id)
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["accept"], "accepted_step_index": 0},
+            )
+        # 200 -> the guard passed; the underlying handler ran to completion.
+        assert resp.status_code == 200, resp.json()
+
+    def test_non_null_step_index_at_step_1_returns_400(self, composer_test_client: TestClient) -> None:
+        """Step-1 SINGLE_SELECT is not PROPOSE_CHAIN -> accepted_step_index must be None.
+
+        Cross-step stale probe: a request with accepted_step_index set at Step 1
+        (where it is semantically irrelevant) is caught before it can corrupt
+        step-machine state.
+        """
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+        # Currently at Step 1 SINGLE_SELECT.
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"], "accepted_step_index": 0},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "accepted_step_index" in detail
+        assert "null" in detail

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -1472,3 +1472,107 @@ class TestCodex12ControlSignalValidation:
         assert resp.status_code == 400, resp.json()
         detail = resp.json()["detail"]
         assert "Unknown control_signal" in detail
+
+
+# ---------------------------------------------------------------------------
+# Wire-validation tests — Codex #16 (per-element sample_rows validation)
+# ---------------------------------------------------------------------------
+
+
+class TestCodex16SampleRowsElementValidation:
+    """Codex #16: per-element Mapping check for sample_rows at Step 1 SCHEMA_FORM.
+
+    The outer-container check (list vs non-list) existed before this change.
+    The new guard catches non-Mapping elements inside the list, which
+    previously triggered an uncontrolled TypeError from dict(r) -> 500.
+    """
+
+    def _drive_to_step_1_schema_form(self, client: TestClient, session_id: str) -> None:
+        """Drive to the Step 1 SCHEMA_FORM state."""
+        _get_guided(client, session_id)
+        _respond(client, session_id, chosen=["csv"])
+
+    def test_non_mapping_elements_in_sample_rows_return_400(self, composer_test_client: TestClient) -> None:
+        """sample_rows containing non-Mapping elements (int, str, list) -> 400 naming the index."""
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+        self._drive_to_step_1_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                    "observed_columns": ["text"],
+                    "sample_rows": [42, "string", []],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        # The error message must name the offending list position.
+        # Detail text form: edited_values['sample_rows'][N] must be an object
+        assert "'sample_rows'][" in detail
+        assert "must be an object" in detail
+
+    def test_single_non_mapping_at_index_1_names_index(self, composer_test_client: TestClient) -> None:
+        """One valid row followed by a non-Mapping element: error names index 1."""
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+        self._drive_to_step_1_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                    "observed_columns": ["text"],
+                    "sample_rows": [{"text": "ok"}, 99],
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "'sample_rows'][1]" in detail
+
+    def test_valid_sample_rows_pass_through(self, composer_test_client: TestClient) -> None:
+        """Asymmetry probe: a well-formed sample_rows list of Mapping elements does not
+        trigger the guard and allows the request to reach the step handler."""
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+        self._drive_to_step_1_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                    "observed_columns": ["text"],
+                    "sample_rows": [{"text": "Hello"}, {"text": "World"}],
+                },
+            },
+        )
+        # Guard passes; step handler runs and advances to Step 2 -> 200.
+        assert resp.status_code == 200, resp.json()
+
+    def test_empty_sample_rows_list_is_valid(self, composer_test_client: TestClient) -> None:
+        """An empty sample_rows list has no elements to fail the per-element check."""
+        session_id = _create_session(composer_test_client)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+        self._drive_to_step_1_schema_form(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "edited_values": {
+                    "plugin": "csv",
+                    "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                    "observed_columns": [],
+                    "sample_rows": [],
+                },
+            },
+        )
+        assert resp.status_code == 200, resp.json()

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -556,6 +556,102 @@ class TestStep25RecipeAccept:
         assert gs["terminal"] is not None
         assert gs["terminal"]["kind"] == "completed"
 
+    # ---- Contract-violation negative tests for chosen=["accept"] -----------
+    # Defends against silent ``.get()`` defaults that rewrite a malformed
+    # ``edited_values`` payload into bogus-but-shape-valid data (e.g.
+    # ``recipe_name=""``). The widget contract is
+    # ``{"recipe_name": str, "slots": Mapping}``; missing keys, a null
+    # payload, or a non-string ``recipe_name`` MUST surface as an HTTP 400
+    # with the contract cited in the message — not flow downstream as an
+    # "unknown recipe ''" error.
+
+    def test_recipe_offer_accept_null_edited_values_returns_400(self, composer_test_client: TestClient) -> None:
+        """``edited_values=null`` on accept is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_recipe_offer(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["accept"], "edited_values": None},
+        )
+        assert resp.status_code == 400, resp.json()
+        detail = resp.json()["detail"]
+        assert "edited_values" in detail
+        assert "null" in detail
+
+    def test_recipe_offer_accept_missing_slots_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``slots`` key on accept is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_recipe_offer(composer_test_client, session_id)
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "chosen": ["accept"],
+                "edited_values": {"recipe_name": "classify-rows-llm-jsonl"},
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        assert "slots" in resp.json()["detail"]
+
+    def test_recipe_offer_accept_missing_recipe_name_returns_400(self, composer_test_client: TestClient) -> None:
+        """Missing ``recipe_name`` key on accept is a protocol violation (HTTP 400)."""
+        session_id = _create_session(composer_test_client)
+        _recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "chosen": ["accept"],
+                "edited_values": {
+                    "slots": {
+                        "source_blob_id": blob_id,
+                        "classifier_template": "Classify: {{ row['text'] }}",
+                        "model": "anthropic/claude-3.5-sonnet",
+                        "api_key_secret": "OPENROUTER_API_KEY",
+                        "required_input_fields": ["text"],
+                        "label_field": "category",
+                        "output_path": output_path,
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        assert "recipe_name" in resp.json()["detail"]
+
+    def test_recipe_offer_accept_empty_recipe_name_returns_400(self, composer_test_client: TestClient) -> None:
+        """Empty-string ``recipe_name`` on accept is a protocol violation (HTTP 400).
+
+        Specifically defends against the silent ``str(edited.get("recipe_name", ""))``
+        pattern that would have routed ``""`` downstream into ``_RecipeMatch`` and
+        failed far away with "unknown recipe ''".
+        """
+        session_id = _create_session(composer_test_client)
+        _recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={
+                "chosen": ["accept"],
+                "edited_values": {
+                    "recipe_name": "",
+                    "slots": {
+                        "source_blob_id": blob_id,
+                        "classifier_template": "Classify: {{ row['text'] }}",
+                        "model": "anthropic/claude-3.5-sonnet",
+                        "api_key_secret": "OPENROUTER_API_KEY",
+                        "required_input_fields": ["text"],
+                        "label_field": "category",
+                        "output_path": output_path,
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 400, resp.json()
+        assert "recipe_name" in resp.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # Error paths: 400 on no GET /guided first, 404 unknown session

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -271,13 +271,20 @@ class TestStep2IntraStep:
         _respond(composer_test_client, session_id, chosen=["json"])
         output_path = _outputs_path(composer_test_client, "out.jsonl")
 
+        # Step-2 SCHEMA_FORM: must include "plugin" in edited_values so the dispatcher
+        # can persist the sink intent into GuidedSession.step_2_sink_intent.
         body = _respond(
             composer_test_client,
             session_id,
             edited_values={
-                "path": output_path,
-                "schema": {"mode": "observed"},
-                "collision_policy": "auto_increment",
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
             },
         )
 
@@ -296,34 +303,30 @@ class TestStep2IntraStep:
         self._drive_to_step_2_single_select(composer_test_client, session_id)
         _respond(composer_test_client, session_id, chosen=["json"])
         output_path = _outputs_path(composer_test_client, "out.jsonl")
+        # Step-2 SCHEMA_FORM: structured shape with plugin + options.
         _respond(
             composer_test_client,
             session_id,
             edited_values={
-                "path": output_path,
-                "schema": {"mode": "observed"},
-                "collision_policy": "auto_increment",
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
             },
         )
 
-        # Confirm required fields — "label" matches the classify-rows recipe's keyword set
+        # Confirm required fields via chosen — "label" matches the classify-rows recipe's
+        # keyword set.  The backend reconstructs SinkOutputResolved from step_2_sink_intent
+        # (plugin + options) plus these required_fields.
         body = _respond(
             composer_test_client,
             session_id,
-            edited_values={
-                "outputs": [
-                    {
-                        "plugin": "json",
-                        "options": {
-                            "path": output_path,
-                            "schema": {"mode": "observed"},
-                            "collision_policy": "auto_increment",
-                        },
-                        "required_fields": ["text", "label"],
-                        "schema_mode": "observed",
-                    }
-                ]
-            },
+            chosen=["text", "label"],
+            custom_inputs=[],
         )
 
         assert body["guided_session"]["step"] == "step_2_5_recipe_match"
@@ -345,34 +348,30 @@ class TestStep2IntraStep:
         self._drive_to_step_2_single_select(composer_test_client, session_id)
         _respond(composer_test_client, session_id, chosen=["json"])
         output_path = _outputs_path(composer_test_client, "out_sink_commit.jsonl")
+        # Step-2 SCHEMA_FORM: structured shape with plugin + options.
         _respond(
             composer_test_client,
             session_id,
             edited_values={
-                "path": output_path,
-                "schema": {"mode": "observed"},
-                "collision_policy": "auto_increment",
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
             },
         )
 
         # The MULTI_SELECT response that triggers step 2 → 2.5 advance.
+        # chosen carries the required field names; the backend reads plugin + options
+        # from GuidedSession.step_2_sink_intent (persisted by the SCHEMA_FORM dispatcher).
         body = _respond(
             composer_test_client,
             session_id,
-            edited_values={
-                "outputs": [
-                    {
-                        "plugin": "json",
-                        "options": {
-                            "path": output_path,
-                            "schema": {"mode": "observed"},
-                            "collision_policy": "auto_increment",
-                        },
-                        "required_fields": ["text", "label"],
-                        "schema_mode": "observed",
-                    }
-                ]
-            },
+            chosen=["text", "label"],
+            custom_inputs=[],
         )
 
         # Step advanced to 2.5.
@@ -418,37 +417,33 @@ class TestStep25RecipeAccept:
         )
         # Step 2: pick json sink
         _respond(client, session_id, chosen=["json"])
-        # Step 2: fill json options — path must be under {data_dir}/outputs/
+        # Step 2: fill json options — path must be under {data_dir}/outputs/.
         # collision_policy is required by the json sink validator.
+        # Must include "plugin" so the dispatcher persists step_2_sink_intent.
         _respond(
             client,
             session_id,
             edited_values={
-                "path": output_path,
-                "schema": {"mode": "observed"},
-                "collision_policy": "auto_increment",
+                "plugin": "json",
+                "options": {
+                    "path": output_path,
+                    "schema": {"mode": "observed"},
+                    "collision_policy": "auto_increment",
+                },
+                "observed_columns": [],
+                "sample_rows": [],
             },
         )
-        # Step 2: declare required fields ("category" matches classify keyword).
+        # Step 2: declare required fields via chosen ("category" matches classify keyword).
+        # The backend reads plugin + options from GuidedSession.step_2_sink_intent and
+        # combines with chosen to construct SinkOutputResolved.
         # output_path must be under {data_dir}/outputs/ and collision_policy must
         # be set (handle_step_2_sink calls _execute_set_output which validates).
         body = _respond(
             client,
             session_id,
-            edited_values={
-                "outputs": [
-                    {
-                        "plugin": "json",
-                        "options": {
-                            "path": output_path,
-                            "schema": {"mode": "observed"},
-                            "collision_policy": "auto_increment",
-                        },
-                        "required_fields": ["text", "category"],
-                        "schema_mode": "observed",
-                    }
-                ]
-            },
+            chosen=["text", "category"],
+            custom_inputs=[],
         )
         return body, blob_id
 

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -999,7 +999,7 @@ class TestStep2SchemaFormAccept:
 
 
 # ---------------------------------------------------------------------------
-# Step 1 INSPECT_AND_CONFIRM — contract-violation negative tests (Pair 4)
+# Step 1 INSPECT_AND_CONFIRM — contract tests (Pair 5a)
 # ---------------------------------------------------------------------------
 # The INSPECT_AND_CONFIRM dispatcher branch (routes.py STEP_1 → STEP_2 path)
 # is currently HTTP-unreachable in normal flow because ``get_guided`` always
@@ -1007,24 +1007,26 @@ class TestStep2SchemaFormAccept:
 # INSPECT_AND_CONFIRM turn (see emitters.build_initial_step_1_turn).  The
 # dispatch branch is exercised here via state injection (the same pattern
 # used by test_progressive_disclosure._seed_terminal_state at line 170): a
-# TurnRecord with turn_type=INSPECT_AND_CONFIRM is seeded into
-# guided.history before POST /respond fires.
+# TurnRecord with turn_type=INSPECT_AND_CONFIRM AND step_1_source_intent is
+# seeded into guided state before POST /respond fires.
+#
+# New wire contract (Pair 5a):
+#   edited_values = {"columns": list[str]}
+#
+# Plugin, options, observed_columns, and sample_rows are now held server-side
+# in step_1_source_intent (state_machine.SourceIntent).  The old 4-key wire
+# shape is gone; tests for the removed plugin/options/observed_columns guards
+# are removed.
 #
 # Shadowing note:
-#   ``_advance_step_1`` in state_machine.py runs BEFORE the dispatcher and
-#   itself raises ValueError on null ``edited_values`` and KeyError on missing
-#   required keys.  Those errors propagate as HTTP 500, not site-2's HTTP 400.
-#   The dispatcher's null/missing-key guards remain as defense-in-depth (and
-#   are documented in the dispatcher comment) but cannot be asserted as 400
-#   via normal HTTP; the unit-level test_state_machine suite pins them at the
-#   ValueError/KeyError boundary.
-#
-#   The validators that ARE HTTP-reachable as 400 are those where step_advance's
-#   ``str()``/``tuple()`` coercion passes the raw value through:
-#     - non-string plugin (str(42) → "42" passes; isinstance(42,str)=False fires)
-#     - empty plugin     (str("")=""    passes; ``not plugin_name`` fires)
-#     - non-list observed_columns (tuple("abc")=('a','b','c') passes; isinstance fires)
-#   These three are tested below.
+#   ``_advance_step_1`` runs BEFORE the dispatcher and raises ValueError on
+#   null ``edited_values`` and KeyError on missing ``columns``.  Those errors
+#   propagate as HTTP 500, not the dispatcher's HTTP 400.  The dispatcher's
+#   null guard and missing-key guard remain as defense-in-depth.  The guard
+#   that IS HTTP-reachable as 400 is the ``isinstance(columns_raw, list)``
+#   check: ``_advance_step_1``'s ``tuple(str(c) for c in columns_raw)``
+#   silently accepts a scalar string (iterating its characters), so the
+#   dispatcher catches non-list here before that coercion runs.
 
 
 class TestStep1InspectAndConfirmAccept:
@@ -1033,13 +1035,18 @@ class TestStep1InspectAndConfirmAccept:
         client: TestClient,
         session_id: str,
     ) -> None:
-        """Seed an INSPECT_AND_CONFIRM TurnRecord into the session's guided history.
+        """Seed an INSPECT_AND_CONFIRM TurnRecord + step_1_source_intent into the session.
 
         This bypasses GET /guided because the server-side initial-turn builder
         passes blob_inspection=None unconditionally and so never emits an
         inspect_and_confirm turn.  We inject the state directly via
         save_composition_state — the same pattern used by
         test_progressive_disclosure._seed_terminal_state (line 170).
+
+        step_1_source_intent is populated so that _advance_step_1 can recover
+        plugin/options/sample_rows when the POST /respond fires — without it
+        _advance_step_1 raises ValueError before the dispatcher can validate
+        edited_values.
         """
         from dataclasses import replace
 
@@ -1048,6 +1055,7 @@ class TestStep1InspectAndConfirmAccept:
         from elspeth.web.composer.guided.state_machine import (
             GuidedSession,
             GuidedStep,
+            SourceIntent,
             TurnRecord,
         )
         from elspeth.web.sessions.converters import state_from_record
@@ -1067,7 +1075,8 @@ class TestStep1InspectAndConfirmAccept:
 
         # Build the GuidedSession with an INSPECT_AND_CONFIRM TurnRecord
         # at STEP_1_SOURCE so the dispatcher's current_turn_type read picks
-        # it up on POST /respond.
+        # it up on POST /respond.  Also seed step_1_source_intent so that
+        # _advance_step_1 can build SourceResolved from it.
         guided = state.guided_session if state.guided_session is not None else GuidedSession.initial()
         record = TurnRecord(
             step=GuidedStep.STEP_1_SOURCE,
@@ -1076,7 +1085,13 @@ class TestStep1InspectAndConfirmAccept:
             response_hash=None,
             emitter="server",
         )
-        guided = replace(guided, history=(*guided.history, record))
+        intent = SourceIntent(
+            plugin="csv",
+            options={"path": "/data/input.csv"},
+            observed_columns=("id", "name", "score"),
+            sample_rows=({"id": 1, "name": "Alice", "score": 99},),
+        )
+        guided = replace(guided, history=(*guided.history, record), step_1_source_intent=intent)
         state = replace(state, guided_session=guided)
 
         new_composer_meta = {**existing_meta, "guided_session": guided.to_dict()}
@@ -1093,12 +1108,14 @@ class TestStep1InspectAndConfirmAccept:
         )
         asyncio.run(service.save_composition_state(session_uuid, state_data))
 
-    def test_inspect_and_confirm_empty_plugin_returns_400(self, composer_test_client: TestClient) -> None:
-        """Empty-string ``plugin`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
+    def test_inspect_and_confirm_non_list_columns_returns_400(self, composer_test_client: TestClient) -> None:
+        """Non-list ``columns`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
 
-        Site 2's ``isinstance(plugin_name, str) or not plugin_name`` check
-        fires the 400 on the raw empty-string value (replacing the previous
-        silent ``str(edited["plugin"])`` coercion).
+        The dispatcher's ``isinstance(columns_raw, list)`` guard fires the 400
+        on the raw scalar value.  This guard IS HTTP-reachable as 400 because
+        ``_advance_step_1``'s ``tuple(str(c) for c in columns_raw)`` coercion
+        would silently accept a scalar string (iterating its characters),
+        so the dispatcher must catch it before that coercion runs.
         """
         session_id = _create_session(composer_test_client)
         self._seed_inspect_and_confirm_history(composer_test_client, session_id)
@@ -1107,83 +1124,12 @@ class TestStep1InspectAndConfirmAccept:
             f"/api/sessions/{session_id}/guided/respond",
             json={
                 "edited_values": {
-                    "plugin": "",
-                    "options": {},
-                    "observed_columns": [],
-                    "sample_rows": [],
+                    "columns": "id,name,score",  # string, not a list
                 },
             },
         )
         assert resp.status_code == 400, resp.json()
         detail = resp.json()["detail"]
-        # Assert the boundary-message marker, not a bare substring — without
-        # the dispatcher guard, ``""`` would flow through ``handle_step_1_source``
-        # and the resulting 400 ``"Step 1 source commit failed: ToolResult(...)"``
-        # repr contains the word "plugin", so ``"inspect_and_confirm" in detail``
-        # / ``"plugin" in detail`` would BOTH pass against the unguarded path
-        # (the dispatcher's own 400 message starts ``"inspect_and_confirm
-        # response at step 1 ..."``, and the downstream commit-failure 400
-        # carries the dispatched ToolResult which echoes "plugin"). Only the
-        # contract-citing message "must be a non-empty string" mechanically
-        # pins this test to the dispatcher's guard.
-        assert "inspect_and_confirm response at step 1" in detail
-        assert "must be a non-empty string" in detail
-        assert "''" in detail  # the offending empty-string value is echoed in the detail
-
-    def test_inspect_and_confirm_non_string_plugin_returns_400(self, composer_test_client: TestClient) -> None:
-        """Non-string ``plugin`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
-
-        Site 2's ``isinstance(plugin_name, str)`` check fires the 400 on the
-        raw integer value (replacing the previous silent ``str(42)="42"``
-        coercion).
-        """
-        session_id = _create_session(composer_test_client)
-        self._seed_inspect_and_confirm_history(composer_test_client, session_id)
-
-        resp = composer_test_client.post(
-            f"/api/sessions/{session_id}/guided/respond",
-            json={
-                "edited_values": {
-                    "plugin": 42,
-                    "options": {},
-                    "observed_columns": [],
-                    "sample_rows": [],
-                },
-            },
-        )
-        assert resp.status_code == 400, resp.json()
-        detail = resp.json()["detail"]
-        # Boundary-message marker pins the dispatcher's 400 against the
-        # downstream ToolResult-repr 400 that also contains "plugin".
-        assert "inspect_and_confirm response at step 1" in detail
-        assert "must be a non-empty string" in detail
-        assert "42" in detail  # the offending integer value is echoed in the detail
-
-    def test_inspect_and_confirm_non_list_observed_columns_returns_400(self, composer_test_client: TestClient) -> None:
-        """Non-list ``observed_columns`` at post-advance INSPECT_AND_CONFIRM is a protocol violation (HTTP 400).
-
-        Site 2's ``isinstance(observed_columns_raw, list)`` check fires the
-        400 on the raw scalar value (replacing the previous silent
-        ``tuple("abc")=('a','b','c')`` coercion that would have yielded a
-        character-wise tuple).
-        """
-        session_id = _create_session(composer_test_client)
-        self._seed_inspect_and_confirm_history(composer_test_client, session_id)
-
-        resp = composer_test_client.post(
-            f"/api/sessions/{session_id}/guided/respond",
-            json={
-                "edited_values": {
-                    "plugin": "csv",
-                    "options": {},
-                    "observed_columns": "abc",
-                    "sample_rows": [],
-                },
-            },
-        )
-        assert resp.status_code == 400, resp.json()
-        detail = resp.json()["detail"]
-        # Boundary-message marker pins the dispatcher's list-guard.
         assert "inspect_and_confirm response at step 1" in detail
         assert "must be a list" in detail
         assert "str" in detail  # offending type is named

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -269,11 +269,16 @@ class TestStep2IntraStep:
         session_id = _create_session(composer_test_client)
         self._drive_to_step_2_single_select(composer_test_client, session_id)
         _respond(composer_test_client, session_id, chosen=["json"])
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
 
         body = _respond(
             composer_test_client,
             session_id,
-            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+            edited_values={
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
         )
 
         assert body["next_turn"]["type"] == "multi_select_with_custom"
@@ -290,10 +295,15 @@ class TestStep2IntraStep:
         session_id = _create_session(composer_test_client)
         self._drive_to_step_2_single_select(composer_test_client, session_id)
         _respond(composer_test_client, session_id, chosen=["json"])
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
         _respond(
             composer_test_client,
             session_id,
-            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+            edited_values={
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
         )
 
         # Confirm required fields — "label" matches the classify-rows recipe's keyword set
@@ -304,7 +314,11 @@ class TestStep2IntraStep:
                 "outputs": [
                     {
                         "plugin": "json",
-                        "options": {"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        "options": {
+                            "path": output_path,
+                            "schema": {"mode": "observed"},
+                            "collision_policy": "auto_increment",
+                        },
                         "required_fields": ["text", "label"],
                         "schema_mode": "observed",
                     }
@@ -318,6 +332,57 @@ class TestStep2IntraStep:
         payload = body["next_turn"]["payload"]
         assert "recipe_name" in payload
         assert payload["recipe_name"] == "classify-rows-llm-jsonl"
+
+    def test_multi_select_response_commits_sink_to_state(self, composer_test_client: TestClient) -> None:
+        """M1: MULTI_SELECT_WITH_CUSTOM → step 2.5 transition commits sink to composition_state.outputs.
+
+        Verifies C2 fix: handle_step_2_sink IS called on the MULTI_SELECT_WITH_CUSTOM
+        → step 2.5 transition.  Before the fix, state.outputs was empty because
+        handle_step_2_sink was never called; the recipe-apply path (step 2.5) would
+        then fail with a missing sink when generating YAML.
+        """
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_single_select(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["json"])
+        output_path = _outputs_path(composer_test_client, "out_sink_commit.jsonl")
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+        )
+
+        # The MULTI_SELECT response that triggers step 2 → 2.5 advance.
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "outputs": [
+                    {
+                        "plugin": "json",
+                        "options": {
+                            "path": output_path,
+                            "schema": {"mode": "observed"},
+                            "collision_policy": "auto_increment",
+                        },
+                        "required_fields": ["text", "label"],
+                        "schema_mode": "observed",
+                    }
+                ]
+            },
+        )
+
+        # Step advanced to 2.5.
+        assert body["guided_session"]["step"] == "step_2_5_recipe_match"
+
+        # Composition state must have at least one output — sink was committed.
+        cs = body["composition_state"]
+        assert cs is not None, "composition_state missing from response"
+        outputs = cs.get("outputs", {})
+        assert outputs, "composition_state.outputs is empty after MULTI_SELECT advance — handle_step_2_sink was not called (C2 regression)"
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +400,7 @@ class TestStep25RecipeAccept:
         (``_execute_set_source`` requires the path to be under {data_dir}/blobs/).
         """
         blob_id, storage_path = _seed_blob(client, session_id)
+        output_path = _outputs_path(client, "out.jsonl")
 
         _get_guided(client, session_id)
         # Step 1: pick csv
@@ -352,13 +418,20 @@ class TestStep25RecipeAccept:
         )
         # Step 2: pick json sink
         _respond(client, session_id, chosen=["json"])
-        # Step 2: fill json options
+        # Step 2: fill json options — path must be under {data_dir}/outputs/
+        # collision_policy is required by the json sink validator.
         _respond(
             client,
             session_id,
-            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+            edited_values={
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
         )
-        # Step 2: declare required fields ("category" matches classify keyword)
+        # Step 2: declare required fields ("category" matches classify keyword).
+        # output_path must be under {data_dir}/outputs/ and collision_policy must
+        # be set (handle_step_2_sink calls _execute_set_output which validates).
         body = _respond(
             client,
             session_id,
@@ -366,7 +439,11 @@ class TestStep25RecipeAccept:
                 "outputs": [
                     {
                         "plugin": "json",
-                        "options": {"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        "options": {
+                            "path": output_path,
+                            "schema": {"mode": "observed"},
+                            "collision_policy": "auto_increment",
+                        },
                         "required_fields": ["text", "category"],
                         "schema_mode": "observed",
                     }

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -335,6 +335,20 @@ class TestStep2IntraStep:
         payload = body["next_turn"]["payload"]
         assert "recipe_name" in payload
         assert payload["recipe_name"] == "classify-rows-llm-jsonl"
+        # Gap 6 wire-shape: payload exposes the unsatisfied required slots
+        # so the frontend can render an editable form for them.  classify-rows
+        # has three required slots not derivable from (source, sink):
+        # classifier_template, model, api_key_secret.
+        assert "unsatisfied_slots" in payload
+        unsatisfied_names = {entry["name"] for entry in payload["unsatisfied_slots"]}
+        assert unsatisfied_names == {
+            "classifier_template",
+            "model",
+            "api_key_secret",
+        }
+        for entry in payload["unsatisfied_slots"]:
+            assert set(entry.keys()) == {"name", "slot_type", "description", "required"}
+            assert entry["required"] is True
 
     def test_multi_select_response_commits_sink_to_state(self, composer_test_client: TestClient) -> None:
         """M1: MULTI_SELECT_WITH_CUSTOM → step 2.5 transition commits sink to composition_state.outputs.

--- a/tests/integration/web/composer/guided/test_respond.py
+++ b/tests/integration/web/composer/guided/test_respond.py
@@ -1,0 +1,497 @@
+"""Integration tests for POST /api/sessions/{id}/guided/respond.
+
+Verifies the dispatcher's step routing, intra-step turn progression, and
+the happy-path walk from step 1 (SINGLE_SELECT) through step 2.5
+(RECIPE_OFFER) to a COMPLETED terminal state.
+
+HTTP transport: SyncASGITestClient (in-process, synchronous — same pattern
+as test_get_guided.py).  The full roundtrip exercises:
+  - route handler lock + guided session load
+  - _dispatch_guided_respond per-step routing
+  - step_advance (pure) + step handlers (side-effectful)
+  - GuidedSession serialisation round-trip through composer_meta
+  - audit drain via _persist_tool_invocations
+
+Per spec §3.1, §3.2, §3.3, §5.3:
+  - SINGLE_SELECT at step 1 → server emits SCHEMA_FORM (intra-step)
+  - SCHEMA_FORM at step 1 → handle_step_1_source + advance to step 2;
+    server emits SINGLE_SELECT (step 2 initial)
+  - SINGLE_SELECT at step 2 → server emits SCHEMA_FORM (intra-step)
+  - SCHEMA_FORM at step 2 → server emits MULTI_SELECT_WITH_CUSTOM (intra-step)
+  - MULTI_SELECT_WITH_CUSTOM at step 2 → handle_step_2_sink + advance;
+    server emits RECIPE_OFFER if recipe matched
+  - RECIPE_OFFER chosen=["accept"] → handle_step_2_5_recipe_apply;
+    terminal=COMPLETED
+
+Error paths (exit_to_freeform, 409 after terminal) live in test_error_paths.py
+(Task 3.6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import UUID
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    """Create a session and return its string id."""
+    resp = client.post("/api/sessions", json={"title": "respond-test"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    """Fetch GET /guided and assert 200."""
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    """POST /guided/respond and assert 200."""
+    resp = client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _seed_blob(client: TestClient, session_id: str) -> tuple[str, str]:
+    """Seed a CSV blob and return (blob_id, storage_path).
+
+    The ``storage_path`` is the authoritative file path under
+    ``{data_dir}/blobs/{session_id}/`` and can be passed directly as the
+    ``path`` option in a source SCHEMA_FORM response (it's already under
+    the allowed source directories).
+
+    Needed for:
+    - Step 1 SCHEMA_FORM advance: ``_execute_set_source`` validates that
+      ``path`` is under ``{data_dir}/blobs/``.
+    - Step 2.5 recipe-apply: ``blob_id`` must resolve to a real file in
+      the session DB for ``_resolve_source_blob``.
+    """
+    content = "text,category\nHello world,greeting\nGoodbye,farewell\n"
+    resp = client.post(
+        f"/api/sessions/{session_id}/blobs/inline",
+        json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+    )
+    assert resp.status_code == 201, resp.json()
+    blob_id = resp.json()["id"]
+
+    # Retrieve storage_path from the blob service (not exposed by API).
+    blob_service = client.app.state.blob_service
+    record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+    return blob_id, record.storage_path
+
+
+def _outputs_path(client: TestClient, filename: str) -> str:
+    """Return an absolute path under {data_dir}/outputs/ for use as a sink path.
+
+    Sink paths are validated by _validate_sink_path to be under {data_dir}/outputs/
+    or {data_dir}/blobs/.  Tests must use this helper instead of bare relative paths
+    like "out.jsonl" to pass the path allowlist check.
+    """
+    data_dir: Path = client.app.state.settings.data_dir
+    outputs_dir = data_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    return str(outputs_dir / filename)
+
+
+# ---------------------------------------------------------------------------
+# Step 1 intra-step — SINGLE_SELECT → SCHEMA_FORM
+# ---------------------------------------------------------------------------
+
+
+class TestStep1IntraStep:
+    def test_single_select_response_emits_schema_form(self, composer_test_client: TestClient) -> None:
+        """POST /respond with a SINGLE_SELECT response emits SCHEMA_FORM for the chosen plugin."""
+        session_id = _create_session(composer_test_client)
+        get_body = _get_guided(composer_test_client, session_id)
+        assert get_body["next_turn"]["type"] == "single_select"
+
+        # Respond to the single_select: pick "csv"
+        body = _respond(composer_test_client, session_id, chosen=["csv"])
+
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "schema_form"
+        payload = body["next_turn"]["payload"]
+        assert payload["plugin"] == "csv"
+        assert "schema_block" in payload
+        assert "prefilled" in payload
+        # schema.mode defaults to "observed"
+        assert payload["prefilled"].get("schema", {}).get("mode") == "observed"
+
+    def test_single_select_response_records_response_hash(self, composer_test_client: TestClient) -> None:
+        """The TurnRecord for the SINGLE_SELECT turn is updated with a response_hash."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        body = _respond(composer_test_client, session_id, chosen=["csv"])
+
+        history = body["guided_session"]["history"]
+        # First record: the SINGLE_SELECT turn (now has response_hash)
+        ss_record = next(r for r in history if r["turn_type"] == "single_select")
+        assert ss_record["response_hash"] is not None
+        # Second record: the new SCHEMA_FORM turn (no response yet)
+        sf_record = next(r for r in history if r["turn_type"] == "schema_form")
+        assert sf_record["response_hash"] is None
+        assert sf_record["emitter"] == "server"
+
+    def test_schema_form_step_index_matches_step_1(self, composer_test_client: TestClient) -> None:
+        """The emitted schema_form is still at step_index 0 (step_1_source)."""
+        session_id = _create_session(composer_test_client)
+        _get_guided(composer_test_client, session_id)
+
+        body = _respond(composer_test_client, session_id, chosen=["csv"])
+
+        assert body["next_turn"]["step_index"] == 0  # STEP_1_SOURCE is index 0
+        assert body["guided_session"]["step"] == "step_1_source"
+
+
+# ---------------------------------------------------------------------------
+# Step 1 completing — SCHEMA_FORM → handle_step_1_source → Step 2
+# ---------------------------------------------------------------------------
+
+
+class TestStep1Advance:
+    def _drive_to_schema_form(self, client: TestClient, session_id: str) -> dict:
+        """Drive to the Step 1 SCHEMA_FORM state. Returns the last /respond body."""
+        _get_guided(client, session_id)
+        return _respond(client, session_id, chosen=["csv"])
+
+    def test_schema_form_response_advances_to_step_2(self, composer_test_client: TestClient) -> None:
+        """A SCHEMA_FORM response calls handle_step_1_source and advances to STEP_2_SINK."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+
+        # Submit SCHEMA_FORM response with source options — path must be under {data_dir}/blobs/
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "category"],
+                "sample_rows": [{"text": "Hello", "category": "greeting"}],
+            },
+        )
+
+        assert body["guided_session"]["step"] == "step_2_sink"
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "single_select"
+        assert body["next_turn"]["step_index"] == 1  # STEP_2_SINK is index 1
+
+    def test_schema_form_response_commits_source_to_state(self, composer_test_client: TestClient) -> None:
+        """After SCHEMA_FORM advance, composition_state has a source set."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["col_a"],
+                "sample_rows": [],
+            },
+        )
+
+        cs = body["composition_state"]
+        assert cs is not None
+        assert cs["source"] is not None
+        assert cs["source"]["plugin"] == "csv"
+
+    def test_step_2_single_select_lists_sink_plugins(self, composer_test_client: TestClient) -> None:
+        """The step-2 initial turn is single_select listing registered sink plugins."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_schema_form(composer_test_client, session_id)
+        _blob_id, storage_path = _seed_blob(composer_test_client, session_id)
+
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["x"],
+                "sample_rows": [],
+            },
+        )
+
+        options = body["next_turn"]["payload"]["options"]
+        ids = [o["id"] for o in options]
+        assert "json" in ids, f"json sink not found in options: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# Step 2 intra-step — sink SINGLE_SELECT → SCHEMA_FORM → MULTI_SELECT
+# ---------------------------------------------------------------------------
+
+
+class TestStep2IntraStep:
+    def _drive_to_step_2_single_select(self, client: TestClient, session_id: str) -> dict:
+        """Drive to the Step 2 initial SINGLE_SELECT state."""
+        _get_guided(client, session_id)
+        _respond(client, session_id, chosen=["csv"])
+        _blob_id, storage_path = _seed_blob(client, session_id)
+        return _respond(
+            client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "label"],
+                "sample_rows": [],
+            },
+        )
+
+    def test_step_2_single_select_response_emits_schema_form(self, composer_test_client: TestClient) -> None:
+        """Picking a sink plugin emits SCHEMA_FORM for the sink options."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_single_select(composer_test_client, session_id)
+
+        body = _respond(composer_test_client, session_id, chosen=["json"])
+
+        assert body["next_turn"]["type"] == "schema_form"
+        assert body["next_turn"]["payload"]["plugin"] == "json"
+        assert body["next_turn"]["step_index"] == 1
+
+    def test_schema_form_at_step_2_emits_multi_select(self, composer_test_client: TestClient) -> None:
+        """Filling in sink options emits MULTI_SELECT_WITH_CUSTOM for required fields."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_single_select(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["json"])
+
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+        )
+
+        assert body["next_turn"]["type"] == "multi_select_with_custom"
+        payload = body["next_turn"]["payload"]
+        assert "options" in payload
+        assert "default_chosen" in payload
+        # Observed columns from step 1 appear as options
+        option_ids = [o["id"] for o in payload["options"]]
+        assert "text" in option_ids
+        assert "label" in option_ids
+
+    def test_multi_select_response_advances_to_step_2_5_with_recipe(self, composer_test_client: TestClient) -> None:
+        """MULTI_SELECT_WITH_CUSTOM response advances to step 2.5 with a RECIPE_OFFER turn."""
+        session_id = _create_session(composer_test_client)
+        self._drive_to_step_2_single_select(composer_test_client, session_id)
+        _respond(composer_test_client, session_id, chosen=["json"])
+        _respond(
+            composer_test_client,
+            session_id,
+            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+        )
+
+        # Confirm required fields — "label" matches the classify-rows recipe's keyword set
+        body = _respond(
+            composer_test_client,
+            session_id,
+            edited_values={
+                "outputs": [
+                    {
+                        "plugin": "json",
+                        "options": {"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        "required_fields": ["text", "label"],
+                        "schema_mode": "observed",
+                    }
+                ]
+            },
+        )
+
+        assert body["guided_session"]["step"] == "step_2_5_recipe_match"
+        assert body["next_turn"] is not None
+        assert body["next_turn"]["type"] == "recipe_offer"
+        payload = body["next_turn"]["payload"]
+        assert "recipe_name" in payload
+        assert payload["recipe_name"] == "classify-rows-llm-jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Step 2.5 — RECIPE_OFFER accept → terminal=COMPLETED
+# ---------------------------------------------------------------------------
+
+
+class TestStep25RecipeAccept:
+    def _drive_to_recipe_offer(self, client: TestClient, session_id: str) -> tuple[dict, str]:
+        """Drive to the RECIPE_OFFER state. Returns (last body, blob_id).
+
+        blob_id is returned for use as ``source_blob_id`` in the recipe-accept
+        slots, where _execute_apply_pipeline_recipe resolves it via the session DB.
+        storage_path is used as the source ``path`` option for the step-1 commit
+        (``_execute_set_source`` requires the path to be under {data_dir}/blobs/).
+        """
+        blob_id, storage_path = _seed_blob(client, session_id)
+
+        _get_guided(client, session_id)
+        # Step 1: pick csv
+        _respond(client, session_id, chosen=["csv"])
+        # Step 1: fill csv options — path must be under {data_dir}/blobs/
+        _respond(
+            client,
+            session_id,
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": storage_path, "schema": {"mode": "observed"}},
+                "observed_columns": ["text", "category"],
+                "sample_rows": [{"text": "Hello", "category": "greeting"}],
+            },
+        )
+        # Step 2: pick json sink
+        _respond(client, session_id, chosen=["json"])
+        # Step 2: fill json options
+        _respond(
+            client,
+            session_id,
+            edited_values={"path": "out.jsonl", "schema": {"mode": "observed"}},
+        )
+        # Step 2: declare required fields ("category" matches classify keyword)
+        body = _respond(
+            client,
+            session_id,
+            edited_values={
+                "outputs": [
+                    {
+                        "plugin": "json",
+                        "options": {"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        "required_fields": ["text", "category"],
+                        "schema_mode": "observed",
+                    }
+                ]
+            },
+        )
+        return body, blob_id
+
+    def test_recipe_offer_accept_produces_terminal_completed(self, composer_test_client: TestClient) -> None:
+        """Accepting the recipe offer produces terminal.kind=completed with pipeline YAML."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        # Verify recipe was offered
+        assert recipe_body["next_turn"]["type"] == "recipe_offer"
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        # Accept the recipe — output_path must be under {data_dir}/outputs/
+        body = _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        assert body["terminal"] is not None
+        assert body["terminal"]["kind"] == "completed"
+        assert body["terminal"]["pipeline_yaml"] is not None
+        assert "source:" in body["terminal"]["pipeline_yaml"]
+        assert body["next_turn"] is None
+
+    def test_completed_terminal_reflected_in_guided_session(self, composer_test_client: TestClient) -> None:
+        """After recipe accept, guided_session.terminal is COMPLETED."""
+        session_id = _create_session(composer_test_client)
+        _recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+
+        body = _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": "classify-rows-llm-jsonl",
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        gs = body["guided_session"]
+        assert gs["terminal"] is not None
+        assert gs["terminal"]["kind"] == "completed"
+        assert gs["terminal"]["reason"] is None
+
+    def test_recipe_state_survives_roundtrip(self, composer_test_client: TestClient) -> None:
+        """After the full walk, a GET /guided re-fetch returns terminal state from DB."""
+        session_id = _create_session(composer_test_client)
+        recipe_body, blob_id = self._drive_to_recipe_offer(composer_test_client, session_id)
+        output_path = _outputs_path(composer_test_client, "out.jsonl")
+        offered_recipe = recipe_body["next_turn"]["payload"]["recipe_name"]
+
+        _respond(
+            composer_test_client,
+            session_id,
+            chosen=["accept"],
+            edited_values={
+                "recipe_name": offered_recipe,
+                "slots": {
+                    "source_blob_id": blob_id,
+                    "classifier_template": "Classify: {{ row['text'] }}",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "api_key_secret": "OPENROUTER_API_KEY",
+                    "required_input_fields": ["text"],
+                    "label_field": "category",
+                    "output_path": output_path,
+                },
+            },
+        )
+
+        # Re-fetch from DB
+        get_body = _get_guided(composer_test_client, session_id)
+        gs = get_body["guided_session"]
+        assert gs["terminal"] is not None
+        assert gs["terminal"]["kind"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Error paths: 400 on no GET /guided first, 404 unknown session
+# ---------------------------------------------------------------------------
+
+
+class TestRespondErrorPaths:
+    def test_respond_without_prior_get_returns_400(self, composer_test_client: TestClient) -> None:
+        """POST /respond without prior GET /guided returns 400 (no turn emitted)."""
+        session_id = _create_session(composer_test_client)
+        resp = composer_test_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"chosen": ["csv"]},
+        )
+        # No TurnRecord emitted yet — dispatcher crashes with 400.
+        assert resp.status_code == 400
+
+    def test_respond_unknown_session_returns_404(self, composer_test_client: TestClient) -> None:
+        """POST /respond for a non-existent session returns 404."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        resp = composer_test_client.post(
+            f"/api/sessions/{fake_id}/guided/respond",
+            json={"chosen": ["csv"]},
+        )
+        assert resp.status_code == 404

--- a/tests/integration/web/composer/guided/test_step_3_e2e.py
+++ b/tests/integration/web/composer/guided/test_step_3_e2e.py
@@ -1,0 +1,231 @@
+"""End-to-end Step 3 chain-solver tests.
+
+Walks the wizard from new-session through Step 1 (CSV source) + Step 2
+(JSON sink, no recipe match by virtue of non-classifier ``required_fields``)
++ Step 3 (LLM-proposed chain, accepted) to a COMPLETED terminal with
+rendered YAML.  The LLM is stubbed by patching ``_litellm_acompletion`` on
+the chain_solver module the same way Task 4.3 stubs it in
+``test_chain_solver.py``.
+
+Reject and clarifying-question paths are deferred to Phase 5; for the MVP
+they raise ``HTTPException`` 501, which the second test exercises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from tests.unit.web._sync_asgi_client import SyncASGITestClient as TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_respond.py — kept local to avoid cross-file imports)
+# ---------------------------------------------------------------------------
+
+
+def _create_session(client: TestClient) -> str:
+    resp = client.post("/api/sessions", json={"title": "step-3-e2e"})
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["id"]
+
+
+def _get_guided(client: TestClient, session_id: str) -> dict:
+    resp = client.get(f"/api/sessions/{session_id}/guided")
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _respond(client: TestClient, session_id: str, **kwargs) -> dict:
+    resp = client.post(f"/api/sessions/{session_id}/guided/respond", json=kwargs)
+    assert resp.status_code == 200, resp.json()
+    return resp.json()
+
+
+def _seed_blob(client: TestClient, session_id: str) -> tuple[str, str]:
+    content = "text,note\nHello world,greeting\nGoodbye,farewell\n"
+    resp = client.post(
+        f"/api/sessions/{session_id}/blobs/inline",
+        json={"filename": "data.csv", "content": content, "mime_type": "text/csv"},
+    )
+    assert resp.status_code == 201, resp.json()
+    blob_id = resp.json()["id"]
+    blob_service = client.app.state.blob_service
+    record = asyncio.run(blob_service.get_blob(UUID(blob_id)))
+    return blob_id, record.storage_path
+
+
+def _outputs_path(client: TestClient, filename: str) -> str:
+    data_dir: Path = client.app.state.settings.data_dir
+    outputs_dir = data_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    return str(outputs_dir / filename)
+
+
+def _fake_llm_response_for_passthrough() -> SimpleNamespace:
+    """A LiteLLM-shaped response that proposes a single passthrough transform.
+
+    Passthrough is the safest stub target: minimal options
+    (only ``schema: {mode: observed}`` required) so the
+    ``_execute_set_pipeline`` step inside ``handle_step_3_chain_accept`` is
+    exercising the wiring, not plugin-specific validation.
+    """
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="emit_turn",
+                                arguments=json.dumps(
+                                    {
+                                        "turn_type": "propose_chain",
+                                        "payload": {
+                                            "steps": [
+                                                {
+                                                    "plugin": "passthrough",
+                                                    "options": {"schema": {"mode": "observed"}},
+                                                    "rationale": "no transformation needed; pass rows through unchanged",
+                                                }
+                                            ],
+                                            "why": "source rows already match sink schema; identity chain is sufficient",
+                                        },
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+
+
+def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple[dict, str, str]:
+    """Drive the wizard to the Step 3 ``propose_chain`` turn.
+
+    Returns (response_body_at_step_3, blob_id, output_path).
+
+    Picks ``required_fields=["text"]`` so the deterministic recipe matcher
+    finds no match (no classifier keyword present, single JSON output —
+    neither ``classify-rows-llm-jsonl`` nor ``split-by-numeric-threshold``
+    fires), forcing the chain-solver entry seam at the no-recipe branch.
+    """
+    blob_id, storage_path = _seed_blob(client, session_id)
+    output_path = _outputs_path(client, "out.jsonl")
+
+    _get_guided(client, session_id)
+    _respond(client, session_id, chosen=["csv"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "plugin": "csv",
+            "options": {"path": storage_path, "schema": {"mode": "observed"}},
+            "observed_columns": ["text", "note"],
+            "sample_rows": [{"text": "Hello world", "note": "greeting"}],
+        },
+    )
+    _respond(client, session_id, chosen=["json"])
+    _respond(
+        client,
+        session_id,
+        edited_values={
+            "path": output_path,
+            "schema": {"mode": "observed"},
+            "collision_policy": "auto_increment",
+        },
+    )
+    body = _respond(
+        client,
+        session_id,
+        edited_values={
+            "outputs": [
+                {
+                    "plugin": "json",
+                    "options": {
+                        "path": output_path,
+                        "schema": {"mode": "observed"},
+                        "collision_policy": "auto_increment",
+                    },
+                    # No classifier keyword (no category/label/tag/classification),
+                    # not exactly two outputs → no recipe matches → chain solver
+                    # entry seam fires.
+                    "required_fields": ["text"],
+                    "schema_mode": "observed",
+                }
+            ]
+        },
+    )
+    return body, blob_id, output_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStep3ChainAccept:
+    def test_csv_to_json_step_3_accept_completes_session(self, composer_test_client: TestClient) -> None:
+        """End-to-end: Step 1 + Step 2 + Step 3 ACCEPT → terminal=COMPLETED with YAML."""
+        session_id = _create_session(composer_test_client)
+
+        # Drive Steps 1 + 2 + the auto-advance to Step 3 (with chain-solver stubbed).
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_passthrough(),
+        ):
+            body, _blob_id, _output_path = _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+            # Verify we are now at Step 3 with a server-emitted propose_chain turn.
+            assert body["guided_session"]["step"] == "step_3_transforms"
+            next_turn = body["next_turn"]
+            assert next_turn is not None
+            assert next_turn["type"] == "propose_chain"
+            assert next_turn["step_index"] == 3
+            payload = next_turn["payload"]
+            assert set(payload.keys()) == {"steps", "why", "blockers"}
+            assert payload["blockers"] == []
+            assert payload["steps"][0]["plugin"] == "passthrough"
+
+            # Accept the chain.  handle_step_3_chain_accept commits via
+            # _execute_set_pipeline and stamps terminal=COMPLETED.
+            accept_body = _respond(composer_test_client, session_id, chosen=["accept"])
+
+        terminal = accept_body["terminal"]
+        assert terminal is not None
+        assert terminal["kind"] == "completed"
+        assert terminal["pipeline_yaml"] is not None
+        assert "source:" in terminal["pipeline_yaml"]
+        assert "passthrough" in terminal["pipeline_yaml"]
+        assert accept_body["next_turn"] is None
+
+        gs = accept_body["guided_session"]
+        assert gs["terminal"]["kind"] == "completed"
+
+
+class TestStep3RejectIsPhase5:
+    def test_csv_to_json_step_3_reject_returns_501(self, composer_test_client: TestClient) -> None:
+        """Rejecting the chain proposal returns 501 (Phase 5 scope)."""
+        session_id = _create_session(composer_test_client)
+
+        with patch(
+            "elspeth.web.composer.guided.chain_solver._litellm_acompletion",
+            new_callable=AsyncMock,
+            return_value=_fake_llm_response_for_passthrough(),
+        ):
+            _drive_to_step_3_propose_chain(composer_test_client, session_id)
+
+            resp = composer_test_client.post(
+                f"/api/sessions/{session_id}/guided/respond",
+                json={"chosen": ["reject"]},
+            )
+
+        assert resp.status_code == 501
+        # Phase-5 punt is explicit and mentions exit_to_freeform as the workaround.
+        assert "Phase 5" in resp.json()["detail"]

--- a/tests/integration/web/composer/guided/test_step_3_e2e.py
+++ b/tests/integration/web/composer/guided/test_step_3_e2e.py
@@ -135,31 +135,23 @@ def _drive_to_step_3_propose_chain(client: TestClient, session_id: str) -> tuple
         client,
         session_id,
         edited_values={
-            "path": output_path,
-            "schema": {"mode": "observed"},
-            "collision_policy": "auto_increment",
+            "plugin": "json",
+            "options": {
+                "path": output_path,
+                "schema": {"mode": "observed"},
+                "collision_policy": "auto_increment",
+            },
+            "observed_columns": [],
+            "sample_rows": [],
         },
     )
+    # No classifier keyword (no category/label/tag/classification),
+    # not exactly two outputs → no recipe matches → chain solver entry seam fires.
     body = _respond(
         client,
         session_id,
-        edited_values={
-            "outputs": [
-                {
-                    "plugin": "json",
-                    "options": {
-                        "path": output_path,
-                        "schema": {"mode": "observed"},
-                        "collision_policy": "auto_increment",
-                    },
-                    # No classifier keyword (no category/label/tag/classification),
-                    # not exactly two outputs → no recipe matches → chain solver
-                    # entry seam fires.
-                    "required_fields": ["text"],
-                    "schema_mode": "observed",
-                }
-            ]
-        },
+        chosen=["text"],
+        custom_inputs=[],
     )
     return body, blob_id, output_path
 

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -7,6 +7,8 @@ helpers; only the catalog is constructed via the public test seam
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 
 from elspeth.web.composer.guided.state_machine import (
@@ -164,3 +166,144 @@ class TestStep2Handler:
                 resolved=SinkResolved(outputs=()),
                 catalog=catalog,
             )
+
+
+class TestStep25Handler:
+    """Tests for handle_step_2_5_recipe_apply.
+
+    The success test requires a seeded session engine (blob registered in the
+    DB) because _execute_apply_pipeline_recipe → _execute_set_pipeline calls
+    _resolve_source_blob, which reads the blob record from the session DB.
+    The failure test uses no catalog interaction (recipe-not-found is rejected
+    at apply_recipe before any state or catalog access).
+    """
+
+    @pytest.fixture
+    def _seeded(self, tmp_path):
+        """Seed a minimal session DB with one CSV blob.
+
+        Returns (engine, session_id, blob_id) for use in the success test.
+        Pattern matches tests/unit/web/composer/test_recipes.py::TestApplyRecipeEndToEnd._seeded.
+        """
+        from datetime import UTC, datetime
+
+        from sqlalchemy.pool import StaticPool
+
+        from elspeth.web.blobs.service import content_hash as _content_hash
+        from elspeth.web.sessions.engine import create_session_engine
+        from elspeth.web.sessions.models import blobs_table, sessions_table
+        from elspeth.web.sessions.schema import initialize_session_schema
+
+        engine = create_session_engine(
+            "sqlite:///:memory:",
+            poolclass=StaticPool,
+            connect_args={"check_same_thread": False},
+        )
+        initialize_session_schema(engine)
+        session_id = str(uuid4())
+        now = datetime.now(UTC)
+        with engine.begin() as conn:
+            conn.execute(
+                sessions_table.insert().values(
+                    id=session_id,
+                    user_id="test-user",
+                    auth_provider_type="local",
+                    title="Test",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+        blob_id = str(uuid4())
+        storage_dir = tmp_path / "blobs" / session_id
+        storage_dir.mkdir(parents=True)
+        storage_path = storage_dir / f"{blob_id}_data.csv"
+        body = b"text,category\nHello world,greeting\nBye,farewell\n"
+        storage_path.write_bytes(body)
+        with engine.begin() as conn:
+            conn.execute(
+                blobs_table.insert().values(
+                    id=blob_id,
+                    session_id=session_id,
+                    filename="data.csv",
+                    mime_type="text/csv",
+                    size_bytes=len(body),
+                    content_hash=_content_hash(body),
+                    storage_path=str(storage_path),
+                    created_at=now,
+                    created_by="user",
+                    source_description=None,
+                    status="ready",
+                )
+            )
+        return engine, session_id, blob_id
+
+    def _real_catalog(self):
+        """Real PluginManager so set_pipeline's prevalidation sees authentic schemas."""
+        from elspeth.plugins.infrastructure.manager import PluginManager
+        from elspeth.web.catalog.service import CatalogServiceImpl
+
+        pm = PluginManager()
+        pm.register_builtin_plugins()
+        return CatalogServiceImpl(pm)
+
+    def test_apply_recipe_terminates_completed_with_yaml(self, _seeded) -> None:
+        from elspeth.web.composer.guided.recipe_match import RecipeMatch
+        from elspeth.web.composer.guided.state_machine import TerminalKind
+        from elspeth.web.composer.guided.steps import handle_step_2_5_recipe_apply
+
+        engine, session_id, blob_id = _seeded
+        state = _empty_state()
+        catalog = self._real_catalog()
+
+        # Required slots for classify-rows-llm-jsonl per _RECIPE1_SLOTS:
+        # required: source_blob_id, classifier_template, model, api_key_secret
+        # optional with defaults: provider, label_field, required_input_fields, output_path
+        # api_key_secret becomes {secret_ref: NAME} — stripped before validation.
+        match = RecipeMatch(
+            recipe_name="classify-rows-llm-jsonl",
+            slots={
+                "source_blob_id": blob_id,
+                "classifier_template": "Classify the following text: {{ row['text'] }}",
+                "model": "anthropic/claude-3.5-sonnet",
+                "api_key_secret": "OPENROUTER_API_KEY",
+                "required_input_fields": ["text"],
+            },
+        )
+
+        result = handle_step_2_5_recipe_apply(
+            state=state,
+            session=GuidedSession.initial(),
+            match=match,
+            catalog=catalog,
+            session_engine=engine,
+            session_id=session_id,
+        )
+
+        assert result.tool_result.success is True, f"recipe application failed: {getattr(result.tool_result, 'data', result.tool_result)}"
+        assert result.state.source is not None
+        assert len(result.state.outputs) >= 1
+        assert result.session.terminal is not None
+        assert result.session.terminal.kind is TerminalKind.COMPLETED
+        assert result.session.terminal.reason is None
+        assert result.session.terminal.pipeline_yaml is not None
+        assert "source:" in result.session.terminal.pipeline_yaml
+
+    def test_apply_recipe_failure_returns_state_unchanged(self) -> None:
+        from elspeth.web.composer.guided.recipe_match import RecipeMatch
+        from elspeth.web.composer.guided.steps import handle_step_2_5_recipe_apply
+
+        state = _empty_state()
+        result = handle_step_2_5_recipe_apply(
+            state=state,
+            session=GuidedSession.initial(),
+            match=RecipeMatch(
+                recipe_name="this-recipe-does-not-exist",
+                slots={},
+            ),
+            catalog=create_catalog_service(),
+        )
+
+        assert result.tool_result.success is False
+        assert result.state is state
+        assert result.session.terminal is None

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -269,6 +269,7 @@ class TestStep25Handler:
                 "api_key_secret": "OPENROUTER_API_KEY",
                 "required_input_fields": ["text"],
             },
+            unsatisfied_slots={},
         )
 
         result = handle_step_2_5_recipe_apply(
@@ -300,6 +301,7 @@ class TestStep25Handler:
             match=RecipeMatch(
                 recipe_name="this-recipe-does-not-exist",
                 slots={},
+                unsatisfied_slots={},
             ),
             catalog=create_catalog_service(),
         )

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -1,0 +1,77 @@
+"""Integration tests for guided-mode step commit handlers.
+
+These tests use real CompositionState and the real tools.py mutation
+helpers; only the catalog is constructed via the public test seam
+(create_catalog_service()).
+"""
+
+from __future__ import annotations
+
+from elspeth.web.composer.guided.state_machine import (
+    GuidedSession,
+    SourceResolved,
+)
+from elspeth.web.composer.guided.steps import StepHandlerResult, handle_step_1_source
+from elspeth.web.composer.state import CompositionState, PipelineMetadata
+from elspeth.web.dependencies import create_catalog_service
+
+
+def _empty_state() -> CompositionState:
+    """Construct an empty CompositionState per errata C3 (6-arg required ctor)."""
+    return CompositionState(
+        source=None,
+        nodes=(),
+        edges=(),
+        outputs=(),
+        metadata=PipelineMetadata(),
+        version=1,
+    )
+
+
+class TestStep1Handler:
+    def test_commits_source_to_state_on_success(self) -> None:
+        state = _empty_state()
+        session = GuidedSession.initial()
+        catalog = create_catalog_service()
+
+        result = handle_step_1_source(
+            state=state,
+            session=session,
+            resolved=SourceResolved(
+                plugin="csv",
+                options={"path": "data.csv", "schema": {"mode": "observed"}},
+                observed_columns=("a", "b"),
+                sample_rows=({"a": "1", "b": "2"},),
+            ),
+            catalog=catalog,
+        )
+
+        assert isinstance(result, StepHandlerResult)
+        assert result.tool_result.success is True
+        assert result.state.source is not None
+        assert result.state.source.plugin == "csv"
+        assert result.session.step_1_result is not None
+        assert result.session.step_1_result.plugin == "csv"
+        # Session step pointer is NOT advanced here — the dispatcher does that.
+        assert result.session.step == session.step
+
+    def test_returns_failure_unchanged_session_when_plugin_unknown(self) -> None:
+        state = _empty_state()
+        session = GuidedSession.initial()
+        catalog = create_catalog_service()
+
+        result = handle_step_1_source(
+            state=state,
+            session=session,
+            resolved=SourceResolved(
+                plugin="DEFINITELY_NOT_A_REAL_PLUGIN_xyzzy",
+                options={},
+                observed_columns=(),
+                sample_rows=(),
+            ),
+            catalog=catalog,
+        )
+
+        assert result.tool_result.success is False
+        assert result.state is state  # unchanged on failure
+        assert result.session.step_1_result is None

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -7,11 +7,19 @@ helpers; only the catalog is constructed via the public test seam
 
 from __future__ import annotations
 
+import pytest
+
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
+    SinkOutputResolved,
+    SinkResolved,
     SourceResolved,
 )
-from elspeth.web.composer.guided.steps import StepHandlerResult, handle_step_1_source
+from elspeth.web.composer.guided.steps import (
+    StepHandlerResult,
+    handle_step_1_source,
+    handle_step_2_sink,
+)
 from elspeth.web.composer.state import CompositionState, PipelineMetadata
 from elspeth.web.dependencies import create_catalog_service
 
@@ -75,3 +83,84 @@ class TestStep1Handler:
         assert result.tool_result.success is False
         assert result.state is state  # unchanged on failure
         assert result.session.step_1_result is None
+
+
+class TestStep2Handler:
+    def test_commits_outputs_to_state_on_success(self) -> None:
+        # Step 1 sets a CSV source with on_success="main".
+        # Then Step 2 attaches a json output named "main".
+        state = _empty_state()
+        session = GuidedSession.initial()
+        catalog = create_catalog_service()
+
+        step_1 = handle_step_1_source(
+            state=state,
+            session=session,
+            catalog=catalog,
+            resolved=SourceResolved(
+                plugin="csv",
+                options={"path": "x.csv", "schema": {"mode": "observed"}},
+                observed_columns=("a",),
+                sample_rows=({"a": "1"},),
+            ),
+        )
+        assert step_1.tool_result.success is True
+
+        result = handle_step_2_sink(
+            state=step_1.state,
+            session=step_1.session,
+            catalog=catalog,
+            resolved=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        required_fields=("a",),
+                        schema_mode="observed",
+                    ),
+                ),
+            ),
+        )
+
+        assert result.tool_result.success is True
+        assert len(result.state.outputs) == 1
+        assert result.state.outputs[0].plugin == "json"
+        assert result.state.outputs[0].name == "main"
+        assert result.session.step_2_result is not None
+
+    def test_returns_failure_unchanged_when_plugin_unknown(self) -> None:
+        state = _empty_state()
+        catalog = create_catalog_service()
+
+        # _execute_set_output validates plugin-name first, before any source
+        # presence check — so this exercises the failure path on empty state.
+        result = handle_step_2_sink(
+            state=state,
+            session=GuidedSession.initial(),
+            catalog=catalog,
+            resolved=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="DEFINITELY_NOT_A_REAL_PLUGIN_xyzzy",
+                        options={},
+                        required_fields=(),
+                        schema_mode="observed",
+                    ),
+                ),
+            ),
+        )
+
+        assert result.tool_result.success is False
+        assert result.state is state  # identity: unchanged on failure
+        assert result.session.step_2_result is None
+
+    def test_refuses_empty_outputs(self) -> None:
+        catalog = create_catalog_service()
+
+        with pytest.raises(ValueError, match="empty list"):
+            handle_step_2_sink(
+                state=_empty_state(),
+                session=GuidedSession.initial(),
+                resolved=SinkResolved(outputs=()),
+                catalog=catalog,
+            )

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -307,3 +307,119 @@ class TestStep25Handler:
         assert result.tool_result.success is False
         assert result.state is state
         assert result.session.terminal is None
+
+
+class TestStep3Handler:
+    """Tests for handle_step_3_chain_accept.
+
+    The success test composes Step 1 (CSV source) + Step 2 (JSON sink) + Step 3
+    (transform chain) end-to-end to exercise the real _execute_set_pipeline
+    path. Stubs only at the LLM boundary (proposal is constructed in-test).
+
+    Uses `passthrough` as the transform plugin — it is the simplest transform
+    in the catalogue (only `schema` is required) and isolates the wiring
+    contract from plugin-config bookkeeping. The brief's `type_coerce` example
+    had the wrong options shape (`fields` instead of `conversions`) so I
+    switched to `passthrough` to avoid coupling the test to that drift.
+    """
+
+    def test_chain_accepted_commits_and_completes(self) -> None:
+        from elspeth.web.composer.guided.state_machine import (
+            ChainProposal,
+            TerminalKind,
+        )
+        from elspeth.web.composer.guided.steps import handle_step_3_chain_accept
+
+        state = _empty_state()
+        session = GuidedSession.initial()
+        catalog = create_catalog_service()
+
+        step_1 = handle_step_1_source(
+            state=state,
+            session=session,
+            catalog=catalog,
+            resolved=SourceResolved(
+                plugin="csv",
+                options={"path": "x.csv", "schema": {"mode": "observed"}},
+                observed_columns=("price",),
+                sample_rows=({"price": "1.99"},),
+            ),
+        )
+        assert step_1.tool_result.success is True
+
+        step_2 = handle_step_2_sink(
+            state=step_1.state,
+            session=step_1.session,
+            catalog=catalog,
+            resolved=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={"path": "out.jsonl", "schema": {"mode": "observed"}},
+                        required_fields=("price",),
+                        schema_mode="observed",
+                    ),
+                ),
+            ),
+        )
+        assert step_2.tool_result.success is True
+
+        proposal = ChainProposal(
+            steps=(
+                {
+                    "plugin": "passthrough",
+                    "options": {"schema": {"mode": "observed"}},
+                    "rationale": "echo rows; minimal transform for wiring proof",
+                },
+            ),
+            why="single-step chain verifying chain_in→main wiring",
+        )
+
+        result = handle_step_3_chain_accept(
+            state=step_2.state,
+            session=step_2.session,
+            catalog=catalog,
+            proposal=proposal,
+        )
+
+        assert result.tool_result.success is True, f"set_pipeline failed: {getattr(result.tool_result, 'data', result.tool_result)}"
+        assert len(result.state.nodes) == 1
+        assert result.state.nodes[0].plugin == "passthrough"
+        assert result.state.nodes[0].input == "chain_in"
+        assert result.state.nodes[0].on_success == "main"
+        assert result.state.source is not None
+        assert result.state.source.on_success == "chain_in"  # rewired
+        assert result.session.terminal is not None
+        assert result.session.terminal.kind == TerminalKind.COMPLETED
+        assert result.session.terminal.reason is None
+        assert result.session.terminal.pipeline_yaml is not None
+        assert len(result.session.terminal.pipeline_yaml) > 0
+        assert result.session.step_3_proposal is proposal
+
+    def test_refuses_empty_proposal(self) -> None:
+        from elspeth.web.composer.guided.state_machine import ChainProposal
+        from elspeth.web.composer.guided.steps import handle_step_3_chain_accept
+
+        with pytest.raises(ValueError, match="zero steps"):
+            handle_step_3_chain_accept(
+                state=_empty_state(),
+                session=GuidedSession.initial(),
+                catalog=create_catalog_service(),
+                proposal=ChainProposal(steps=(), why="empty"),
+            )
+
+    def test_refuses_when_no_source(self) -> None:
+        from elspeth.web.composer.guided.state_machine import ChainProposal
+        from elspeth.web.composer.guided.steps import handle_step_3_chain_accept
+
+        proposal = ChainProposal(
+            steps=({"plugin": "passthrough", "options": {"schema": {"mode": "observed"}}, "rationale": "x"},),
+            why="x",
+        )
+        with pytest.raises(ValueError, match=r"no.*source|committed source"):
+            handle_step_3_chain_accept(
+                state=_empty_state(),
+                session=GuidedSession.initial(),
+                catalog=create_catalog_service(),
+                proposal=proposal,
+            )

--- a/tests/integration/web/composer/guided/test_step_handlers.py
+++ b/tests/integration/web/composer/guided/test_step_handlers.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 import pytest
 
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
     SinkOutputResolved,
@@ -159,7 +160,7 @@ class TestStep2Handler:
     def test_refuses_empty_outputs(self) -> None:
         catalog = create_catalog_service()
 
-        with pytest.raises(ValueError, match="empty list"):
+        with pytest.raises(InvariantError, match="empty list"):
             handle_step_2_sink(
                 state=_empty_state(),
                 session=GuidedSession.initial(),
@@ -402,7 +403,7 @@ class TestStep3Handler:
         from elspeth.web.composer.guided.state_machine import ChainProposal
         from elspeth.web.composer.guided.steps import handle_step_3_chain_accept
 
-        with pytest.raises(ValueError, match="zero steps"):
+        with pytest.raises(InvariantError, match="zero steps"):
             handle_step_3_chain_accept(
                 state=_empty_state(),
                 session=GuidedSession.initial(),
@@ -418,7 +419,7 @@ class TestStep3Handler:
             steps=({"plugin": "passthrough", "options": {"schema": {"mode": "observed"}}, "rationale": "x"},),
             why="x",
         )
-        with pytest.raises(ValueError, match=r"no.*source|committed source"):
+        with pytest.raises(InvariantError, match=r"no.*source|committed source"):
             handle_step_3_chain_accept(
                 state=_empty_state(),
                 session=GuidedSession.initial(),

--- a/tests/unit/scripts/cicd/test_check_slot_type_cross_language.py
+++ b/tests/unit/scripts/cicd/test_check_slot_type_cross_language.py
@@ -1,0 +1,167 @@
+"""Tests for scripts/cicd/check_slot_type_cross_language.py.
+
+Tests the golden (in-sync) case, drift cases (Python has extras, TS has extras),
+and error cases (malformed TS, missing file). Uses subprocess.run to invoke the
+script in a realistic way so the test exercises the same code path as CI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers for building minimal mock files in tmp_path
+# ---------------------------------------------------------------------------
+
+_PYTHON_TEMPLATE = """\
+from typing import Literal
+
+SlotType = Literal[{members}]
+"""
+
+_TS_TEMPLATE = """\
+export interface RecipeSlotInput {{
+  name: string;
+  slot_type: {ts_union};
+  description: string;
+}}
+"""
+
+
+def _write_python(directory: Path, members: list[str]) -> Path:
+    """Write a minimal recipes.py with a SlotType Literal."""
+    py_dir = directory / "src" / "elspeth" / "web" / "composer"
+    py_dir.mkdir(parents=True, exist_ok=True)
+    # Write __init__.py for the package chain so importlib finds it
+    for parent in [
+        directory / "src",
+        directory / "src" / "elspeth",
+        directory / "src" / "elspeth" / "web",
+        directory / "src" / "elspeth" / "web" / "composer",
+    ]:
+        (parent / "__init__.py").write_text("")
+    member_str = ", ".join(f'"{m}"' for m in members)
+    f = py_dir / "recipes.py"
+    f.write_text(_PYTHON_TEMPLATE.format(members=member_str))
+    return f
+
+
+def _write_ts(directory: Path, members: list[str]) -> Path:
+    """Write a minimal guided.ts with a slot_type field union."""
+    ts_dir = directory / "src" / "elspeth" / "web" / "frontend" / "src" / "types"
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    ts_union = " | ".join(f'"{m}"' for m in members)
+    f = ts_dir / "guided.ts"
+    f.write_text(_TS_TEMPLATE.format(ts_union=ts_union))
+    return f
+
+
+def _run_script(cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run check_slot_type_cross_language.py from a given cwd."""
+    script = Path(__file__).parents[4] / "scripts" / "cicd" / "check_slot_type_cross_language.py"
+    return subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden case: both sets in sync
+# ---------------------------------------------------------------------------
+
+
+class TestGoldenCase:
+    def test_in_sync_exits_0(self, tmp_path: Path) -> None:
+        members = ["blob_id", "str", "float", "int", "str_list"]
+        _write_python(tmp_path, members)
+        _write_ts(tmp_path, members)
+        result = _run_script(tmp_path)
+        assert result.returncode == 0, result.stderr
+
+    def test_in_sync_prints_ok_and_sorted_set(self, tmp_path: Path) -> None:
+        members = ["str", "int", "float"]  # unsorted order
+        _write_python(tmp_path, members)
+        _write_ts(tmp_path, ["float", "int", "str"])  # different order
+        result = _run_script(tmp_path)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+        # Output must be sorted: float < int < str
+        assert "['float', 'int', 'str']" in result.stdout
+
+    def test_real_codebase_is_in_sync(self) -> None:
+        """Smoke-test: run against the actual repo.  Fails if the mirror has drifted."""
+        repo_root = Path(__file__).parents[4]
+        result = _run_script(repo_root)
+        assert result.returncode == 0, "SlotType / guided.ts mirror has drifted in the real codebase!\n" + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Drift case: TypeScript is missing a member Python has
+# ---------------------------------------------------------------------------
+
+
+class TestPythonHasExtra:
+    def test_exits_1(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str", "int", "float", "new_type"])
+        _write_ts(tmp_path, ["str", "int", "float"])
+        result = _run_script(tmp_path)
+        assert result.returncode == 1
+
+    def test_reports_python_only_member(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str", "int", "float", "new_type"])
+        _write_ts(tmp_path, ["str", "int", "float"])
+        result = _run_script(tmp_path)
+        assert "new_type" in result.stderr
+        assert "In Python only" in result.stderr
+
+    def test_prints_both_sets(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str", "new_type"])
+        _write_ts(tmp_path, ["str"])
+        result = _run_script(tmp_path)
+        assert "Python members" in result.stderr
+        assert "TypeScript members" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Drift case: TypeScript has a member Python doesn't
+# ---------------------------------------------------------------------------
+
+
+class TestTSHasExtra:
+    def test_exits_1(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str", "int"])
+        _write_ts(tmp_path, ["str", "int", "ts_only"])
+        result = _run_script(tmp_path)
+        assert result.returncode == 1
+
+    def test_reports_ts_only_member(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str"])
+        _write_ts(tmp_path, ["str", "ts_only"])
+        result = _run_script(tmp_path)
+        assert "ts_only" in result.stderr
+        assert "In TypeScript only" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Error case: missing source files
+# ---------------------------------------------------------------------------
+
+
+class TestMissingFiles:
+    def test_exits_1_when_python_source_missing(self, tmp_path: Path) -> None:
+        _write_ts(tmp_path, ["str"])
+        # Do NOT write Python source — Python path will not exist
+        result = _run_script(tmp_path)
+        assert result.returncode == 1
+        assert "not found" in result.stderr
+
+    def test_exits_1_when_ts_source_missing(self, tmp_path: Path) -> None:
+        _write_python(tmp_path, ["str"])
+        # Do NOT write TS source — TS path will not exist
+        result = _run_script(tmp_path)
+        assert result.returncode == 1
+        assert "not found" in result.stderr

--- a/tests/unit/web/composer/guided/test_audit.py
+++ b/tests/unit/web/composer/guided/test_audit.py
@@ -161,6 +161,7 @@ class TestEmitDroppedToFreeform:
         assert inv.tool_name == "guided_dropped_to_freeform"
         decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
         assert decoded["drop_reason"] == "solver_exhausted"
+        assert decoded["prev_step"] == "step_3_transforms"
         assert decoded["validation_result"] == {"errors": ["..."]}
         assert inv.result_canonical is None
 

--- a/tests/unit/web/composer/guided/test_audit.py
+++ b/tests/unit/web/composer/guided/test_audit.py
@@ -1,0 +1,202 @@
+"""Tests for guided-mode audit emit helpers.
+
+Audit-tier (Tier 1) per CLAUDE.md. Coercion forbidden — every field is
+either present or the function raises.
+
+Per Errata C4: the four event types are recorded as ComposerToolInvocation
+records with a tool_name discriminator, NOT via GuidedAuditEvent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from elspeth.contracts.composer_audit import ComposerToolInvocation
+from elspeth.web.composer.guided.audit import (
+    emit_dropped_to_freeform,
+    emit_step_advanced,
+    emit_turn_answered,
+    emit_turn_emitted,
+)
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
+from elspeth.web.composer.guided.state_machine import TerminalReason
+
+
+class _FakeRecorder:
+    """Captures ComposerToolInvocation records without DB side effects.
+
+    Implements the ComposerToolRecorder protocol structurally (both
+    `record` and `resolve_session`). The `record_llm_call` assertion guard
+    verifies guided events never route through the LLM-call path.
+    """
+
+    def __init__(self) -> None:
+        self.invocations: list[ComposerToolInvocation] = []
+
+    def record(self, invocation: ComposerToolInvocation) -> None:
+        self.invocations.append(invocation)
+
+    def resolve_session(self, session_id: str) -> None:
+        pass  # no-op for in-memory fake; satisfies the Protocol
+
+    def record_llm_call(self, *_: object, **__: object) -> None:
+        raise AssertionError("guided events must not route through record_llm_call")
+
+
+class TestEmitTurnEmitted:
+    def test_records_step_and_type(self) -> None:
+        rec = _FakeRecorder()
+        emit_turn_emitted(
+            rec,
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.SINGLE_SELECT,
+            payload_hash="abc",
+            payload_payload_id="payload-1",
+            emitter="server",
+            composition_version=1,
+            actor="test-actor",
+        )
+        assert len(rec.invocations) == 1
+        inv = rec.invocations[0]
+        assert inv.tool_name == "guided_turn_emitted"
+        decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
+        assert decoded["step_index"] == "step_1_source"
+        assert inv.actor == "test-actor"
+        assert inv.version_before == inv.version_after
+        assert inv.result_canonical is None
+        assert inv.result_hash is None
+
+    def test_invalid_emitter_raises(self) -> None:
+        rec = _FakeRecorder()
+        with pytest.raises(ValueError, match="emitter"):
+            emit_turn_emitted(
+                rec,
+                step=GuidedStep.STEP_1_SOURCE,
+                turn_type=TurnType.SINGLE_SELECT,
+                payload_hash="abc",
+                payload_payload_id="payload-1",
+                emitter="robot",  # invalid
+                composition_version=1,
+                actor="test-actor",
+            )
+        assert len(rec.invocations) == 0  # nothing recorded on validation failure
+
+
+class TestEmitTurnAnswered:
+    def test_records_response_hash(self) -> None:
+        rec = _FakeRecorder()
+        emit_turn_answered(
+            rec,
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.SINGLE_SELECT,
+            response_hash="xyz",
+            response_payload_id="payload-2",
+            control_signal=None,
+            composition_version=2,
+            actor="test-actor",
+        )
+        assert len(rec.invocations) == 1
+        inv = rec.invocations[0]
+        assert inv.tool_name == "guided_turn_answered"
+        decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
+        assert decoded["response_hash"] == "xyz"
+        assert "validation_result" not in decoded  # no spurious keys
+        assert inv.version_before == inv.version_after == 2
+        assert inv.result_canonical is None
+        assert inv.result_hash is None
+
+
+class TestEmitStepAdvanced:
+    def test_records_prev_and_next(self) -> None:
+        rec = _FakeRecorder()
+        emit_step_advanced(
+            rec,
+            prev=GuidedStep.STEP_1_SOURCE,
+            next_=GuidedStep.STEP_2_SINK,
+            reason="user_advanced",
+            composition_version=3,
+            actor="test-actor",
+        )
+        assert len(rec.invocations) == 1
+        inv = rec.invocations[0]
+        assert inv.tool_name == "guided_step_advanced"
+        decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
+        assert decoded["prev_step"] == "step_1_source"
+        assert decoded["next_step"] == "step_2_sink"
+        assert decoded["reason"] == "user_advanced"
+        assert inv.version_before == inv.version_after
+        assert inv.result_canonical is None
+
+    def test_invalid_reason_raises(self) -> None:
+        rec = _FakeRecorder()
+        with pytest.raises(ValueError, match="reason"):
+            emit_step_advanced(
+                rec,
+                prev=GuidedStep.STEP_1_SOURCE,
+                next_=GuidedStep.STEP_2_SINK,
+                reason="teleported",  # invalid
+                composition_version=1,
+                actor="test-actor",
+            )
+        assert len(rec.invocations) == 0
+
+
+class TestEmitDroppedToFreeform:
+    def test_records_drop_reason(self) -> None:
+        rec = _FakeRecorder()
+        emit_dropped_to_freeform(
+            rec,
+            prev=GuidedStep.STEP_3_TRANSFORMS,
+            drop_reason=TerminalReason.SOLVER_EXHAUSTED,
+            validation_result={"errors": ["..."]},
+            composition_version=5,
+            actor="test-actor",
+        )
+        assert len(rec.invocations) == 1
+        inv = rec.invocations[0]
+        assert inv.tool_name == "guided_dropped_to_freeform"
+        decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
+        assert decoded["drop_reason"] == "solver_exhausted"
+        assert decoded["validation_result"] == {"errors": ["..."]}
+        assert inv.result_canonical is None
+
+    def test_user_pressed_exit_has_no_validation_result(self) -> None:
+        rec = _FakeRecorder()
+        emit_dropped_to_freeform(
+            rec,
+            prev=GuidedStep.STEP_2_SINK,
+            drop_reason=TerminalReason.USER_PRESSED_EXIT,
+            validation_result=None,
+            composition_version=1,
+            actor="test-actor",
+        )
+        inv = rec.invocations[0]
+        decoded: dict[str, Any] = json.loads(inv.arguments_canonical)
+        # validation_result must be absent (None means "never sent"), not present-as-null
+        assert "validation_result" not in decoded
+
+
+class TestArgumentsHashInvariant:
+    """Tier-1 audit invariant: arguments_hash == sha256(arguments_canonical)."""
+
+    def test_arguments_hash_matches_canonical(self) -> None:
+        rec = _FakeRecorder()
+        emit_turn_emitted(
+            rec,
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.SINGLE_SELECT,
+            payload_hash="deadbeef",
+            payload_payload_id="payload-99",
+            emitter="llm",
+            composition_version=7,
+            actor="audit-verifier",
+        )
+        inv = rec.invocations[0]
+        # Reproduce the hash independently using only hashlib — no canonical_json import.
+        # This ensures the test doesn't tautologically depend on the same helper.
+        expected_hash = hashlib.sha256(inv.arguments_canonical.encode("utf-8")).hexdigest()
+        assert inv.arguments_hash == expected_hash

--- a/tests/unit/web/composer/guided/test_emitters.py
+++ b/tests/unit/web/composer/guided/test_emitters.py
@@ -1,0 +1,128 @@
+"""Tests for guided-mode turn emitters (Task 10.0 — Gap 6 wire shape).
+
+Existing emitter coverage lives alongside protocol tests (test_protocol.py's
+``TestBuildStep3ProposeChainTurn``); this module specifically pins the
+``build_step_2_5_recipe_offer_turn`` emitter that consumes the new
+``RecipeMatch.unsatisfied_slots`` field and projects each ``SlotSpec`` to the
+``_RecipeSlotInput`` wire shape.
+"""
+
+from __future__ import annotations
+
+from elspeth.web.composer.guided.emitters import build_step_2_5_recipe_offer_turn
+from elspeth.web.composer.guided.protocol import TurnType, validate_payload
+from elspeth.web.composer.guided.recipe_match import RecipeMatch
+from elspeth.web.composer.recipes import SlotSpec
+
+
+class TestBuildStep25RecipeOfferTurn:
+    def test_emits_recipe_offer_type(self) -> None:
+        match = RecipeMatch(
+            recipe_name="classify-rows-llm-jsonl",
+            slots={"source_blob_id": "abc"},
+            unsatisfied_slots={},
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        assert turn["type"] == TurnType.RECIPE_OFFER.value
+        # STEP_2_5_RECIPE_MATCH ordinal in the wizard sequence.
+        assert turn["step_index"] == 2
+
+    def test_payload_carries_recipe_name_slots_alternatives_and_unsatisfied(
+        self,
+    ) -> None:
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={"a": 1},
+            unsatisfied_slots={
+                "x": SlotSpec(slot_type="str", description="hint", required=True),
+            },
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        payload = turn["payload"]
+        assert set(payload.keys()) == {
+            "recipe_name",
+            "slots",
+            "alternatives",
+            "unsatisfied_slots",
+        }
+        assert payload["recipe_name"] == "r"
+        assert payload["slots"] == {"a": 1}
+        assert payload["alternatives"] == ["build_manually"]
+
+    def test_payload_validates_against_recipe_offer_schema(self) -> None:
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={},
+            unsatisfied_slots={
+                "x": SlotSpec(slot_type="str", description="d", required=True),
+            },
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        assert validate_payload(TurnType.RECIPE_OFFER, turn["payload"]) is None
+
+    def test_unsatisfied_slot_entries_carry_name_type_description_required(
+        self,
+    ) -> None:
+        """Each entry is a _RecipeSlotInput TypedDict literal — the four keys
+        the frontend needs to render the editable form."""
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={},
+            unsatisfied_slots={
+                "model": SlotSpec(
+                    slot_type="str",
+                    description="LLM model identifier",
+                    required=True,
+                ),
+            },
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        entries = list(turn["payload"]["unsatisfied_slots"])
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["name"] == "model"
+        assert entry["slot_type"] == "str"
+        assert entry["description"] == "LLM model identifier"
+        assert entry["required"] is True
+
+    def test_unsatisfied_slots_empty_when_resolver_covers_all_required(self) -> None:
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={"source_blob_id": "abc"},
+            unsatisfied_slots={},
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        assert list(turn["payload"]["unsatisfied_slots"]) == []
+
+    def test_unsatisfied_slots_preserves_iteration_order(self) -> None:
+        """Frontend rendering order matters; iteration order of the source
+        mapping is preserved (dict iteration is insertion-ordered in
+        CPython ≥3.7)."""
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={},
+            unsatisfied_slots={
+                "first": SlotSpec(slot_type="str", description="1", required=True),
+                "second": SlotSpec(slot_type="int", description="2", required=True),
+                "third": SlotSpec(slot_type="float", description="3", required=True),
+            },
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        names = [entry["name"] for entry in turn["payload"]["unsatisfied_slots"]]
+        assert names == ["first", "second", "third"]
+
+    def test_unsatisfied_slot_numeric_types_project_to_wire(self) -> None:
+        """slot_type field carries the raw SlotType literal so the frontend
+        can pick the right <input type=...>."""
+        match = RecipeMatch(
+            recipe_name="r",
+            slots={},
+            unsatisfied_slots={
+                "threshold": SlotSpec(slot_type="float", description="d", required=True),
+                "count": SlotSpec(slot_type="int", description="d", required=True),
+            },
+        )
+        turn = build_step_2_5_recipe_offer_turn(match)
+        by_name = {e["name"]: e for e in turn["payload"]["unsatisfied_slots"]}
+        assert by_name["threshold"]["slot_type"] == "float"
+        assert by_name["count"]["slot_type"] == "int"

--- a/tests/unit/web/composer/guided/test_emitters.py
+++ b/tests/unit/web/composer/guided/test_emitters.py
@@ -60,11 +60,16 @@ class TestBuildStep25RecipeOfferTurn:
         turn = build_step_2_5_recipe_offer_turn(match)
         assert validate_payload(TurnType.RECIPE_OFFER, turn["payload"]) is None
 
-    def test_unsatisfied_slot_entries_carry_name_type_description_required(
+    def test_unsatisfied_slot_entries_carry_name_type_description(
         self,
     ) -> None:
-        """Each entry is a _RecipeSlotInput TypedDict literal — the four keys
-        the frontend needs to render the editable form."""
+        """Each entry is a _RecipeSlotInput TypedDict literal — the three keys
+        the frontend needs to render the editable form.
+
+        ``required`` is intentionally absent from the wire shape: the
+        RecipeMatch invariant guarantees every entry is required, so the field
+        would carry only dead information (always True).
+        """
         match = RecipeMatch(
             recipe_name="r",
             slots={},
@@ -83,7 +88,7 @@ class TestBuildStep25RecipeOfferTurn:
         assert entry["name"] == "model"
         assert entry["slot_type"] == "str"
         assert entry["description"] == "LLM model identifier"
-        assert entry["required"] is True
+        assert "required" not in entry
 
     def test_unsatisfied_slots_empty_when_resolver_covers_all_required(self) -> None:
         match = RecipeMatch(

--- a/tests/unit/web/composer/guided/test_mode_transition_prompt.py
+++ b/tests/unit/web/composer/guided/test_mode_transition_prompt.py
@@ -1,6 +1,7 @@
-"""Unit tests for build_mode_transition_system_prompt and _load_freeform_skill.
+"""Unit tests for build_mode_transition_system_prompt.
 
 Phase 5 Task 5.2 — progressive disclosure transition prompt.
+Codex #17 — freeform_skill parameter threading (dependency-inversion fix).
 """
 
 from __future__ import annotations
@@ -8,9 +9,13 @@ from __future__ import annotations
 import pytest
 
 from elspeth.web.composer.guided.prompts import (
-    _load_freeform_skill,
     build_mode_transition_system_prompt,
+    load_guided_skill,
 )
+
+# Sentinel freeform skill used across tests — unique enough to identify as
+# the supplied value without depending on production skill content.
+_SENTINEL_FREEFORM = "SENTINEL_FREEFORM_SKILL_CONTENT_XYZ"
 
 
 class TestBuildModeTransitionSystemPrompt:
@@ -27,7 +32,10 @@ class TestBuildModeTransitionSystemPrompt:
     )
     def test_layered_content_all_reasons(self, reason: str) -> None:
         """Returned prompt contains guided-skill content, LIFTED signal, reason, and freeform content."""
-        result = build_mode_transition_system_prompt(terminal_reason=reason)
+        result = build_mode_transition_system_prompt(
+            terminal_reason=reason,
+            freeform_skill=_SENTINEL_FREEFORM,
+        )
 
         # (a) guided-skill content present (guided_pipeline.md mentions "guided mode")
         assert "guided mode" in result.lower(), "Missing guided-skill content marker"
@@ -38,16 +46,19 @@ class TestBuildModeTransitionSystemPrompt:
         # (c) the terminal reason string present
         assert reason in result, f"Missing reason string: {reason}"
 
-        # (d) freeform-skill content present (pipeline_composer.md contains "Audit Primacy")
-        assert "Audit Primacy" in result, "Missing freeform-skill content marker"
+        # (d) supplied freeform_skill present verbatim
+        assert _SENTINEL_FREEFORM in result, "Missing freeform_skill content in result"
 
     def test_layer_ordering(self) -> None:
         """Guided-skill content appears before transition header, before freeform-skill content."""
-        result = build_mode_transition_system_prompt(terminal_reason="user_pressed_exit")
+        result = build_mode_transition_system_prompt(
+            terminal_reason="user_pressed_exit",
+            freeform_skill=_SENTINEL_FREEFORM,
+        )
 
         guided_pos = result.lower().find("guided mode")
         transition_pos = result.find("## Mode Transition")
-        freeform_pos = result.find("Audit Primacy")
+        freeform_pos = result.find(_SENTINEL_FREEFORM)
 
         assert guided_pos != -1, "guided-skill marker not found"
         assert transition_pos != -1, "transition header not found"
@@ -58,30 +69,43 @@ class TestBuildModeTransitionSystemPrompt:
 
     def test_transition_header_literal(self) -> None:
         """Transition header matches spec §8.2 exactly."""
-        result = build_mode_transition_system_prompt(terminal_reason="solver_exhausted")
+        result = build_mode_transition_system_prompt(
+            terminal_reason="solver_exhausted",
+            freeform_skill=_SENTINEL_FREEFORM,
+        )
 
         assert "## Mode Transition — Guided → Freeform" in result
 
     def test_reason_in_transition_block(self) -> None:
         """The reason appears inside the transition header block (not elsewhere)."""
-        result = build_mode_transition_system_prompt(terminal_reason="completed_pipeline")
+        result = build_mode_transition_system_prompt(
+            terminal_reason="completed_pipeline",
+            freeform_skill=_SENTINEL_FREEFORM,
+        )
 
         assert "reason: completed_pipeline" in result
 
+    def test_freeform_skill_supplied_verbatim(self) -> None:
+        """The freeform_skill argument appears in the output exactly as supplied.
 
-class TestLoadFreeformSkill:
-    def test_is_cached(self) -> None:
-        """Two calls return the same object (lru_cache contract)."""
-        first = _load_freeform_skill()
-        second = _load_freeform_skill()
+        This is the core contract for Codex #17: the caller-supplied (fully
+        processed) freeform skill reaches the returned prompt unchanged —
+        deployment overlay and advisor-strip are the caller's responsibility.
+        """
+        custom_skill = "CUSTOM_DEPLOYMENT_OVERLAY_CONTENT\nadvisor_stripped: true"
+        result = build_mode_transition_system_prompt(
+            terminal_reason="completed_pipeline",
+            freeform_skill=custom_skill,
+        )
 
-        assert first is second
+        assert custom_skill in result
 
-    def test_returns_non_empty_string(self) -> None:
-        content = _load_freeform_skill()
-        assert isinstance(content, str)
-        assert len(content) > 0
+    def test_guided_skill_from_load_guided_skill(self) -> None:
+        """The guided section equals load_guided_skill() exactly."""
+        guided = load_guided_skill()
+        result = build_mode_transition_system_prompt(
+            terminal_reason="completed_pipeline",
+            freeform_skill=_SENTINEL_FREEFORM,
+        )
 
-    def test_contains_audit_primacy_marker(self) -> None:
-        content = _load_freeform_skill()
-        assert "Audit Primacy" in content
+        assert result.startswith(guided), "Guided skill must be the first layer of the returned prompt"

--- a/tests/unit/web/composer/guided/test_mode_transition_prompt.py
+++ b/tests/unit/web/composer/guided/test_mode_transition_prompt.py
@@ -1,0 +1,96 @@
+"""Unit tests for build_mode_transition_system_prompt and _load_freeform_skill.
+
+Phase 5 Task 5.2 — progressive disclosure transition prompt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestBuildModeTransitionSystemPrompt:
+    """Tests for build_mode_transition_system_prompt."""
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "user_pressed_exit",
+            "protocol_violation",
+            "solver_exhausted",
+            "completed_pipeline",
+        ],
+    )
+    def test_layered_content_all_reasons(self, reason: str) -> None:
+        """Returned prompt contains guided-skill content, LIFTED signal, reason, and freeform content."""
+        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+
+        result = build_mode_transition_system_prompt(terminal_reason=reason)
+
+        # (a) guided-skill content present (guided_pipeline.md mentions "guided mode")
+        assert "guided mode" in result.lower(), "Missing guided-skill content marker"
+
+        # (b) rules-lifted signal present (spec §8.2 line 522)
+        assert "LIFTED" in result, "Missing LIFTED signal"
+
+        # (c) the terminal reason string present
+        assert reason in result, f"Missing reason string: {reason}"
+
+        # (d) freeform-skill content present (pipeline_composer.md contains "Audit Primacy")
+        assert "Audit Primacy" in result, "Missing freeform-skill content marker"
+
+    def test_layer_ordering(self) -> None:
+        """Guided-skill content appears before transition header, before freeform-skill content."""
+        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+
+        result = build_mode_transition_system_prompt(terminal_reason="user_pressed_exit")
+
+        guided_pos = result.lower().find("guided mode")
+        transition_pos = result.find("## Mode Transition")
+        freeform_pos = result.find("Audit Primacy")
+
+        assert guided_pos != -1, "guided-skill marker not found"
+        assert transition_pos != -1, "transition header not found"
+        assert freeform_pos != -1, "freeform-skill marker not found"
+
+        assert guided_pos < transition_pos, "Guided content must appear before transition header"
+        assert transition_pos < freeform_pos, "Transition header must appear before freeform content"
+
+    def test_transition_header_literal(self) -> None:
+        """Transition header matches spec §8.2 exactly."""
+        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+
+        result = build_mode_transition_system_prompt(terminal_reason="solver_exhausted")
+
+        assert "## Mode Transition — Guided → Freeform" in result
+
+    def test_reason_in_transition_block(self) -> None:
+        """The reason appears inside the transition header block (not elsewhere)."""
+        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
+
+        result = build_mode_transition_system_prompt(terminal_reason="completed_pipeline")
+
+        assert "reason: completed_pipeline" in result
+
+
+class TestLoadFreeformSkill:
+    def test_is_cached(self) -> None:
+        """Two calls return the same object (lru_cache contract)."""
+        from elspeth.web.composer.guided.prompts import _load_freeform_skill
+
+        first = _load_freeform_skill()
+        second = _load_freeform_skill()
+
+        assert first is second
+
+    def test_returns_non_empty_string(self) -> None:
+        from elspeth.web.composer.guided.prompts import _load_freeform_skill
+
+        content = _load_freeform_skill()
+        assert isinstance(content, str)
+        assert len(content) > 0
+
+    def test_contains_audit_primacy_marker(self) -> None:
+        from elspeth.web.composer.guided.prompts import _load_freeform_skill
+
+        content = _load_freeform_skill()
+        assert "Audit Primacy" in content

--- a/tests/unit/web/composer/guided/test_mode_transition_prompt.py
+++ b/tests/unit/web/composer/guided/test_mode_transition_prompt.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 
 import pytest
 
+from elspeth.web.composer.guided.prompts import (
+    _load_freeform_skill,
+    build_mode_transition_system_prompt,
+)
+
 
 class TestBuildModeTransitionSystemPrompt:
     """Tests for build_mode_transition_system_prompt."""
@@ -22,8 +27,6 @@ class TestBuildModeTransitionSystemPrompt:
     )
     def test_layered_content_all_reasons(self, reason: str) -> None:
         """Returned prompt contains guided-skill content, LIFTED signal, reason, and freeform content."""
-        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
-
         result = build_mode_transition_system_prompt(terminal_reason=reason)
 
         # (a) guided-skill content present (guided_pipeline.md mentions "guided mode")
@@ -40,8 +43,6 @@ class TestBuildModeTransitionSystemPrompt:
 
     def test_layer_ordering(self) -> None:
         """Guided-skill content appears before transition header, before freeform-skill content."""
-        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
-
         result = build_mode_transition_system_prompt(terminal_reason="user_pressed_exit")
 
         guided_pos = result.lower().find("guided mode")
@@ -57,16 +58,12 @@ class TestBuildModeTransitionSystemPrompt:
 
     def test_transition_header_literal(self) -> None:
         """Transition header matches spec §8.2 exactly."""
-        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
-
         result = build_mode_transition_system_prompt(terminal_reason="solver_exhausted")
 
         assert "## Mode Transition — Guided → Freeform" in result
 
     def test_reason_in_transition_block(self) -> None:
         """The reason appears inside the transition header block (not elsewhere)."""
-        from elspeth.web.composer.guided.prompts import build_mode_transition_system_prompt
-
         result = build_mode_transition_system_prompt(terminal_reason="completed_pipeline")
 
         assert "reason: completed_pipeline" in result
@@ -75,22 +72,16 @@ class TestBuildModeTransitionSystemPrompt:
 class TestLoadFreeformSkill:
     def test_is_cached(self) -> None:
         """Two calls return the same object (lru_cache contract)."""
-        from elspeth.web.composer.guided.prompts import _load_freeform_skill
-
         first = _load_freeform_skill()
         second = _load_freeform_skill()
 
         assert first is second
 
     def test_returns_non_empty_string(self) -> None:
-        from elspeth.web.composer.guided.prompts import _load_freeform_skill
-
         content = _load_freeform_skill()
         assert isinstance(content, str)
         assert len(content) > 0
 
     def test_contains_audit_primacy_marker(self) -> None:
-        from elspeth.web.composer.guided.prompts import _load_freeform_skill
-
         content = _load_freeform_skill()
         assert "Audit Primacy" in content

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -186,3 +186,60 @@ class TestPayloadValidation:
 
         with pytest.raises(ValueError):
             validate_payload("not_a_turn_type", {})  # type: ignore[arg-type]
+
+
+class TestBuildStep3ProposeChainTurn:
+    """Tests for the propose_chain emitter (Task 4.5)."""
+
+    def test_emits_propose_chain_with_step_index_3(self) -> None:
+        from elspeth.web.composer.guided.emitters import build_step_3_propose_chain_turn
+        from elspeth.web.composer.guided.state_machine import ChainProposal
+
+        proposal = ChainProposal(
+            steps=(
+                {
+                    "plugin": "passthrough",
+                    "options": {"schema": {"mode": "observed"}},
+                    "rationale": "no-op chain",
+                },
+            ),
+            why="rows already conform",
+        )
+
+        turn = build_step_3_propose_chain_turn(proposal)
+
+        assert turn["type"] == TurnType.PROPOSE_CHAIN.value
+        # STEP_3_TRANSFORMS is the 4th step (0-based index 3).
+        assert turn["step_index"] == 3
+
+    def test_payload_carries_steps_why_and_empty_blockers(self) -> None:
+        from elspeth.web.composer.guided.emitters import build_step_3_propose_chain_turn
+        from elspeth.web.composer.guided.state_machine import ChainProposal
+
+        proposal = ChainProposal(
+            steps=({"plugin": "passthrough", "options": {"schema": {"mode": "observed"}}, "rationale": "r"},),
+            why="why-text",
+        )
+
+        turn = build_step_3_propose_chain_turn(proposal)
+        payload = turn["payload"]
+
+        assert set(payload.keys()) == {"steps", "why", "blockers"}
+        assert payload["why"] == "why-text"
+        # MVP-scope decision: blockers is always [] for server-emitted
+        # propose_chain — solve_chain raises rather than returning a
+        # partial proposal with blockers populated.
+        assert payload["blockers"] == []
+        assert payload["steps"][0]["plugin"] == "passthrough"
+
+    def test_payload_validates_against_propose_chain_schema(self) -> None:
+        from elspeth.web.composer.guided.emitters import build_step_3_propose_chain_turn
+        from elspeth.web.composer.guided.protocol import validate_payload
+        from elspeth.web.composer.guided.state_machine import ChainProposal
+
+        proposal = ChainProposal(
+            steps=({"plugin": "passthrough", "options": {"schema": {"mode": "observed"}}, "rationale": "r"},),
+            why="ok",
+        )
+        turn = build_step_3_propose_chain_turn(proposal)
+        assert validate_payload(TurnType.PROPOSE_CHAIN, turn["payload"]) is None

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -231,6 +231,142 @@ class TestPayloadValidation:
         with pytest.raises(ValueError):
             validate_payload("not_a_turn_type", {})  # type: ignore[arg-type]
 
+    # ---------------------------------------------------------------------------
+    # Recursive nested-shape validation (S4 uplift)
+    # ---------------------------------------------------------------------------
+
+    def test_inspect_and_confirm_golden_validates(self) -> None:
+        """Full valid INSPECT_AND_CONFIRM payload passes recursively."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.INSPECT_AND_CONFIRM,
+            {"observed": {"columns": ["a", "b"], "samples": [{"a": 1}], "warnings": []}},
+        )
+        assert err is None
+
+    def test_inspect_and_confirm_missing_nested_key(self) -> None:
+        """``observed`` present but missing ``columns`` — error path-rooted."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.INSPECT_AND_CONFIRM,
+            {"observed": {"samples": [], "warnings": []}},  # missing "columns"
+        )
+        assert err is not None
+        # Path-rooted: must mention "payload.observed"
+        assert "payload.observed" in err
+        assert "columns" in err
+
+    def test_inspect_and_confirm_observed_not_mapping(self) -> None:
+        """``observed`` is a scalar, not a Mapping — type error is path-rooted."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.INSPECT_AND_CONFIRM,
+            {"observed": "not-a-mapping"},
+        )
+        assert err is not None
+        assert "payload.observed" in err
+        assert "mapping" in err
+
+    def test_recipe_offer_golden_validates(self) -> None:
+        """Full valid RECIPE_OFFER payload with unsatisfied slots passes."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {
+                "recipe_name": "r",
+                "slots": {},
+                "alternatives": [],
+                "unsatisfied_slots": [
+                    {"name": "x", "slot_type": "str", "description": "hint"},
+                ],
+            },
+        )
+        assert err is None
+
+    def test_recipe_offer_empty_unsatisfied_slots_valid(self) -> None:
+        """Empty unsatisfied_slots list is valid (resolver covered all required slots)."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {
+                "recipe_name": "r",
+                "slots": {"x": 1},
+                "alternatives": [],
+                "unsatisfied_slots": [],
+            },
+        )
+        assert err is None
+
+    def test_recipe_offer_unsatisfied_slot_missing_key(self) -> None:
+        """An unsatisfied slot entry missing ``slot_type`` — path-rooted error."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {
+                "recipe_name": "r",
+                "slots": {},
+                "alternatives": [],
+                "unsatisfied_slots": [
+                    {"name": "x", "description": "d"},  # missing "slot_type"
+                ],
+            },
+        )
+        assert err is not None
+        # Path-rooted: "payload.unsatisfied_slots[0] missing required keys: ..."
+        assert "payload.unsatisfied_slots[0]" in err
+        assert "slot_type" in err
+
+    def test_recipe_offer_unsatisfied_slots_not_sequence(self) -> None:
+        """``unsatisfied_slots`` is a Mapping, not a Sequence — type error is path-rooted."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {
+                "recipe_name": "r",
+                "slots": {},
+                "alternatives": [],
+                "unsatisfied_slots": {"name": "x"},  # Mapping instead of Sequence
+            },
+        )
+        assert err is not None
+        assert "payload.unsatisfied_slots" in err
+        assert "sequence" in err
+
+    def test_recipe_offer_unsatisfied_slot_not_mapping(self) -> None:
+        """An unsatisfied slot entry is a string, not a Mapping — type error is path-rooted."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {
+                "recipe_name": "r",
+                "slots": {},
+                "alternatives": [],
+                "unsatisfied_slots": ["not-a-mapping"],
+            },
+        )
+        assert err is not None
+        assert "payload.unsatisfied_slots[0]" in err
+        assert "mapping" in err
+
+    def test_top_level_missing_key_error_takes_priority(self) -> None:
+        """Missing top-level key is reported before nested checks run."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        # "observed" is missing entirely — nested check cannot run.
+        err = validate_payload(TurnType.INSPECT_AND_CONFIRM, {})
+        assert err is not None
+        assert "observed" in err
+        # Path-rooted nested error should NOT appear when top-level is missing.
+        assert "payload.observed" not in err
+
 
 class TestBuildStep3ProposeChainTurn:
     """Tests for the propose_chain emitter (Task 4.5)."""

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -87,7 +87,11 @@ class TestPayloadShapes:
         assert payload["recipe_name"] == "classify-rows-llm-jsonl"
 
     def test_recipe_offer_payload_with_unsatisfied_slots(self) -> None:
-        """unsatisfied_slots carries the editable schema for unfilled required slots."""
+        """unsatisfied_slots carries the editable schema for unfilled required slots.
+
+        ``required`` is intentionally absent from the wire shape: the
+        RecipeMatch invariant guarantees every entry is required.
+        """
         from elspeth.web.composer.guided.protocol import validate_payload
 
         payload: RecipeOfferPayload = {
@@ -99,13 +103,11 @@ class TestPayloadShapes:
                     "name": "classifier_template",
                     "slot_type": "str",
                     "description": "Jinja2 template",
-                    "required": True,
                 },
                 {
                     "name": "model",
                     "slot_type": "str",
                     "description": "LLM model identifier",
-                    "required": True,
                 },
             ],
         }

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -1,0 +1,81 @@
+"""Tests for guided-mode protocol types."""
+
+from __future__ import annotations
+
+from elspeth.web.composer.guided.protocol import (
+    InspectAndConfirmPayload,
+    MultiSelectWithCustomPayload,
+    ProposeChainPayload,
+    RecipeOfferPayload,
+    SchemaFormPayload,
+    SingleSelectPayload,
+    TurnType,
+)
+
+
+class TestTurnType:
+    def test_six_turn_types_defined(self) -> None:
+        expected = {
+            "inspect_and_confirm",
+            "single_select",
+            "multi_select_with_custom",
+            "schema_form",
+            "propose_chain",
+            "recipe_offer",
+        }
+        assert {t.value for t in TurnType} == expected
+
+    def test_turn_type_is_str_enum(self) -> None:
+        assert TurnType.SINGLE_SELECT.value == "single_select"
+        assert TurnType("single_select") is TurnType.SINGLE_SELECT
+
+
+class TestPayloadShapes:
+    def test_inspect_and_confirm_payload_required_keys(self) -> None:
+        payload: InspectAndConfirmPayload = {
+            "observed": {"columns": ["a", "b"], "samples": [{"a": 1}], "warnings": []},
+        }
+        assert payload["observed"]["columns"] == ["a", "b"]
+
+    def test_single_select_payload(self) -> None:
+        payload: SingleSelectPayload = {
+            "question": "Pick one",
+            "options": [{"id": "a", "label": "A", "hint": None}],
+            "allow_custom": False,
+        }
+        assert payload["allow_custom"] is False
+
+    def test_multi_select_payload(self) -> None:
+        payload: MultiSelectWithCustomPayload = {
+            "question": "Pick many",
+            "options": [{"id": "a", "label": "A", "hint": None}],
+            "default_chosen": ["a"],
+            "escape_label": "Or: let source decide",
+        }
+        assert payload["escape_label"] == "Or: let source decide"
+
+    def test_schema_form_payload(self) -> None:
+        payload: SchemaFormPayload = {
+            "plugin": "csv",
+            "schema_block": {"path": {"type": "string"}},
+            "prefilled": {},
+        }
+        assert payload["plugin"] == "csv"
+
+    def test_propose_chain_payload(self) -> None:
+        payload: ProposeChainPayload = {
+            "steps": [
+                {"plugin": "type_coerce", "options": {}, "rationale": "needed for gate"},
+            ],
+            "why": "bridge str to float",
+            "blockers": [],
+        }
+        assert len(payload["steps"]) == 1
+
+    def test_recipe_offer_payload(self) -> None:
+        payload: RecipeOfferPayload = {
+            "recipe_name": "classify-rows-llm-jsonl",
+            "slots": {},
+            "alternatives": [],
+        }
+        assert payload["recipe_name"] == "classify-rows-llm-jsonl"

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -156,9 +156,13 @@ class TestTurnResponse:
             "custom_inputs": None,
             "accepted_step_index": None,
             "edit_step_index": None,
-            "control_signal": ControlSignal.EXIT_TO_FREEFORM.value,
+            "control_signal": ControlSignal.EXIT_TO_FREEFORM,
         }
-        assert resp["control_signal"] == "exit_to_freeform"
+        assert resp["control_signal"] is ControlSignal.EXIT_TO_FREEFORM
+        # StrEnum members serialize as their .value for canonical-JSON / wire
+        # purposes — document the equivalence so the round-trip contract is
+        # captured in test code.
+        assert ControlSignal.EXIT_TO_FREEFORM.value == "exit_to_freeform"
 
 
 class TestTurn:

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from elspeth.web.composer.guided.protocol import (
+    ControlSignal,
     InspectAndConfirmPayload,
     MultiSelectWithCustomPayload,
     ProposeChainPayload,
     RecipeOfferPayload,
     SchemaFormPayload,
     SingleSelectPayload,
+    Turn,
+    TurnResponse,
     TurnType,
 )
 
@@ -79,3 +82,49 @@ class TestPayloadShapes:
             "alternatives": [],
         }
         assert payload["recipe_name"] == "classify-rows-llm-jsonl"
+
+
+class TestTurnResponse:
+    def test_control_signal_values(self) -> None:
+        assert {s.value for s in ControlSignal} == {
+            "exit_to_freeform",
+            "request_advisor",
+            "reject",
+        }
+
+    def test_turn_response_minimal(self) -> None:
+        resp: TurnResponse = {
+            "chosen": ["jsonl"],
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        assert resp["chosen"] == ["jsonl"]
+
+    def test_turn_response_with_control_signal(self) -> None:
+        resp: TurnResponse = {
+            "chosen": None,
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": ControlSignal.EXIT_TO_FREEFORM.value,
+        }
+        assert resp["control_signal"] == "exit_to_freeform"
+
+
+class TestTurn:
+    def test_turn_carries_type_and_payload(self) -> None:
+        turn: Turn = {
+            "type": "single_select",
+            "step_index": 1,
+            "payload": {
+                "question": "X?",
+                "options": [],
+                "allow_custom": False,
+            },
+        }
+        assert turn["type"] == "single_select"
+        assert turn["step_index"] == 1

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from elspeth.web.composer.guided.protocol import (
     ControlSignal,
     InspectAndConfirmPayload,
@@ -128,3 +130,59 @@ class TestTurn:
         }
         assert turn["type"] == "single_select"
         assert turn["step_index"] == 1
+
+
+class TestLegalTurnMatrix:
+    def test_step_1_legal_types(self) -> None:
+        from elspeth.web.composer.guided.protocol import GuidedStep, legal_turn_types_for
+
+        legal = legal_turn_types_for(GuidedStep.STEP_1_SOURCE)
+        assert TurnType.INSPECT_AND_CONFIRM in legal
+        assert TurnType.SINGLE_SELECT in legal
+        assert TurnType.SCHEMA_FORM in legal
+        assert TurnType.PROPOSE_CHAIN not in legal
+
+    def test_step_2_legal_types(self) -> None:
+        from elspeth.web.composer.guided.protocol import GuidedStep, legal_turn_types_for
+
+        legal = legal_turn_types_for(GuidedStep.STEP_2_SINK)
+        assert TurnType.SINGLE_SELECT in legal
+        assert TurnType.MULTI_SELECT_WITH_CUSTOM in legal
+        assert TurnType.SCHEMA_FORM in legal
+
+    def test_step_2_5_recipe_offer_only(self) -> None:
+        from elspeth.web.composer.guided.protocol import GuidedStep, legal_turn_types_for
+
+        legal = legal_turn_types_for(GuidedStep.STEP_2_5_RECIPE_MATCH)
+        assert legal == frozenset({TurnType.RECIPE_OFFER})
+
+    def test_step_3_legal_types(self) -> None:
+        from elspeth.web.composer.guided.protocol import GuidedStep, legal_turn_types_for
+
+        legal = legal_turn_types_for(GuidedStep.STEP_3_TRANSFORMS)
+        assert TurnType.PROPOSE_CHAIN in legal
+        assert TurnType.SINGLE_SELECT in legal
+
+
+class TestPayloadValidation:
+    def test_validate_single_select_ok(self) -> None:
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        ok = validate_payload(
+            TurnType.SINGLE_SELECT,
+            {"question": "Q?", "options": [], "allow_custom": False},
+        )
+        assert ok is None
+
+    def test_validate_single_select_missing_field(self) -> None:
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(TurnType.SINGLE_SELECT, {"question": "Q?"})
+        assert err is not None
+        assert "options" in err
+
+    def test_validate_unknown_turn_type_rejected(self) -> None:
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        with pytest.raises(ValueError):
+            validate_payload("not_a_turn_type", {})  # type: ignore[arg-type]

--- a/tests/unit/web/composer/guided/test_protocol.py
+++ b/tests/unit/web/composer/guided/test_protocol.py
@@ -82,8 +82,50 @@ class TestPayloadShapes:
             "recipe_name": "classify-rows-llm-jsonl",
             "slots": {},
             "alternatives": [],
+            "unsatisfied_slots": [],
         }
         assert payload["recipe_name"] == "classify-rows-llm-jsonl"
+
+    def test_recipe_offer_payload_with_unsatisfied_slots(self) -> None:
+        """unsatisfied_slots carries the editable schema for unfilled required slots."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        payload: RecipeOfferPayload = {
+            "recipe_name": "classify-rows-llm-jsonl",
+            "slots": {"source_blob_id": "abc-uuid", "output_path": "out.jsonl"},
+            "alternatives": ["build_manually"],
+            "unsatisfied_slots": [
+                {
+                    "name": "classifier_template",
+                    "slot_type": "str",
+                    "description": "Jinja2 template",
+                    "required": True,
+                },
+                {
+                    "name": "model",
+                    "slot_type": "str",
+                    "description": "LLM model identifier",
+                    "required": True,
+                },
+            ],
+        }
+        assert validate_payload(TurnType.RECIPE_OFFER, payload) is None
+        assert payload["unsatisfied_slots"][0]["name"] == "classifier_template"
+
+    def test_recipe_offer_payload_missing_unsatisfied_slots_rejected(self) -> None:
+        """A payload missing the new required key surfaces a validation error."""
+        from elspeth.web.composer.guided.protocol import validate_payload
+
+        err = validate_payload(
+            TurnType.RECIPE_OFFER,
+            {  # type: ignore[arg-type]
+                "recipe_name": "x",
+                "slots": {},
+                "alternatives": [],
+            },
+        )
+        assert err is not None
+        assert "unsatisfied_slots" in err
 
 
 class TestTurnResponse:

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.recipe_match import RecipeMatch, match_recipe
 from elspeth.web.composer.guided.state_machine import (
     SinkOutputResolved,
@@ -285,7 +286,7 @@ class TestMissingBlobRef:
             sample_rows=(),
         )
         sink = _make_single_json_sink(required_fields=("category",))
-        with pytest.raises(ValueError, match="blob_ref"):
+        with pytest.raises(InvariantError, match="blob_ref"):
             match_recipe(source, sink)
 
     def test_threshold_raises_when_blob_ref_absent(self) -> None:
@@ -297,7 +298,7 @@ class TestMissingBlobRef:
             sample_rows=(),
         )
         sink = _make_two_json_sink()
-        with pytest.raises(ValueError, match="blob_ref"):
+        with pytest.raises(InvariantError, match="blob_ref"):
             match_recipe(source, sink)
 
 
@@ -390,10 +391,11 @@ class TestUnsatisfiedSlots:
     def test_rejects_slot_overlapping_with_unsatisfied(self) -> None:
         """A name present in both ``slots`` and ``unsatisfied_slots`` is a
         direct contradiction of the invariant: a slot cannot simultaneously
-        be resolved and unsatisfied.  Constructor must raise ValueError."""
+        be resolved and unsatisfied.  Constructor must raise InvariantError
+        (server bug — only our own code constructs RecipeMatch)."""
         from elspeth.web.composer.recipes import SlotSpec
 
-        with pytest.raises(ValueError, match="overlap") as exc_info:
+        with pytest.raises(InvariantError, match="overlap") as exc_info:
             RecipeMatch(
                 recipe_name="test-recipe",
                 slots={"foo": "resolved-value"},
@@ -409,10 +411,11 @@ class TestUnsatisfiedSlots:
         """``unsatisfied_slots`` is the schema for *required* slots the resolver
         could not pre-fill.  Optional slots have declared defaults and are
         auto-filled by ``validate_slots`` at apply time — surfacing them to
-        the operator is a contract violation.  Constructor must raise."""
+        the operator is a contract violation.  Constructor must raise
+        InvariantError (server bug — only our own code constructs RecipeMatch)."""
         from elspeth.web.composer.recipes import SlotSpec
 
-        with pytest.raises(ValueError, match="optional") as exc_info:
+        with pytest.raises(InvariantError, match="optional") as exc_info:
             RecipeMatch(
                 recipe_name="test-recipe",
                 slots={},

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -1,0 +1,273 @@
+# tests/unit/web/composer/guided/test_recipe_match.py
+"""Tests for match_recipe() — deterministic recipe matcher (topology-only)."""
+
+from __future__ import annotations
+
+import pytest
+
+from elspeth.web.composer.guided.recipe_match import RecipeMatch, match_recipe
+from elspeth.web.composer.guided.state_machine import (
+    SinkOutputResolved,
+    SinkResolved,
+    SourceResolved,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_csv_source(blob_id: str = "blob-123") -> SourceResolved:
+    """Return a minimal CSV SourceResolved with a blob_id in options."""
+    return SourceResolved(
+        plugin="csv",
+        options={"blob_id": blob_id},
+        observed_columns=("id", "text"),
+        sample_rows=({"id": "1", "text": "hello"},),
+    )
+
+
+def _make_json_output(
+    required_fields: tuple[str, ...] = (),
+    path: str = "outputs/out.jsonl",
+) -> SinkOutputResolved:
+    return SinkOutputResolved(
+        plugin="json",
+        options={"path": path, "format": "jsonl"},
+        required_fields=required_fields,
+        schema_mode="observed",
+    )
+
+
+def _make_single_json_sink(
+    required_fields: tuple[str, ...] = (),
+    path: str = "outputs/classified.jsonl",
+) -> SinkResolved:
+    return SinkResolved(outputs=(_make_json_output(required_fields, path),))
+
+
+def _make_two_json_sink(
+    above_path: str = "outputs/above.jsonl",
+    below_path: str = "outputs/below.jsonl",
+) -> SinkResolved:
+    return SinkResolved(
+        outputs=(
+            _make_json_output(("amount",), above_path),
+            _make_json_output(("amount",), below_path),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# RecipeMatch dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeMatch:
+    def test_recipe_match_slots_are_frozen(self) -> None:
+        match = RecipeMatch(
+            recipe_name="test-recipe",
+            slots={"source_blob_id": "blob-abc"},
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            match.slots["source_blob_id"] = "mutated"  # type: ignore[index]
+
+    def test_recipe_match_name_is_frozen(self) -> None:
+        match = RecipeMatch(recipe_name="test-recipe", slots={})
+        with pytest.raises(AttributeError):
+            match.recipe_name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Classify-rows-llm-jsonl matching
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyRecipeMatch:
+    def test_csv_to_json_with_llm_intent_matches(self) -> None:
+        """CSV + single JSON output with a classifier keyword → classify recipe."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("category",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.recipe_name == "classify-rows-llm-jsonl"
+        # C8 slot-name verification
+        assert "source_blob_id" in match.slots
+        assert "label_field" in match.slots
+
+    def test_classify_slot_label_field_uses_keyword_match(self) -> None:
+        """label_field is the keyword-matching field, not necessarily [0]."""
+        source = _make_csv_source(blob_id="blob-xyz")
+        sink = _make_single_json_sink(required_fields=("record_id", "label"))
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["label_field"] == "label"
+
+    def test_classify_slot_source_blob_id_populated_from_options(self) -> None:
+        source = _make_csv_source(blob_id="test-blob-456")
+        sink = _make_single_json_sink(required_fields=("tag",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["source_blob_id"] == "test-blob-456"
+
+    def test_classify_slot_output_path_from_sink_options(self) -> None:
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("classification",), path="my/custom.jsonl")
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["output_path"] == "my/custom.jsonl"
+
+    def test_classify_slot_output_path_default_when_absent(self) -> None:
+        """When the sink output has no 'path' option, the default applies."""
+        source = _make_csv_source()
+        output = SinkOutputResolved(
+            plugin="json",
+            options={},  # no path key
+            required_fields=("category",),
+            schema_mode="observed",
+        )
+        sink = SinkResolved(outputs=(output,))
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["output_path"] == "outputs/classified.jsonl"
+
+    def test_classify_does_not_match_without_keyword_field(self) -> None:
+        """CSV + single JSON output WITHOUT classifier keywords → no classify match."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("record_id", "score"))
+        match = match_recipe(source, sink)
+        # No recipe matches (threshold needs two outputs, classify needs keyword).
+        assert match is None
+
+    def test_classify_does_not_match_non_csv_source(self) -> None:
+        """Non-CSV source → classify does not match even with keyword field."""
+        source = SourceResolved(
+            plugin="api",
+            options={},
+            observed_columns=("label",),
+            sample_rows=(),
+        )
+        sink = _make_single_json_sink(required_fields=("label",))
+        match = match_recipe(source, sink)
+        assert match is None
+
+    def test_classify_does_not_match_non_json_sink(self) -> None:
+        """CSV + non-JSON single output → no match."""
+        source = _make_csv_source()
+        output = SinkOutputResolved(
+            plugin="csv",
+            options={"path": "out.csv"},
+            required_fields=("category",),
+            schema_mode="observed",
+        )
+        sink = SinkResolved(outputs=(output,))
+        match = match_recipe(source, sink)
+        assert match is None
+
+
+# ---------------------------------------------------------------------------
+# Split-by-numeric-threshold matching
+# ---------------------------------------------------------------------------
+
+
+class TestSplitThresholdRecipeMatch:
+    def test_csv_to_two_json_outputs_matches_threshold(self) -> None:
+        """CSV + two JSON outputs → split-by-numeric-threshold."""
+        source = _make_csv_source()
+        sink = _make_two_json_sink()
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.recipe_name == "split-by-numeric-threshold"
+
+    def test_split_threshold_slots_use_correct_names(self) -> None:
+        """Slot map keys must match _RECIPE2_SLOTS declarations (C8 verification)."""
+        source = _make_csv_source(blob_id="blob-789")
+        sink = _make_two_json_sink(above_path="my/above.jsonl", below_path="my/below.jsonl")
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.recipe_name == "split-by-numeric-threshold"
+        assert set(match.slots.keys()) >= {
+            "source_blob_id",
+            "above_output_path",
+            "below_output_path",
+        }
+        assert match.slots["source_blob_id"] == "blob-789"
+        assert match.slots["above_output_path"] == "my/above.jsonl"
+        assert match.slots["below_output_path"] == "my/below.jsonl"
+
+    def test_threshold_does_not_match_single_output(self) -> None:
+        """Single JSON output → threshold does not match (needs two)."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("amount",))
+        match = match_recipe(source, sink)
+        # No keyword fields → classify also misses; net result: None.
+        assert match is None
+
+    def test_threshold_does_not_match_non_csv_source(self) -> None:
+        source = SourceResolved(
+            plugin="database",
+            options={},
+            observed_columns=("value",),
+            sample_rows=(),
+        )
+        sink = _make_two_json_sink()
+        match = match_recipe(source, sink)
+        assert match is None
+
+
+# ---------------------------------------------------------------------------
+# No-match cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatch:
+    def test_no_match_returns_none(self) -> None:
+        """Sink with three outputs → no registered recipe matches."""
+        source = _make_csv_source()
+        sink = SinkResolved(
+            outputs=(
+                _make_json_output((), "a.jsonl"),
+                _make_json_output((), "b.jsonl"),
+                _make_json_output((), "c.jsonl"),
+            )
+        )
+        match = match_recipe(source, sink)
+        assert match is None
+
+    def test_empty_sink_outputs_returns_none(self) -> None:
+        source = _make_csv_source()
+        sink = SinkResolved(outputs=())
+        match = match_recipe(source, sink)
+        assert match is None
+
+
+# ---------------------------------------------------------------------------
+# Source blob_id missing from options (boundary coercion)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingBlobId:
+    def test_classify_source_blob_id_empty_when_options_has_no_blob_id(self) -> None:
+        """source.options without blob_id → source_blob_id is empty string."""
+        source = SourceResolved(
+            plugin="csv",
+            options={},  # no blob_id
+            observed_columns=("text",),
+            sample_rows=(),
+        )
+        sink = _make_single_json_sink(required_fields=("category",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["source_blob_id"] == ""
+
+    def test_threshold_source_blob_id_empty_when_options_has_no_blob_id(self) -> None:
+        source = SourceResolved(
+            plugin="csv",
+            options={},  # no blob_id
+            observed_columns=("amount",),
+            sample_rows=(),
+        )
+        sink = _make_two_json_sink()
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.slots["source_blob_id"] == ""

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 import pytest
 
 from elspeth.web.composer.guided.errors import InvariantError
-from elspeth.web.composer.guided.recipe_match import RecipeMatch, match_recipe
+from elspeth.web.composer.guided.recipe_match import (
+    RecipeMatch,
+    _classify_slot_resolver,
+    _split_threshold_slot_resolver,
+    match_recipe,
+)
 from elspeth.web.composer.guided.state_machine import (
     SinkOutputResolved,
     SinkResolved,
@@ -28,6 +33,21 @@ def _make_csv_source(blob_ref: str = "a1b2c3d4-0000-0000-0000-000000000001") -> 
     return SourceResolved(
         plugin="csv",
         options={"blob_ref": blob_ref},
+        observed_columns=("id", "text"),
+        sample_rows=({"id": "1", "text": "hello"},),
+    )
+
+
+def _make_csv_source_no_blob() -> SourceResolved:
+    """Return a minimal CSV SourceResolved WITHOUT blob_ref in options.
+
+    Models the legitimate case of a CSV source configured via SchemaForm with
+    a direct file path and no blob upload.  Neither recipe predicate should
+    match this source; ``match_recipe`` must return None.
+    """
+    return SourceResolved(
+        plugin="csv",
+        options={"path": "/data/my_file.csv"},
         observed_columns=("id", "text"),
         sample_rows=({"id": "1", "text": "hello"},),
     )
@@ -265,41 +285,80 @@ class TestNoMatch:
 
 
 # ---------------------------------------------------------------------------
-# Source blob_ref missing from options (invariant violation — offensive crash)
+# CSV source without blob_ref: predicate returns False → no recipe match
 # ---------------------------------------------------------------------------
 
 
-class TestMissingBlobRef:
-    def test_classify_raises_when_blob_ref_absent(self) -> None:
-        """source.options without blob_ref → ValueError (state-machine invariant).
+class TestCsvNoBlobRef:
+    """CSV sources without a blob_ref (direct file-path configuration) are
+    legitimate user configurations.  Both predicates gate on blob_ref presence
+    before returning True, so ``match_recipe`` returns None rather than crashing.
+    "No recipe match" is the correct outcome — the guided flow continues to
+    manual chain solving via Step 3.
 
-        The slot resolver must only be reached for blob-backed sources.
-        When blob_ref is absent it means handle_step_1_source (steps.py)
-        did not enrich the options, which is a dispatcher bug — crash loudly
-        rather than silently producing an empty source_blob_id that fails
-        recipe validation with an opaque error later.
-        """
-        source = SourceResolved(
-            plugin="csv",
-            options={},  # no blob_ref
-            observed_columns=("text",),
-            sample_rows=(),
-        )
+    Asymmetry probes: reverting either predicate's blob_ref check causes these
+    tests to fail (the predicate returns True and the slot resolver crashes with
+    InvariantError, which leaks up through match_recipe as an unhandled exception).
+    """
+
+    def test_classify_returns_none_when_blob_ref_absent(self) -> None:
+        """CSV + classifier-keyword sink, but no blob_ref → None (no recipe match)."""
+        source = _make_csv_source_no_blob()
+        sink = _make_single_json_sink(required_fields=("category",))
+        # Predicate gates out on missing blob_ref; resolver never reached.
+        assert match_recipe(source, sink) is None
+
+    def test_split_threshold_returns_none_when_blob_ref_absent(self) -> None:
+        """CSV + two-JSON sink, but no blob_ref → None (no recipe match)."""
+        source = _make_csv_source_no_blob()
+        sink = _make_two_json_sink()
+        # Predicate gates out on missing blob_ref; resolver never reached.
+        assert match_recipe(source, sink) is None
+
+    def test_classify_no_blob_does_not_raise(self) -> None:
+        """Confirms the predicate change: no InvariantError leaks from match_recipe
+        when blob_ref is absent.  If the predicate's blob_ref check were reverted,
+        the resolver would raise InvariantError and this test would fail."""
+        source = _make_csv_source_no_blob()
+        sink = _make_single_json_sink(required_fields=("label",))
+        # Must NOT raise — returns None silently.
+        result = match_recipe(source, sink)
+        assert result is None
+
+    def test_split_threshold_no_blob_does_not_raise(self) -> None:
+        """Same probe for the split-threshold predicate."""
+        source = _make_csv_source_no_blob()
+        sink = _make_two_json_sink()
+        result = match_recipe(source, sink)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Resolver-level defence-in-depth (InvariantError still raised directly)
+# ---------------------------------------------------------------------------
+
+
+class TestResolverDefenceInDepth:
+    """The slot resolvers retain their InvariantError guard even though the
+    predicates now prevent blob_ref-less sources from ever reaching them through
+    ``match_recipe``.  These tests call the resolvers directly to prove the
+    defence-in-depth guard is intact — any future caller that bypasses the
+    predicate registry will get a clear crash rather than a silent KeyError.
+    """
+
+    def test_classify_resolver_crashes_directly_without_blob_ref(self) -> None:
+        """_classify_slot_resolver called directly with no blob_ref → InvariantError."""
+        source = _make_csv_source_no_blob()
         sink = _make_single_json_sink(required_fields=("category",))
         with pytest.raises(InvariantError, match="blob_ref"):
-            match_recipe(source, sink)
+            _classify_slot_resolver(source, sink)
 
-    def test_threshold_raises_when_blob_ref_absent(self) -> None:
-        """split-by-numeric-threshold resolver also crashes on missing blob_ref."""
-        source = SourceResolved(
-            plugin="csv",
-            options={},  # no blob_ref
-            observed_columns=("amount",),
-            sample_rows=(),
-        )
+    def test_split_threshold_resolver_crashes_directly_without_blob_ref(self) -> None:
+        """_split_threshold_slot_resolver called directly with no blob_ref → InvariantError."""
+        source = _make_csv_source_no_blob()
         sink = _make_two_json_sink()
         with pytest.raises(InvariantError, match="blob_ref"):
-            match_recipe(source, sink)
+            _split_threshold_slot_resolver(source, sink)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -17,11 +17,16 @@ from elspeth.web.composer.guided.state_machine import (
 # ---------------------------------------------------------------------------
 
 
-def _make_csv_source(blob_id: str = "blob-123") -> SourceResolved:
-    """Return a minimal CSV SourceResolved with a blob_id in options."""
+def _make_csv_source(blob_ref: str = "a1b2c3d4-0000-0000-0000-000000000001") -> SourceResolved:
+    """Return a minimal CSV SourceResolved with blob_ref in options.
+
+    ``blob_ref`` is the composer-canonical key for the blob UUID, written by
+    ``_execute_set_source_from_blob`` and by the ``handle_step_1_source``
+    blob-enrichment path in steps.py.
+    """
     return SourceResolved(
         plugin="csv",
-        options={"blob_id": blob_id},
+        options={"blob_ref": blob_ref},
         observed_columns=("id", "text"),
         sample_rows=({"id": "1", "text": "hello"},),
     )
@@ -97,18 +102,20 @@ class TestClassifyRecipeMatch:
 
     def test_classify_slot_label_field_uses_keyword_match(self) -> None:
         """label_field is the keyword-matching field, not necessarily [0]."""
-        source = _make_csv_source(blob_id="blob-xyz")
+        source = _make_csv_source(blob_ref="a1b2c3d4-0000-0000-0000-00000000abcd")
         sink = _make_single_json_sink(required_fields=("record_id", "label"))
         match = match_recipe(source, sink)
         assert match is not None
         assert match.slots["label_field"] == "label"
 
-    def test_classify_slot_source_blob_id_populated_from_options(self) -> None:
-        source = _make_csv_source(blob_id="test-blob-456")
+    def test_classify_slot_source_blob_id_populated_from_blob_ref(self) -> None:
+        """source_blob_id slot is populated from source.options['blob_ref']."""
+        blob_uuid = "a1b2c3d4-0000-0000-0000-000000000099"
+        source = _make_csv_source(blob_ref=blob_uuid)
         sink = _make_single_json_sink(required_fields=("tag",))
         match = match_recipe(source, sink)
         assert match is not None
-        assert match.slots["source_blob_id"] == "test-blob-456"
+        assert match.slots["source_blob_id"] == blob_uuid
 
     def test_classify_slot_output_path_from_sink_options(self) -> None:
         source = _make_csv_source()
@@ -181,7 +188,8 @@ class TestSplitThresholdRecipeMatch:
 
     def test_split_threshold_slots_use_correct_names(self) -> None:
         """Slot map keys must match _RECIPE2_SLOTS declarations (C8 verification)."""
-        source = _make_csv_source(blob_id="blob-789")
+        blob_uuid = "a1b2c3d4-0000-0000-0000-000000000789"
+        source = _make_csv_source(blob_ref=blob_uuid)
         sink = _make_two_json_sink(above_path="my/above.jsonl", below_path="my/below.jsonl")
         match = match_recipe(source, sink)
         assert match is not None
@@ -191,7 +199,7 @@ class TestSplitThresholdRecipeMatch:
             "above_output_path",
             "below_output_path",
         }
-        assert match.slots["source_blob_id"] == "blob-789"
+        assert match.slots["source_blob_id"] == blob_uuid
         assert match.slots["above_output_path"] == "my/above.jsonl"
         assert match.slots["below_output_path"] == "my/below.jsonl"
 
@@ -242,32 +250,38 @@ class TestNoMatch:
 
 
 # ---------------------------------------------------------------------------
-# Source blob_id missing from options (boundary coercion)
+# Source blob_ref missing from options (invariant violation — offensive crash)
 # ---------------------------------------------------------------------------
 
 
-class TestMissingBlobId:
-    def test_classify_source_blob_id_empty_when_options_has_no_blob_id(self) -> None:
-        """source.options without blob_id → source_blob_id is empty string."""
+class TestMissingBlobRef:
+    def test_classify_raises_when_blob_ref_absent(self) -> None:
+        """source.options without blob_ref → ValueError (state-machine invariant).
+
+        The slot resolver must only be reached for blob-backed sources.
+        When blob_ref is absent it means handle_step_1_source (steps.py)
+        did not enrich the options, which is a dispatcher bug — crash loudly
+        rather than silently producing an empty source_blob_id that fails
+        recipe validation with an opaque error later.
+        """
         source = SourceResolved(
             plugin="csv",
-            options={},  # no blob_id
+            options={},  # no blob_ref
             observed_columns=("text",),
             sample_rows=(),
         )
         sink = _make_single_json_sink(required_fields=("category",))
-        match = match_recipe(source, sink)
-        assert match is not None
-        assert match.slots["source_blob_id"] == ""
+        with pytest.raises(ValueError, match="blob_ref"):
+            match_recipe(source, sink)
 
-    def test_threshold_source_blob_id_empty_when_options_has_no_blob_id(self) -> None:
+    def test_threshold_raises_when_blob_ref_absent(self) -> None:
+        """split-by-numeric-threshold resolver also crashes on missing blob_ref."""
         source = SourceResolved(
             plugin="csv",
-            options={},  # no blob_id
+            options={},  # no blob_ref
             observed_columns=("amount",),
             sample_rows=(),
         )
         sink = _make_two_json_sink()
-        match = match_recipe(source, sink)
-        assert match is not None
-        assert match.slots["source_blob_id"] == ""
+        with pytest.raises(ValueError, match="blob_ref"):
+            match_recipe(source, sink)

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -73,14 +73,28 @@ class TestRecipeMatch:
         match = RecipeMatch(
             recipe_name="test-recipe",
             slots={"source_blob_id": "blob-abc"},
+            unsatisfied_slots={},
         )
         with pytest.raises((AttributeError, TypeError)):
             match.slots["source_blob_id"] = "mutated"  # type: ignore[index]
 
     def test_recipe_match_name_is_frozen(self) -> None:
-        match = RecipeMatch(recipe_name="test-recipe", slots={})
+        match = RecipeMatch(recipe_name="test-recipe", slots={}, unsatisfied_slots={})
         with pytest.raises(AttributeError):
             match.recipe_name = "other"  # type: ignore[misc]
+
+    def test_recipe_match_unsatisfied_slots_are_frozen(self) -> None:
+        from elspeth.web.composer.recipes import SlotSpec
+
+        match = RecipeMatch(
+            recipe_name="test-recipe",
+            slots={},
+            unsatisfied_slots={
+                "model": SlotSpec(slot_type="str", description="LLM model"),
+            },
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            match.unsatisfied_slots["model"] = SlotSpec(slot_type="str")  # type: ignore[index]
 
 
 # ---------------------------------------------------------------------------
@@ -285,3 +299,80 @@ class TestMissingBlobRef:
         sink = _make_two_json_sink()
         with pytest.raises(ValueError, match="blob_ref"):
             match_recipe(source, sink)
+
+
+# ---------------------------------------------------------------------------
+# Unsatisfied required-slot schema (Task 10.0 — Gap 6)
+# ---------------------------------------------------------------------------
+
+
+class TestUnsatisfiedSlots:
+    """match_recipe populates RecipeMatch.unsatisfied_slots with the required
+    slots the resolver could NOT pre-fill.
+
+    The frontend renders editable inputs for these so the operator can supply
+    the values before Apply.  Optional slots with declared defaults are NOT
+    surfaced — ``validate_slots`` auto-fills them at apply time.
+    """
+
+    def test_classify_unsatisfied_lists_three_required_slots(self) -> None:
+        """classify-rows-llm-jsonl: classifier_template, model, api_key_secret."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("category",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        unsatisfied_names = set(match.unsatisfied_slots.keys())
+        assert unsatisfied_names == {
+            "classifier_template",
+            "model",
+            "api_key_secret",
+        }
+
+    def test_classify_unsatisfied_excludes_resolver_filled_slots(self) -> None:
+        """Resolver fills source_blob_id / output_path / label_field — these
+        must NOT appear in unsatisfied_slots."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("label",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        for name in ("source_blob_id", "output_path", "label_field"):
+            assert name not in match.unsatisfied_slots, f"resolver-filled slot {name!r} leaked into unsatisfied_slots"
+
+    def test_classify_unsatisfied_excludes_optional_slots_with_defaults(self) -> None:
+        """Optional slots (provider, required_input_fields) have declared
+        defaults and must NOT appear in unsatisfied_slots."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("tag",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        for name in ("provider", "required_input_fields"):
+            assert name not in match.unsatisfied_slots, f"optional slot {name!r} surfaced as unsatisfied"
+
+    def test_classify_unsatisfied_carries_slot_specs(self) -> None:
+        """Each unsatisfied entry is a SlotSpec with the recipe's declared
+        metadata — slot_type, description, required=True."""
+        source = _make_csv_source()
+        sink = _make_single_json_sink(required_fields=("classification",))
+        match = match_recipe(source, sink)
+        assert match is not None
+        spec = match.unsatisfied_slots["model"]
+        assert spec.slot_type == "str"
+        assert spec.required is True
+        assert spec.description  # non-empty hint
+
+    def test_split_threshold_unsatisfied_lists_field_and_threshold(self) -> None:
+        """split-by-numeric-threshold: field, threshold are the only required
+        slots the resolver does not pre-fill."""
+        source = _make_csv_source()
+        sink = _make_two_json_sink()
+        match = match_recipe(source, sink)
+        assert match is not None
+        unsatisfied_names = set(match.unsatisfied_slots.keys())
+        assert unsatisfied_names == {"field", "threshold"}
+
+    def test_split_threshold_unsatisfied_threshold_slot_type_is_float(self) -> None:
+        source = _make_csv_source()
+        sink = _make_two_json_sink()
+        match = match_recipe(source, sink)
+        assert match is not None
+        assert match.unsatisfied_slots["threshold"].slot_type == "float"

--- a/tests/unit/web/composer/guided/test_recipe_match.py
+++ b/tests/unit/web/composer/guided/test_recipe_match.py
@@ -376,3 +376,75 @@ class TestUnsatisfiedSlots:
         match = match_recipe(source, sink)
         assert match is not None
         assert match.unsatisfied_slots["threshold"].slot_type == "float"
+
+    # ------------------------------------------------------------------
+    # I4: constructor-level invariants on ``unsatisfied_slots``
+    # ------------------------------------------------------------------
+    #
+    # The match_recipe() construction site enforces the slots / unsatisfied_slots
+    # contract by discipline (set-comprehension excludes resolved slots; filters
+    # to ``spec.required``).  These tests pin the invariants at the constructor
+    # itself so any *other* caller — apply-time reconstruction in routes.py,
+    # test fixtures, future code paths — also crashes on contract violation.
+
+    def test_rejects_slot_overlapping_with_unsatisfied(self) -> None:
+        """A name present in both ``slots`` and ``unsatisfied_slots`` is a
+        direct contradiction of the invariant: a slot cannot simultaneously
+        be resolved and unsatisfied.  Constructor must raise ValueError."""
+        from elspeth.web.composer.recipes import SlotSpec
+
+        with pytest.raises(ValueError, match="overlap") as exc_info:
+            RecipeMatch(
+                recipe_name="test-recipe",
+                slots={"foo": "resolved-value"},
+                unsatisfied_slots={
+                    "foo": SlotSpec(slot_type="str", description="conflicting", required=True),
+                },
+            )
+        # Message must name the offending key so the audit trail / log
+        # surfaces *which* slot violated the invariant, not just that one did.
+        assert "foo" in str(exc_info.value)
+
+    def test_rejects_optional_slot_in_unsatisfied(self) -> None:
+        """``unsatisfied_slots`` is the schema for *required* slots the resolver
+        could not pre-fill.  Optional slots have declared defaults and are
+        auto-filled by ``validate_slots`` at apply time — surfacing them to
+        the operator is a contract violation.  Constructor must raise."""
+        from elspeth.web.composer.recipes import SlotSpec
+
+        with pytest.raises(ValueError, match="optional") as exc_info:
+            RecipeMatch(
+                recipe_name="test-recipe",
+                slots={},
+                unsatisfied_slots={
+                    "foo": SlotSpec(
+                        slot_type="str",
+                        description="should not be here",
+                        required=False,
+                    ),
+                },
+            )
+        # Message must name the offending slot for debuggability.
+        assert "foo" in str(exc_info.value)
+
+    def test_apply_time_reconstruction_shape_is_trivially_valid(self) -> None:
+        """routes.py:~2033 reconstructs a RecipeMatch at apply time with
+        ``unsatisfied_slots={}``.  With the constructor invariants in place,
+        an empty unsatisfied_slots mapping makes both checks trivially pass
+        regardless of the contents of ``slots`` — verify here so a future
+        refactor that changes the apply-site shape gets a regression signal."""
+        match = RecipeMatch(
+            recipe_name="classify-rows-llm-jsonl",
+            slots={
+                "source_blob_id": "blob-abc",
+                "model": "gpt-4o-mini",
+                "classifier_template": "Classify: {text}",
+                "api_key_secret": "openai/key",
+                "output_path": "out.jsonl",
+                "label_field": "category",
+            },
+            unsatisfied_slots={},
+        )
+        # Constructor did not raise; both invariants vacuously satisfied.
+        assert match.unsatisfied_slots == {}
+        assert "source_blob_id" in match.slots

--- a/tests/unit/web/composer/guided/test_skill.py
+++ b/tests/unit/web/composer/guided/test_skill.py
@@ -36,3 +36,38 @@ class TestGuidedSkill:
         text = load_guided_skill()
         # The hard rule that survives from freeform skill (spec §8.1.4)
         assert "anti-fabrication" in text.lower() or "do not invent" in text.lower()
+
+
+class TestStep3ContextBlock:
+    def test_renders_source_and_sink(self) -> None:
+        from elspeth.web.composer.guided.prompts import build_step_3_context_block
+        from elspeth.web.composer.guided.state_machine import (
+            SinkOutputResolved,
+            SinkResolved,
+            SourceResolved,
+        )
+
+        ctx = build_step_3_context_block(
+            source=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("price", "qty"),
+                sample_rows=({"price": "1.99", "qty": "2"},),
+            ),
+            sink=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={"path": "out.jsonl"},
+                        required_fields=("avg_price",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+            recipe_match=None,
+        )
+        assert "source:" in ctx
+        assert "csv" in ctx
+        assert "price" in ctx
+        assert "avg_price" in ctx
+        assert "recipe_match: null" in ctx

--- a/tests/unit/web/composer/guided/test_skill.py
+++ b/tests/unit/web/composer/guided/test_skill.py
@@ -1,0 +1,38 @@
+"""Tests for guided-mode skill prompt loading + structural assertions.
+
+Skill prompts are LLM behaviour, not code — these tests verify the file
+exists, loads, and contains the load-bearing protocol-definition strings.
+They do not assert the prompt's behavioural quality; that is verified by
+real-LLM tests in test_chain_solver.py.
+"""
+
+from __future__ import annotations
+
+from elspeth.web.composer.guided.prompts import load_guided_skill
+
+
+class TestGuidedSkill:
+    def test_loads(self) -> None:
+        text = load_guided_skill()
+        assert len(text) > 0
+
+    def test_under_size_target(self) -> None:
+        text = load_guided_skill()
+        assert text.count("\n") <= 100, "guided skill should be ≤100 lines (target ≤80)"
+
+    def test_mentions_six_turn_types(self) -> None:
+        text = load_guided_skill()
+        for turn_type in (
+            "inspect_and_confirm",
+            "single_select",
+            "multi_select_with_custom",
+            "schema_form",
+            "propose_chain",
+            "recipe_offer",
+        ):
+            assert turn_type in text, f"missing turn type: {turn_type}"
+
+    def test_anti_fabrication_clause_present(self) -> None:
+        text = load_guided_skill()
+        # The hard rule that survives from freeform skill (spec §8.1.4)
+        assert "anti-fabrication" in text.lower() or "do not invent" in text.lower()

--- a/tests/unit/web/composer/guided/test_state_field.py
+++ b/tests/unit/web/composer/guided/test_state_field.py
@@ -1,0 +1,39 @@
+"""Tests for CompositionState.guided_session field."""
+
+from __future__ import annotations
+
+import pytest
+
+from elspeth.web.composer.guided.state_machine import GuidedSession
+from elspeth.web.composer.state import CompositionState, PipelineMetadata
+
+
+def _empty_state(**overrides: object) -> CompositionState:
+    """Return a minimal valid CompositionState, with optional field overrides."""
+    base: dict[str, object] = {
+        "source": None,
+        "nodes": (),
+        "edges": (),
+        "outputs": (),
+        "metadata": PipelineMetadata(),
+        "version": 1,
+    }
+    base.update(overrides)
+    return CompositionState(**base)  # type: ignore[arg-type]
+
+
+class TestGuidedSessionField:
+    def test_default_is_none(self) -> None:
+        state = _empty_state()
+        assert state.guided_session is None
+
+    def test_can_attach_initial_session(self) -> None:
+        sess = GuidedSession.initial()
+        state = _empty_state(guided_session=sess)
+        assert state.guided_session is sess
+
+    def test_session_history_remains_immutable(self) -> None:
+        sess = GuidedSession.initial()
+        state = _empty_state(guided_session=sess)
+        with pytest.raises(AttributeError):
+            state.guided_session = None  # type: ignore[misc]

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -217,6 +217,36 @@ class TestGuidedSession:
         assert restored == sess
         assert restored.step_2_5_recipe_offer is None
 
+    def test_guided_session_roundtrip_with_step_2_chosen_plugin(self) -> None:
+        """GuidedSession with step_2_chosen_plugin survives to_dict/from_dict round-trip.
+
+        Exercises the Tier-1 serialisation boundary for the new staging field.
+        The field is set in the SINGLE_SELECT→SCHEMA_FORM window at STEP_2_SINK;
+        it must survive the persist/restore cycle so GET /guided can rebuild
+        the correct SCHEMA_FORM on refresh.
+        """
+        from dataclasses import replace
+
+        sess = replace(GuidedSession.initial(), step_2_chosen_plugin="json")
+        d = sess.to_dict()
+        assert d["step_2_chosen_plugin"] == "json"  # serialised
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_chosen_plugin == "json"
+
+    def test_guided_session_roundtrip_with_step_2_chosen_plugin_none(self) -> None:
+        """GuidedSession with step_2_chosen_plugin=None round-trips cleanly.
+
+        Ensures the None case is serialised as None (not absent), which would
+        crash from_dict's strict key read.
+        """
+        sess = GuidedSession.initial()
+        d = sess.to_dict()
+        assert d["step_2_chosen_plugin"] is None  # serialised as null
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_chosen_plugin is None
+
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal TurnResponse

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -8,6 +8,7 @@ import pytest
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
+    SourceResolved,
     TerminalKind,
     TerminalReason,
     TerminalState,
@@ -92,8 +93,8 @@ class TestGuidedSession:
 def _make_response(
     *,
     control_signal: str | None = None,
-    edited_values: dict | None = None,
-    chosen: list | None = None,
+    edited_values: dict[str, object] | None = None,
+    chosen: list[str] | None = None,
 ) -> TurnResponse:
     return TurnResponse(
         chosen=chosen,
@@ -161,3 +162,100 @@ class TestStepAdvance:
         assert next_turn is None
         assert terminal is None
         assert directives == []
+
+    # ---------------------------------------------------------------------------
+    # Task 2.2 tests: Step 2 → Step 2.5 branch
+    # ---------------------------------------------------------------------------
+
+    def test_step_2_advances_after_required_fields_declared(self) -> None:
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_SINK,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a", "b"),
+                sample_rows=({"a": "1", "b": "2"},),
+            ),
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response: TurnResponse = {
+            "chosen": None,
+            "edited_values": {
+                "outputs": [
+                    {
+                        "plugin": "json",
+                        "options": {"path": "out.jsonl"},
+                        "required_fields": ["a"],
+                        "schema_mode": "fixed",
+                    },
+                ],
+            },
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+
+        new_sess, _next, terminal, _events = step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
+
+        assert new_sess.step is GuidedStep.STEP_2_5_RECIPE_MATCH
+        assert new_sess.step_2_result is not None
+        assert len(new_sess.step_2_result.outputs) == 1
+        assert terminal is None
+
+    def test_step_2_let_source_decide_sets_observed_mode(self) -> None:
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_SINK,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a", "b"),
+                sample_rows=({},),
+            ),
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response: TurnResponse = {
+            "chosen": None,
+            "edited_values": {
+                "outputs": [
+                    {
+                        "plugin": "json",
+                        "options": {"path": "out.jsonl"},
+                        "required_fields": [],
+                        "schema_mode": "observed",
+                    },
+                ],
+            },
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        new_sess, _next, _terminal, _events = step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
+        assert new_sess.step_2_result is not None
+        assert new_sess.step_2_result.outputs[0].schema_mode == "observed"
+
+    def test_step_2_without_edited_values_raises(self) -> None:
+        """edited_values=None on a MULTI_SELECT_WITH_CUSTOM response must raise ValueError."""
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_SINK,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response = _make_response(edited_values=None)
+        with pytest.raises(ValueError, match="multi_select_with_custom"):
+            step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -8,6 +8,8 @@ import pytest
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
+    SinkOutputResolved,
+    SinkResolved,
     SourceResolved,
     TerminalKind,
     TerminalReason,
@@ -259,3 +261,113 @@ class TestStepAdvance:
         response = _make_response(edited_values=None)
         with pytest.raises(ValueError, match="multi_select_with_custom"):
             step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
+
+    # ---------------------------------------------------------------------------
+    # Task 2.4 tests: Step 2.5 → Step 3 (or passthrough on recipe accept)
+    # ---------------------------------------------------------------------------
+
+    def test_step_2_5_recipe_accepted_session_unchanged(self) -> None:
+        """chosen=["accept"] at STEP_2_5: session stays at STEP_2_5, no directive.
+
+        The endpoint handler (Errata C2) reads response["chosen"] == ["accept"]
+        and invokes _execute_apply_pipeline_recipe to commit the recipe and
+        produce the COMPLETED terminal. step_advance is pure and does not run
+        apply_recipe; it leaves the session unchanged for the handler to act on.
+        """
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={"blob_id": "blob-1"},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=SinkResolved(
+                outputs=(
+                    SinkOutputResolved(
+                        plugin="json",
+                        options={"path": "out.jsonl"},
+                        required_fields=("category",),
+                        schema_mode="fixed",
+                    ),
+                )
+            ),
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response: TurnResponse = {
+            "chosen": ["accept"],
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        new_sess, next_turn, terminal, directives = step_advance(
+            sess,
+            response,
+            current_turn_type=TurnType.RECIPE_OFFER,
+        )
+        # Session stays at STEP_2_5 — endpoint handler advances to COMPLETED
+        assert new_sess.step is GuidedStep.STEP_2_5_RECIPE_MATCH
+        assert new_sess is sess  # pure: no state change
+        assert next_turn is None
+        assert terminal is None
+        assert directives == []
+
+    def test_step_2_5_build_manually_advances_to_step_3(self) -> None:
+        """chosen=["build_manually"] at STEP_2_5: advance to STEP_3_TRANSFORMS."""
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=SinkResolved(outputs=()),
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response: TurnResponse = {
+            "chosen": ["build_manually"],
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        new_sess, next_turn, terminal, directives = step_advance(
+            sess,
+            response,
+            current_turn_type=TurnType.RECIPE_OFFER,
+        )
+        assert new_sess.step is GuidedStep.STEP_3_TRANSFORMS
+        assert next_turn is None
+        assert terminal is None
+        assert len(directives) == 1
+        assert directives[0].tool_name == "guided_step_advanced"
+        assert directives[0].arguments["prev_step"] == GuidedStep.STEP_2_5_RECIPE_MATCH.value
+        assert directives[0].arguments["next_step"] == GuidedStep.STEP_3_TRANSFORMS.value
+        assert directives[0].arguments["reason"] == "user_advanced"
+
+    def test_step_2_5_unexpected_chosen_raises(self) -> None:
+        """Any chosen value other than 'accept' or 'build_manually' is a protocol violation."""
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_5_RECIPE_MATCH,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=SinkResolved(outputs=()),
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response = _make_response(chosen=["nonsense"])
+        with pytest.raises(ValueError, match="unexpected chosen for recipe_offer"):
+            step_advance(sess, response, current_turn_type=TurnType.RECIPE_OFFER)

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -561,7 +561,13 @@ class TestStepAdvance:
         assert directives == []
 
     def test_step_3_unexpected_turn_type_raises(self) -> None:
-        """Any turn type other than PROPOSE_CHAIN or SINGLE_SELECT at Step 3 is a ValueError."""
+        """Any turn type other than PROPOSE_CHAIN or SINGLE_SELECT at Step 3 is an InvariantError.
+
+        Step 3 only ever emits PROPOSE_CHAIN and SINGLE_SELECT turns from the
+        server.  A different turn type in the history record means the emitter
+        stamped an invalid type — that is a server-side bug (InvariantError),
+        not a client protocol violation (ValueError).  Maps to HTTP 500, not 400.
+        """
         sess = GuidedSession(
             step=GuidedStep.STEP_3_TRANSFORMS,
             history=(),
@@ -576,7 +582,7 @@ class TestStepAdvance:
             terminal=None,
         )
         response = _make_response()
-        with pytest.raises(ValueError, match="unexpected turn_type at step 3"):
+        with pytest.raises(InvariantError, match="_advance_step_3"):
             step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
 
 

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -174,6 +174,49 @@ class TestGuidedSession:
         assert restored == sess
         assert restored.step_1_source_intent is None
 
+    def test_guided_session_roundtrip_with_recipe_offer(self) -> None:
+        """GuidedSession with step_2_5_recipe_offer survives to_dict/from_dict round-trip.
+
+        Exercises the Tier-1 serialisation boundary: the staged offer is persisted
+        to composer_meta["guided_session"] when the recipe_offer turn is emitted and
+        must survive the round-trip so the POST /respond accept branch can verify
+        the recipe_name.
+        """
+        from dataclasses import replace
+
+        from elspeth.web.composer.guided.recipe_match import RecipeMatch
+        from elspeth.web.composer.recipes import SlotSpec
+
+        offer = RecipeMatch(
+            recipe_name="classify-rows-llm-jsonl",
+            slots={"source_blob_id": "blob-abc", "output_path": "out.jsonl", "label_field": "category"},
+            unsatisfied_slots={
+                "classifier_template": SlotSpec(slot_type="str", description="Jinja2 template", required=True),
+                "model": SlotSpec(slot_type="str", description="LLM model name", required=True),
+                "api_key_secret": SlotSpec(slot_type="str", description="Secret name", required=True),
+            },
+        )
+        sess = replace(GuidedSession.initial(), step_2_5_recipe_offer=offer)
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_5_recipe_offer is not None
+        assert restored.step_2_5_recipe_offer.recipe_name == "classify-rows-llm-jsonl"
+        assert restored.step_2_5_recipe_offer.slots["source_blob_id"] == "blob-abc"
+        assert "classifier_template" in restored.step_2_5_recipe_offer.unsatisfied_slots
+
+    def test_guided_session_roundtrip_with_recipe_offer_none(self) -> None:
+        """GuidedSession with step_2_5_recipe_offer=None round-trips cleanly.
+
+        Ensures the None case is serialised as None (not absent), which would
+        crash from_dict's strict key read.
+        """
+        sess = GuidedSession.initial()
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_5_recipe_offer is None
+
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal TurnResponse

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -658,6 +658,39 @@ class TestStepAdvance:
         with pytest.raises(InvariantError, match="_advance_step_3"):
             step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
 
+    def test_step_advance_unhandled_step_raises_invariant_error_not_assertion(self) -> None:
+        """Dispatcher fall-through is gated by InvariantError, not AssertionError.
+
+        Regression test for PR-review finding B2: AssertionError is stripped by
+        ``python -O`` and would silently fall through under optimized
+        deployment.  ``InvariantError`` subclasses ``Exception`` directly and
+        survives ``-O`` — see ``elspeth.web.composer.guided.errors``.
+
+        The closed enum ``GuidedStep`` makes this branch unreachable from valid
+        state, so we inject a sentinel via ``object.__setattr__`` on the frozen
+        dataclass to drive the dispatcher into the fall-through.
+        """
+        sess = GuidedSession.initial()
+        # Inject a step value the dispatcher cannot match.  ``object.__setattr__``
+        # bypasses ``frozen=True``; that's intentional here — the production code
+        # never mutates step in place, only via dataclasses.replace.
+        object.__setattr__(sess, "step", "not-a-real-step")
+        response = _make_response()
+        with pytest.raises(InvariantError, match="unhandled step"):
+            step_advance(sess, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+        # And explicitly: it is NOT an AssertionError subclass.  This pins the
+        # python -O contract: AssertionError raises are elided; InvariantError
+        # raises are not.
+        try:
+            object.__setattr__(sess, "step", "also-not-real")
+            step_advance(sess, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+        except InvariantError as exc:
+            assert not isinstance(exc, AssertionError), (
+                "InvariantError must NOT inherit from AssertionError; "
+                "python -O strips AssertionError raises and would silently "
+                "skip the dispatcher gate."
+            )
+
 
 # ---------------------------------------------------------------------------
 # Task 2.5 tests: standalone terminal-failure helpers (spec §5.4)

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -11,6 +11,7 @@ from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnT
 from elspeth.web.composer.guided.state_machine import (
     ChainProposal,
     GuidedSession,
+    SinkIntent,
     SinkOutputResolved,
     SinkResolved,
     SourceResolved,
@@ -90,6 +91,50 @@ class TestGuidedSession:
         )
         assert s.terminal is not None
         assert s.terminal.kind is TerminalKind.COMPLETED
+
+    def test_guided_session_roundtrip_with_sink_intent(self) -> None:
+        """GuidedSession with step_2_sink_intent survives to_dict/from_dict round-trip.
+
+        Exercises the Tier-1 serialisation boundary: the session is persisted to
+        composer_meta["guided_session"] between turns, so the new staging field must
+        survive the round-trip without loss or corruption.
+        """
+        intent = SinkIntent(
+            plugin="json",
+            options={"path": "/data/out.jsonl", "schema": {"mode": "observed"}},
+        )
+        sess = GuidedSession(
+            step=GuidedStep.STEP_2_SINK,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={"path": "/data/in.csv"},
+                observed_columns=("col_a", "col_b"),
+                sample_rows=({"col_a": "x", "col_b": "y"},),
+            ),
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+            step_2_sink_intent=intent,
+        )
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_sink_intent is not None
+        assert restored.step_2_sink_intent.plugin == "json"
+        assert restored.step_2_sink_intent.options["path"] == "/data/out.jsonl"
+
+    def test_guided_session_roundtrip_with_sink_intent_none(self) -> None:
+        """GuidedSession with step_2_sink_intent=None round-trips cleanly.
+
+        Ensures the None case is serialised as None and reconstructed as None
+        (not absent or missing), which would crash from_dict's strict key read.
+        """
+        sess = GuidedSession.initial()
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_2_sink_intent is None
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +220,9 @@ class TestStepAdvance:
     # ---------------------------------------------------------------------------
 
     def test_step_2_advances_after_required_fields_declared(self) -> None:
+        """_advance_step_2 reads chosen + custom_inputs from response and plugin + options
+        from GuidedSession.step_2_sink_intent to construct SinkOutputResolved."""
+        intent = SinkIntent(plugin="json", options={"path": "out.jsonl"})
         sess = GuidedSession(
             step=GuidedStep.STEP_2_SINK,
             history=(),
@@ -187,20 +235,12 @@ class TestStepAdvance:
             step_2_result=None,
             step_3_proposal=None,
             terminal=None,
+            step_2_sink_intent=intent,
         )
         response: TurnResponse = {
-            "chosen": None,
-            "edited_values": {
-                "outputs": [
-                    {
-                        "plugin": "json",
-                        "options": {"path": "out.jsonl"},
-                        "required_fields": ["a"],
-                        "schema_mode": "fixed",
-                    },
-                ],
-            },
-            "custom_inputs": None,
+            "chosen": ["a"],
+            "edited_values": None,
+            "custom_inputs": [],
             "accepted_step_index": None,
             "edit_step_index": None,
             "control_signal": None,
@@ -211,9 +251,17 @@ class TestStepAdvance:
         assert new_sess.step is GuidedStep.STEP_2_5_RECIPE_MATCH
         assert new_sess.step_2_result is not None
         assert len(new_sess.step_2_result.outputs) == 1
+        output = new_sess.step_2_result.outputs[0]
+        assert output.plugin == "json"
+        assert output.required_fields == ("a",)
+        assert output.schema_mode == "observed"
+        # step_2_sink_intent must be cleared after consumption
+        assert new_sess.step_2_sink_intent is None
         assert terminal is None
 
     def test_step_2_let_source_decide_sets_observed_mode(self) -> None:
+        """schema_mode is always 'observed' — the backend sets it, not the frontend."""
+        intent = SinkIntent(plugin="json", options={"path": "out.jsonl"})
         sess = GuidedSession(
             step=GuidedStep.STEP_2_SINK,
             history=(),
@@ -226,20 +274,12 @@ class TestStepAdvance:
             step_2_result=None,
             step_3_proposal=None,
             terminal=None,
+            step_2_sink_intent=intent,
         )
         response: TurnResponse = {
-            "chosen": None,
-            "edited_values": {
-                "outputs": [
-                    {
-                        "plugin": "json",
-                        "options": {"path": "out.jsonl"},
-                        "required_fields": [],
-                        "schema_mode": "observed",
-                    },
-                ],
-            },
-            "custom_inputs": None,
+            "chosen": [],
+            "edited_values": None,
+            "custom_inputs": [],
             "accepted_step_index": None,
             "edit_step_index": None,
             "control_signal": None,
@@ -248,8 +288,9 @@ class TestStepAdvance:
         assert new_sess.step_2_result is not None
         assert new_sess.step_2_result.outputs[0].schema_mode == "observed"
 
-    def test_step_2_without_edited_values_raises(self) -> None:
-        """edited_values=None on a MULTI_SELECT_WITH_CUSTOM response must raise ValueError."""
+    def test_step_2_without_sink_intent_raises(self) -> None:
+        """MULTI_SELECT_WITH_CUSTOM with step_2_sink_intent=None is a state-machine
+        invariant violation — raises ValueError immediately."""
         sess = GuidedSession(
             step=GuidedStep.STEP_2_SINK,
             history=(),
@@ -262,9 +303,17 @@ class TestStepAdvance:
             step_2_result=None,
             step_3_proposal=None,
             terminal=None,
+            step_2_sink_intent=None,  # missing — SCHEMA_FORM dispatcher didn't run
         )
-        response = _make_response(edited_values=None)
-        with pytest.raises(ValueError, match="multi_select_with_custom"):
+        response: TurnResponse = {
+            "chosen": ["a"],
+            "edited_values": None,
+            "custom_inputs": [],
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        with pytest.raises(ValueError, match="step_2_sink_intent is None"):
             step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
 
     # ---------------------------------------------------------------------------

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -7,6 +7,7 @@ import pytest
 
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
+    ChainProposal,
     GuidedSession,
     SinkOutputResolved,
     SinkResolved,
@@ -15,6 +16,8 @@ from elspeth.web.composer.guided.state_machine import (
     TerminalReason,
     TerminalState,
     TurnRecord,
+    mark_protocol_violation,
+    mark_solver_exhausted,
     step_advance,
 )
 
@@ -371,3 +374,100 @@ class TestStepAdvance:
         response = _make_response(chosen=["nonsense"])
         with pytest.raises(ValueError, match="unexpected chosen for recipe_offer"):
             step_advance(sess, response, current_turn_type=TurnType.RECIPE_OFFER)
+
+    # ---------------------------------------------------------------------------
+    # Task 2.5 tests: Step 3 accept/edit/reject + terminal-failure paths
+    # ---------------------------------------------------------------------------
+
+    def test_step_3_accept_chain_marks_session_with_proposal(self) -> None:
+        """PROPOSE_CHAIN at STEP_3: step_advance is a no-op; handler interprets.
+
+        The session must pass through unchanged (step_advance is pure; the
+        endpoint handler runs preview_pipeline and commits via tools.py).
+        The step_3_proposal must remain on the session if it was already set.
+        """
+        proposal = ChainProposal(
+            steps=({"plugin": "rename", "options": {}, "rationale": "normalise names"},),
+            why="The source columns need renaming before sink.",
+        )
+        sess = GuidedSession(
+            step=GuidedStep.STEP_3_TRANSFORMS,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=SinkResolved(outputs=()),
+            step_3_proposal=proposal,
+            terminal=None,
+        )
+        response = _make_response()
+        new_sess, next_turn, terminal, directives = step_advance(
+            sess,
+            response,
+            current_turn_type=TurnType.PROPOSE_CHAIN,
+        )
+        assert new_sess is sess  # pure: no state change
+        assert new_sess.step_3_proposal is proposal
+        assert next_turn is None
+        assert terminal is None
+        assert directives == []
+
+    def test_step_3_unexpected_turn_type_raises(self) -> None:
+        """Any turn type other than PROPOSE_CHAIN or SINGLE_SELECT at Step 3 is a ValueError."""
+        sess = GuidedSession(
+            step=GuidedStep.STEP_3_TRANSFORMS,
+            history=(),
+            step_1_result=SourceResolved(
+                plugin="csv",
+                options={},
+                observed_columns=("a",),
+                sample_rows=({},),
+            ),
+            step_2_result=SinkResolved(outputs=()),
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response = _make_response()
+        with pytest.raises(ValueError, match="unexpected turn_type at step 3"):
+            step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
+
+
+# ---------------------------------------------------------------------------
+# Task 2.5 tests: standalone terminal-failure helpers (spec §5.4)
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalHelpers:
+    def test_mark_solver_exhausted_sets_terminal_and_emits_directive(self) -> None:
+        sess = GuidedSession.initial()
+        new_sess, terminal, directives = mark_solver_exhausted(
+            sess,
+            validation_result={"errors": ["..."]},
+        )
+        assert new_sess.terminal is terminal
+        assert terminal.kind is TerminalKind.EXITED_TO_FREEFORM
+        assert terminal.reason is TerminalReason.SOLVER_EXHAUSTED
+        assert terminal.pipeline_yaml is None
+        # freeze_fields deep-freezes the arguments Mapping: list → tuple.
+        # The stored validation_result is MappingProxyType({'errors': ('...',)}).
+        assert any(
+            d.tool_name == "guided_dropped_to_freeform"
+            and d.arguments["drop_reason"] == "solver_exhausted"
+            and d.arguments["validation_result"] == {"errors": ("...",)}
+            for d in directives
+        )
+
+    def test_mark_solver_exhausted_with_none_validation(self) -> None:
+        sess = GuidedSession.initial()
+        _, _, directives = mark_solver_exhausted(sess, validation_result=None)
+        assert directives[0].arguments["validation_result"] is None
+
+    def test_mark_protocol_violation_sets_terminal_and_emits_directive(self) -> None:
+        sess = GuidedSession.initial()
+        _new_sess, terminal, directives = mark_protocol_violation(sess)
+        assert terminal.kind is TerminalKind.EXITED_TO_FREEFORM
+        assert terminal.reason is TerminalReason.PROTOCOL_VIOLATION
+        assert any(d.tool_name == "guided_dropped_to_freeform" and d.arguments["drop_reason"] == "protocol_violation" for d in directives)

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -8,7 +8,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from elspeth.web.composer.guided.errors import InvariantError
-from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
+from elspeth.web.composer.guided.protocol import ControlSignal, GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
     ChainProposal,
     GuidedSession,
@@ -255,7 +255,7 @@ class TestGuidedSession:
 
 def _make_response(
     *,
-    control_signal: str | None = None,
+    control_signal: ControlSignal | None = None,
     edited_values: dict[str, object] | None = None,
     chosen: list[str] | None = None,
 ) -> TurnResponse:
@@ -360,7 +360,7 @@ class TestStepAdvance:
     def test_exit_to_freeform_terminates_with_user_pressed_exit(self) -> None:
         """control_signal='exit_to_freeform' produces USER_PRESSED_EXIT terminal."""
         session = GuidedSession.initial()
-        response = _make_response(control_signal="exit_to_freeform")
+        response = _make_response(control_signal=ControlSignal.EXIT_TO_FREEFORM)
         _new_sess, next_turn, terminal, directives = step_advance(session, response, current_turn_type=TurnType.SINGLE_SELECT)
         assert terminal is not None
         assert terminal.kind is TerminalKind.EXITED_TO_FREEFORM
@@ -752,7 +752,7 @@ class TestStateMachineInvariants:
             "custom_inputs": None,
             "accepted_step_index": None,
             "edit_step_index": None,
-            "control_signal": "exit_to_freeform",
+            "control_signal": ControlSignal.EXIT_TO_FREEFORM,
         }
         new_sess, _next, terminal, _directives = step_advance(
             sess,

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
@@ -471,3 +473,38 @@ class TestTerminalHelpers:
         assert terminal.kind is TerminalKind.EXITED_TO_FREEFORM
         assert terminal.reason is TerminalReason.PROTOCOL_VIOLATION
         assert any(d.tool_name == "guided_dropped_to_freeform" and d.arguments["drop_reason"] == "protocol_violation" for d in directives)
+
+
+class TestStateMachineInvariants:
+    """Hypothesis property tests for invariants that must hold across all step states."""
+
+    @given(st.sampled_from(list(GuidedStep)))
+    def test_exit_to_freeform_always_terminates(self, starting_step: GuidedStep) -> None:
+        """control_signal='exit_to_freeform' terminates from ANY step, regardless of
+        intra-step state. The terminal kind is EXITED_TO_FREEFORM and the reason is
+        USER_PRESSED_EXIT — spec §5.3."""
+        sess = GuidedSession(
+            step=starting_step,
+            history=(),
+            step_1_result=None,
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=None,
+        )
+        response: TurnResponse = {
+            "chosen": None,
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": "exit_to_freeform",
+        }
+        new_sess, _next, terminal, _directives = step_advance(
+            sess,
+            response,
+            current_turn_type=TurnType.SINGLE_SELECT,
+        )
+        assert terminal is not None
+        assert new_sess.terminal is not None
+        assert new_sess.terminal.kind is TerminalKind.EXITED_TO_FREEFORM
+        assert new_sess.terminal.reason is TerminalReason.USER_PRESSED_EXIT

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -7,6 +7,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
     ChainProposal,
@@ -232,17 +233,17 @@ class TestStepAdvance:
         assert any(d.tool_name == "guided_step_advanced" for d in directives)
 
     def test_advance_step_1_raises_when_intent_missing(self) -> None:
-        """INSPECT_AND_CONFIRM without step_1_source_intent raises ValueError.
+        """INSPECT_AND_CONFIRM without step_1_source_intent raises InvariantError.
 
         The intent must be set by the emit site before the turn is sent.
         Arriving at INSPECT_AND_CONFIRM with intent=None is a state-machine
-        invariant violation.
+        invariant violation (server bug, not client fault).
         """
         session = GuidedSession.initial()
         # Confirm intent is None (initial state — no emit site set it).
         assert session.step_1_source_intent is None
         response = _make_response(edited_values={"columns": ["id", "name"]})
-        with pytest.raises(ValueError, match="step_1_source_intent is None"):
+        with pytest.raises(InvariantError, match="step_1_source_intent is None"):
             step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
 
     def test_advance_step_1_columns_are_coerced_to_str(self) -> None:
@@ -383,7 +384,7 @@ class TestStepAdvance:
 
     def test_step_2_without_sink_intent_raises(self) -> None:
         """MULTI_SELECT_WITH_CUSTOM with step_2_sink_intent=None is a state-machine
-        invariant violation — raises ValueError immediately."""
+        invariant violation — raises InvariantError immediately (server bug)."""
         sess = GuidedSession(
             step=GuidedStep.STEP_2_SINK,
             history=(),
@@ -406,7 +407,7 @@ class TestStepAdvance:
             "edit_step_index": None,
             "control_signal": None,
         }
-        with pytest.raises(ValueError, match="step_2_sink_intent is None"):
+        with pytest.raises(InvariantError, match="step_2_sink_intent is None"):
             step_advance(sess, response, current_turn_type=TurnType.MULTI_SELECT_WITH_CUSTOM)
 
     # ---------------------------------------------------------------------------

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -14,6 +14,7 @@ from elspeth.web.composer.guided.state_machine import (
     SinkIntent,
     SinkOutputResolved,
     SinkResolved,
+    SourceIntent,
     SourceResolved,
     TerminalKind,
     TerminalReason,
@@ -136,6 +137,42 @@ class TestGuidedSession:
         assert restored == sess
         assert restored.step_2_sink_intent is None
 
+    def test_guided_session_roundtrip_with_source_intent(self) -> None:
+        """GuidedSession with step_1_source_intent survives to_dict/from_dict round-trip.
+
+        Exercises the Tier-1 serialisation boundary: the session is persisted to
+        composer_meta["guided_session"] between turns, so the new staging field must
+        survive the round-trip without loss or corruption.
+        """
+        intent = SourceIntent(
+            plugin="csv",
+            options={"path": "/data/in.csv", "schema": {"mode": "observed"}},
+            observed_columns=("col_a", "col_b"),
+            sample_rows=({"col_a": "x", "col_b": "y"},),
+        )
+        from dataclasses import replace
+
+        sess = replace(GuidedSession.initial(), step_1_source_intent=intent)
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_1_source_intent is not None
+        assert restored.step_1_source_intent.plugin == "csv"
+        assert restored.step_1_source_intent.observed_columns == ("col_a", "col_b")
+        assert restored.step_1_source_intent.sample_rows == ({"col_a": "x", "col_b": "y"},)
+
+    def test_guided_session_roundtrip_with_source_intent_none(self) -> None:
+        """GuidedSession with step_1_source_intent=None round-trips cleanly.
+
+        Ensures the None case is serialised as None and reconstructed as None
+        (not absent or missing), which would crash from_dict's strict key read.
+        """
+        sess = GuidedSession.initial()
+        d = sess.to_dict()
+        restored = GuidedSession.from_dict(d)
+        assert restored == sess
+        assert restored.step_1_source_intent is None
+
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal TurnResponse
@@ -165,27 +202,83 @@ def _make_response(
 
 class TestStepAdvance:
     def test_initial_session_advances_after_source_confirmed(self) -> None:
-        """INSPECT_AND_CONFIRM with valid edited_values advances to STEP_2_SINK."""
-        session = GuidedSession.initial()
+        """INSPECT_AND_CONFIRM with step_1_source_intent set advances to STEP_2_SINK.
+
+        The new wire contract is narrow: edited_values = {"columns": list}.
+        Plugin, options, and sample_rows are recovered from step_1_source_intent.
+        """
+        intent = SourceIntent(
+            plugin="csv",
+            options={"path": "/data/input.csv"},
+            observed_columns=("id", "name", "score"),
+            sample_rows=({"id": 1, "name": "Alice", "score": 99},),
+        )
+        from dataclasses import replace
+
+        session = replace(GuidedSession.initial(), step_1_source_intent=intent)
         response = _make_response(
             edited_values={
-                "plugin": "csv",
-                "options": {"path": "/data/input.csv"},
-                "observed_columns": ["id", "name", "score"],
-                "sample_rows": [{"id": 1, "name": "Alice", "score": 99}],
+                "columns": ["id", "name", "score"],
             },
         )
         new_sess, next_turn, terminal, directives = step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
         assert new_sess.step is GuidedStep.STEP_2_SINK
         assert new_sess.step_1_result is not None
         assert new_sess.step_1_result.plugin == "csv"
+        assert new_sess.step_1_result.observed_columns == ("id", "name", "score")
+        assert new_sess.step_1_source_intent is None  # consumed; cleared atomically
         assert terminal is None
         assert next_turn is None
         assert any(d.tool_name == "guided_step_advanced" for d in directives)
 
-    def test_inspect_and_confirm_without_edited_values_raises(self) -> None:
-        """edited_values=None on an INSPECT_AND_CONFIRM response must raise ValueError."""
+    def test_advance_step_1_raises_when_intent_missing(self) -> None:
+        """INSPECT_AND_CONFIRM without step_1_source_intent raises ValueError.
+
+        The intent must be set by the emit site before the turn is sent.
+        Arriving at INSPECT_AND_CONFIRM with intent=None is a state-machine
+        invariant violation.
+        """
         session = GuidedSession.initial()
+        # Confirm intent is None (initial state — no emit site set it).
+        assert session.step_1_source_intent is None
+        response = _make_response(edited_values={"columns": ["id", "name"]})
+        with pytest.raises(ValueError, match="step_1_source_intent is None"):
+            step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+
+    def test_advance_step_1_columns_are_coerced_to_str(self) -> None:
+        """Numeric column values in edited_values["columns"] are coerced to str.
+
+        Tier-3 coercion at the HTTP boundary: ``str(c)`` applied to each element.
+        """
+        intent = SourceIntent(
+            plugin="csv",
+            options={"path": "/data/input.csv"},
+            observed_columns=("col_a",),
+            sample_rows=(),
+        )
+        from dataclasses import replace
+
+        session = replace(GuidedSession.initial(), step_1_source_intent=intent)
+        response = _make_response(edited_values={"columns": [42, "name", True]})
+        new_sess, _, _, _ = step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+        assert new_sess.step_1_result is not None
+        assert new_sess.step_1_result.observed_columns == ("42", "name", "True")
+
+    def test_inspect_and_confirm_without_edited_values_raises(self) -> None:
+        """edited_values=None on an INSPECT_AND_CONFIRM response must raise ValueError.
+
+        step_1_source_intent must be set so the intent-guard passes; the
+        edited_values-None guard is the second check.
+        """
+        intent = SourceIntent(
+            plugin="csv",
+            options={"path": "/data/input.csv"},
+            observed_columns=("id",),
+            sample_rows=(),
+        )
+        from dataclasses import replace
+
+        session = replace(GuidedSession.initial(), step_1_source_intent=intent)
         response = _make_response(edited_values=None)
         with pytest.raises(ValueError, match="inspect_and_confirm"):
             step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 import pytest
 
-from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnResponse, TurnType
 from elspeth.web.composer.guided.state_machine import (
     GuidedSession,
     TerminalKind,
     TerminalReason,
     TerminalState,
     TurnRecord,
+    step_advance,
 )
 
 
@@ -81,3 +82,82 @@ class TestGuidedSession:
         )
         assert s.terminal is not None
         assert s.terminal.kind is TerminalKind.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal TurnResponse
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    *,
+    control_signal: str | None = None,
+    edited_values: dict | None = None,
+    chosen: list | None = None,
+) -> TurnResponse:
+    return TurnResponse(
+        chosen=chosen,
+        edited_values=edited_values,
+        custom_inputs=None,
+        accepted_step_index=None,
+        edit_step_index=None,
+        control_signal=control_signal,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2.1 tests: step_advance dispatcher + Step 1 → Step 2 branch
+# ---------------------------------------------------------------------------
+
+
+class TestStepAdvance:
+    def test_initial_session_advances_after_source_confirmed(self) -> None:
+        """INSPECT_AND_CONFIRM with valid edited_values advances to STEP_2_SINK."""
+        session = GuidedSession.initial()
+        response = _make_response(
+            edited_values={
+                "plugin": "csv",
+                "options": {"path": "/data/input.csv"},
+                "observed_columns": ["id", "name", "score"],
+                "sample_rows": [{"id": 1, "name": "Alice", "score": 99}],
+            },
+        )
+        new_sess, next_turn, terminal, directives = step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+        assert new_sess.step is GuidedStep.STEP_2_SINK
+        assert new_sess.step_1_result is not None
+        assert new_sess.step_1_result.plugin == "csv"
+        assert terminal is None
+        assert next_turn is None
+        assert any(d.tool_name == "guided_step_advanced" for d in directives)
+
+    def test_inspect_and_confirm_without_edited_values_raises(self) -> None:
+        """edited_values=None on an INSPECT_AND_CONFIRM response must raise ValueError."""
+        session = GuidedSession.initial()
+        response = _make_response(edited_values=None)
+        with pytest.raises(ValueError, match="inspect_and_confirm"):
+            step_advance(session, response, current_turn_type=TurnType.INSPECT_AND_CONFIRM)
+
+    def test_exit_to_freeform_terminates_with_user_pressed_exit(self) -> None:
+        """control_signal='exit_to_freeform' produces USER_PRESSED_EXIT terminal."""
+        session = GuidedSession.initial()
+        response = _make_response(control_signal="exit_to_freeform")
+        _new_sess, next_turn, terminal, directives = step_advance(session, response, current_turn_type=TurnType.SINGLE_SELECT)
+        assert terminal is not None
+        assert terminal.kind is TerminalKind.EXITED_TO_FREEFORM
+        assert terminal.reason is TerminalReason.USER_PRESSED_EXIT
+        assert terminal.pipeline_yaml is None
+        assert next_turn is None
+        assert any(d.tool_name == "guided_dropped_to_freeform" for d in directives)
+        # The directive must record the drop_reason value so Phase 3 can reconstruct it
+        drop_directive = next(d for d in directives if d.tool_name == "guided_dropped_to_freeform")
+        assert drop_directive.arguments["drop_reason"] == "user_pressed_exit"
+
+    def test_step_1_non_inspect_turn_does_not_advance(self) -> None:
+        """A SINGLE_SELECT response in Step 1 is an intra-step turn — no advance."""
+        session = GuidedSession.initial()
+        response = _make_response(chosen=["csv"])
+        new_sess, next_turn, terminal, directives = step_advance(session, response, current_turn_type=TurnType.SINGLE_SELECT)
+        assert new_sess is session  # same object — no state change
+        assert next_turn is None
+        assert terminal is None
+        assert directives == []

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -1,0 +1,114 @@
+"""Tests for guided-mode state machine dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from elspeth.web.composer.guided.protocol import GuidedStep, TurnType
+from elspeth.web.composer.guided.state_machine import (
+    GuidedSession,
+    TerminalKind,
+    TerminalReason,
+    TerminalState,
+    TurnRecord,
+)
+
+
+class TestTerminalState:
+    def test_completed_kind_has_no_reason(self) -> None:
+        ts = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
+        assert ts.kind == TerminalKind.COMPLETED
+        assert ts.reason is None
+
+    def test_exited_to_freeform_requires_reason(self) -> None:
+        ts = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=TerminalReason.USER_CHOSE_FREEFORM,
+        )
+        assert ts.kind == TerminalKind.EXITED_TO_FREEFORM
+        assert ts.reason == TerminalReason.USER_CHOSE_FREEFORM
+
+    def test_terminal_state_is_frozen(self) -> None:
+        ts = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
+        with pytest.raises(AttributeError):
+            ts.kind = TerminalKind.EXITED_TO_FREEFORM  # type: ignore[misc]
+
+
+class TestTurnRecord:
+    def test_turn_record_carries_emitted_and_response(self) -> None:
+        from elspeth.web.composer.guided.protocol import Turn, TurnResponse
+
+        turn: Turn = {
+            "type": TurnType.SINGLE_SELECT,
+            "step_index": 0,
+            "payload": {
+                "question": "Choose a plugin",
+                "options": [{"id": "csv", "label": "CSV", "hint": None}],
+                "allow_custom": False,
+            },
+        }
+        response: TurnResponse = {
+            "chosen": ["csv"],
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        rec = TurnRecord(turn=turn, response=response)
+        assert rec.turn == turn
+        assert rec.response == response
+
+    def test_turn_record_frozen(self) -> None:
+        from elspeth.web.composer.guided.protocol import Turn, TurnResponse
+
+        turn: Turn = {
+            "type": TurnType.SINGLE_SELECT,
+            "step_index": 0,
+            "payload": {
+                "question": "Choose a plugin",
+                "options": [{"id": "csv", "label": "CSV", "hint": None}],
+                "allow_custom": False,
+            },
+        }
+        response: TurnResponse = {
+            "chosen": ["csv"],
+            "edited_values": None,
+            "custom_inputs": None,
+            "accepted_step_index": None,
+            "edit_step_index": None,
+            "control_signal": None,
+        }
+        rec = TurnRecord(turn=turn, response=response)
+        with pytest.raises(AttributeError):
+            rec.turn = turn  # type: ignore[misc]
+
+
+class TestGuidedSession:
+    def test_initial_session_at_step_1(self) -> None:
+        sess = GuidedSession.initial()
+        assert sess.step == GuidedStep.STEP_1_SOURCE
+        assert sess.history == ()
+        assert sess.step_1_result is None
+        assert sess.step_2_result is None
+        assert sess.step_3_proposal is None
+        assert sess.terminal is None
+
+    def test_session_history_is_immutable_tuple(self) -> None:
+        sess = GuidedSession.initial()
+        assert isinstance(sess.history, tuple)
+        with pytest.raises(AttributeError):
+            sess.history = ()  # type: ignore[misc]
+
+    def test_session_with_terminal_set(self) -> None:
+        term = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
+        sess = GuidedSession(
+            step=GuidedStep.STEP_3_TRANSFORMS,
+            history=(),
+            step_1_result=None,
+            step_2_result=None,
+            step_3_proposal=None,
+            terminal=term,
+        )
+        assert sess.terminal is term
+        assert sess.terminal.kind == TerminalKind.COMPLETED

--- a/tests/unit/web/composer/guided/test_state_machine.py
+++ b/tests/unit/web/composer/guided/test_state_machine.py
@@ -1,4 +1,5 @@
-"""Tests for guided-mode state machine dataclasses."""
+# tests/unit/web/composer/guided/test_state_machine.py
+"""Tests for GuidedSession, TerminalState, TurnRecord — state machine data."""
 
 from __future__ import annotations
 
@@ -16,99 +17,67 @@ from elspeth.web.composer.guided.state_machine import (
 
 class TestTerminalState:
     def test_completed_kind_has_no_reason(self) -> None:
-        ts = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
-        assert ts.kind == TerminalKind.COMPLETED
-        assert ts.reason is None
+        t = TerminalState(kind=TerminalKind.COMPLETED, reason=None, pipeline_yaml="pipeline:\n")
+        assert t.kind is TerminalKind.COMPLETED
+        assert t.reason is None
 
     def test_exited_to_freeform_requires_reason(self) -> None:
-        ts = TerminalState(
+        t = TerminalState(
             kind=TerminalKind.EXITED_TO_FREEFORM,
-            reason=TerminalReason.USER_CHOSE_FREEFORM,
+            reason=TerminalReason.USER_PRESSED_EXIT,
+            pipeline_yaml=None,
         )
-        assert ts.kind == TerminalKind.EXITED_TO_FREEFORM
-        assert ts.reason == TerminalReason.USER_CHOSE_FREEFORM
+        assert t.reason is TerminalReason.USER_PRESSED_EXIT
 
     def test_terminal_state_is_frozen(self) -> None:
-        ts = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
+        t = TerminalState(kind=TerminalKind.COMPLETED, reason=None, pipeline_yaml=None)
         with pytest.raises(AttributeError):
-            ts.kind = TerminalKind.EXITED_TO_FREEFORM  # type: ignore[misc]
+            t.kind = TerminalKind.EXITED_TO_FREEFORM  # type: ignore[misc]
 
 
 class TestTurnRecord:
     def test_turn_record_carries_emitted_and_response(self) -> None:
-        from elspeth.web.composer.guided.protocol import Turn, TurnResponse
-
-        turn: Turn = {
-            "type": TurnType.SINGLE_SELECT,
-            "step_index": 0,
-            "payload": {
-                "question": "Choose a plugin",
-                "options": [{"id": "csv", "label": "CSV", "hint": None}],
-                "allow_custom": False,
-            },
-        }
-        response: TurnResponse = {
-            "chosen": ["csv"],
-            "edited_values": None,
-            "custom_inputs": None,
-            "accepted_step_index": None,
-            "edit_step_index": None,
-            "control_signal": None,
-        }
-        rec = TurnRecord(turn=turn, response=response)
-        assert rec.turn == turn
-        assert rec.response == response
+        rec = TurnRecord(
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.SINGLE_SELECT,
+            payload_hash="abc123",
+            response_hash="def456",
+            emitter="server",
+        )
+        assert rec.emitter == "server"
 
     def test_turn_record_frozen(self) -> None:
-        from elspeth.web.composer.guided.protocol import Turn, TurnResponse
-
-        turn: Turn = {
-            "type": TurnType.SINGLE_SELECT,
-            "step_index": 0,
-            "payload": {
-                "question": "Choose a plugin",
-                "options": [{"id": "csv", "label": "CSV", "hint": None}],
-                "allow_custom": False,
-            },
-        }
-        response: TurnResponse = {
-            "chosen": ["csv"],
-            "edited_values": None,
-            "custom_inputs": None,
-            "accepted_step_index": None,
-            "edit_step_index": None,
-            "control_signal": None,
-        }
-        rec = TurnRecord(turn=turn, response=response)
+        rec = TurnRecord(
+            step=GuidedStep.STEP_1_SOURCE,
+            turn_type=TurnType.SINGLE_SELECT,
+            payload_hash="abc",
+            response_hash=None,
+            emitter="server",
+        )
         with pytest.raises(AttributeError):
-            rec.turn = turn  # type: ignore[misc]
+            rec.emitter = "llm"  # type: ignore[misc]
 
 
 class TestGuidedSession:
     def test_initial_session_at_step_1(self) -> None:
-        sess = GuidedSession.initial()
-        assert sess.step == GuidedStep.STEP_1_SOURCE
-        assert sess.history == ()
-        assert sess.step_1_result is None
-        assert sess.step_2_result is None
-        assert sess.step_3_proposal is None
-        assert sess.terminal is None
+        s = GuidedSession.initial()
+        assert s.step is GuidedStep.STEP_1_SOURCE
+        assert s.terminal is None
+        assert s.history == ()
 
     def test_session_history_is_immutable_tuple(self) -> None:
-        sess = GuidedSession.initial()
-        assert isinstance(sess.history, tuple)
+        s = GuidedSession.initial()
         with pytest.raises(AttributeError):
-            sess.history = ()  # type: ignore[misc]
+            s.history.append(None)  # type: ignore[attr-defined]
 
     def test_session_with_terminal_set(self) -> None:
-        term = TerminalState(kind=TerminalKind.COMPLETED, reason=None)
-        sess = GuidedSession(
+        s = GuidedSession(
             step=GuidedStep.STEP_3_TRANSFORMS,
+            terminal=TerminalState(kind=TerminalKind.COMPLETED, reason=None, pipeline_yaml="x:\n"),
             history=(),
             step_1_result=None,
             step_2_result=None,
             step_3_proposal=None,
-            terminal=term,
         )
-        assert sess.terminal is term
-        assert sess.terminal.kind == TerminalKind.COMPLETED
+        assert s.terminal is not None
+        assert s.terminal.kind is TerminalKind.COMPLETED

--- a/tests/unit/web/composer/test_prompts.py
+++ b/tests/unit/web/composer/test_prompts.py
@@ -18,6 +18,7 @@ from typing import Any
 from elspeth.contracts.freeze import deep_freeze
 from elspeth.web.catalog.protocol import CatalogService, PluginKind
 from elspeth.web.catalog.schemas import PluginSchemaInfo, PluginSummary
+from elspeth.web.composer.guided.state_machine import TerminalKind, TerminalReason, TerminalState
 from elspeth.web.composer.prompts import (
     SYSTEM_PROMPT,
     build_context_string,
@@ -369,6 +370,133 @@ def _blob_source_state(
         metadata=PipelineMetadata(),
         version=1,
     )
+
+
+def _completed_terminal() -> TerminalState:
+    """A COMPLETED TerminalState (no reason required)."""
+    return TerminalState(kind=TerminalKind.COMPLETED, reason=None, pipeline_yaml=None)
+
+
+def _exited_terminal(reason: TerminalReason = TerminalReason.USER_PRESSED_EXIT) -> TerminalState:
+    """An EXITED_TO_FREEFORM TerminalState with a reason."""
+    return TerminalState(kind=TerminalKind.EXITED_TO_FREEFORM, reason=reason, pipeline_yaml=None)
+
+
+class TestBuildMessagesGuidedTerminal:
+    """Integration tests: build_messages with guided_terminal set.
+
+    Verifies Codex #17: the first freeform turn after a guided exit carries the
+    same deployment overlay and advisor-strip as subsequent freeform turns.
+    """
+
+    def test_guided_terminal_with_data_dir_includes_deployment_overlay(self, tmp_path: Path) -> None:
+        """deployment overlay content must appear in the transition prompt system message."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        deployment_content = "# Codex17 Deployment Overlay\n"
+        (skills_dir / "pipeline_composer.md").write_text(deployment_content)
+
+        state = _empty_state()
+        catalog = _stub_catalog()
+
+        messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            data_dir=str(tmp_path),
+            guided_terminal=_completed_terminal(),
+        )
+
+        system_content = messages[0]["content"]
+        assert deployment_content.strip() in system_content, "Deployment overlay missing from guided-terminal transition prompt (Codex #17)"
+
+    def test_guided_terminal_advisor_disabled_strips_advisor_content(self) -> None:
+        """When advisor_enabled=False, advisor-specific content must be absent from the transition prompt."""
+        state = _empty_state()
+        catalog = _stub_catalog()
+
+        messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            advisor_enabled=False,
+            guided_terminal=_completed_terminal(),
+        )
+
+        system_content = messages[0]["content"]
+        # The advisor subsection heading that _strip_advisor_content removes.
+        assert "#### When You Are Still Stuck" not in system_content, (
+            "Advisor subsection must be stripped when advisor_enabled=False (Codex #17)"
+        )
+        # The advisor tool name token that _strip_advisor_content removes.
+        assert ", `request_advisor_hint`" not in system_content, (
+            "Advisor tool token must be stripped when advisor_enabled=False (Codex #17)"
+        )
+
+    def test_guided_terminal_advisor_enabled_retains_advisor_content(self) -> None:
+        """When advisor_enabled=True (default), advisor sections must remain in the transition prompt."""
+        state = _empty_state()
+        catalog = _stub_catalog()
+
+        messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            advisor_enabled=True,
+            guided_terminal=_completed_terminal(),
+        )
+
+        system_content = messages[0]["content"]
+        # At least one of the two advisor-specific markers must survive.
+        has_advisor_section = "#### When You Are Still Stuck" in system_content
+        has_advisor_token = "request_advisor_hint" in system_content
+        assert has_advisor_section or has_advisor_token, "Advisor content must be present when advisor_enabled=True"
+
+    def test_guided_terminal_no_data_dir_matches_non_transition_core_skill(self) -> None:
+        """Without data_dir the transition prompt freeform layer equals the standard system prompt."""
+        state = _empty_state()
+        catalog = _stub_catalog()
+
+        transition_messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            data_dir=None,
+            guided_terminal=_completed_terminal(),
+        )
+        normal_messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            data_dir=None,
+        )
+
+        # The normal freeform system content (SYSTEM_PROMPT) must be a substring
+        # of the transition prompt — the transition prompt wraps it.
+        normal_system = normal_messages[0]["content"]
+        transition_system = transition_messages[0]["content"]
+        assert normal_system in transition_system, "Transition prompt must embed the standard freeform system prompt as its final layer"
+
+    def test_guided_terminal_exited_uses_reason_value(self) -> None:
+        """EXITED_TO_FREEFORM terminal embeds the reason token in the transition prompt."""
+        state = _empty_state()
+        catalog = _stub_catalog()
+
+        messages = build_messages(
+            [],
+            state,
+            "continue",
+            catalog,
+            guided_terminal=_exited_terminal(TerminalReason.SOLVER_EXHAUSTED),
+        )
+
+        system_content = messages[0]["content"]
+        assert "solver_exhausted" in system_content
 
 
 class TestBuildContextStringRedaction:

--- a/tests/unit/web/composer/test_prompts.py
+++ b/tests/unit/web/composer/test_prompts.py
@@ -15,9 +15,12 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from elspeth.contracts.freeze import deep_freeze
 from elspeth.web.catalog.protocol import CatalogService, PluginKind
 from elspeth.web.catalog.schemas import PluginSchemaInfo, PluginSummary
+from elspeth.web.composer.guided.errors import InvariantError
 from elspeth.web.composer.guided.state_machine import TerminalKind, TerminalReason, TerminalState
 from elspeth.web.composer.prompts import (
     SYSTEM_PROMPT,
@@ -497,6 +500,60 @@ class TestBuildMessagesGuidedTerminal:
 
         system_content = messages[0]["content"]
         assert "solver_exhausted" in system_content
+
+    def test_guided_terminal_exited_without_reason_raises_invariant_error_no_leak(self) -> None:
+        """obs-ae69e10e00 regression: an EXITED_TO_FREEFORM TerminalState with
+        ``reason=None`` violates the TerminalState invariant.  build_messages must:
+
+        1. Raise ``InvariantError`` (server-bug sentinel routed through the
+           B1-sanitized 500 handler at routes.py:3252 / 3764), NOT
+           ``RuntimeError`` (which would land at FastAPI's default 500 and
+           bypass the slog event + _safe_frame_strings capture).
+        2. NOT embed ``pipeline_yaml`` or other TerminalState repr content in
+           the exception message — same Tier-1 leak vector that B1
+           (commit eb30f669) and I1 (commit ba424ad9) sanitized at
+           routes.py:4634/4696.  The PR-introduced ``{guided_terminal!r}``
+           formatter would have leaked source paths, plugin options, and
+           secret references via the exception message into any handler that
+           reads ``str(exc)`` (e.g., FastAPI default 500 surfacing).
+        """
+        state = _empty_state()
+        catalog = _stub_catalog()
+        # Construct an invalid TerminalState directly — bypass the step_advance
+        # invariant that would normally prevent this combination.  Sentinel
+        # strings in pipeline_yaml pin the no-leak assertion: if the {!r}
+        # interpolation regresses, the assertion fires.
+        sentinel_yaml = "source:\n  options:\n    secret_ref: env://LEAKED_SECRET_SENTINEL_AE69E10E00\n"
+        bad_terminal = TerminalState(
+            kind=TerminalKind.EXITED_TO_FREEFORM,
+            reason=None,
+            pipeline_yaml=sentinel_yaml,
+        )
+
+        with pytest.raises(InvariantError) as exc_info:
+            build_messages(
+                [],
+                state,
+                "continue",
+                catalog,
+                guided_terminal=bad_terminal,
+            )
+
+        # Class swap pin (B1 conformance): InvariantError is the project
+        # sentinel for server-side invariant violations; the route handler
+        # dispatches on this exact class.
+        assert type(exc_info.value) is InvariantError
+
+        # No-leak pin (load-bearing security assertion): the corrupted
+        # value's repr must not appear in the exception message.  Without
+        # this assertion the {!r}-leak regression would silently re-land.
+        exc_message = str(exc_info.value)
+        assert "LEAKED_SECRET_SENTINEL_AE69E10E00" not in exc_message
+        assert "pipeline_yaml" not in exc_message
+        assert "secret_ref" not in exc_message
+        assert sentinel_yaml not in exc_message
+        # Invariant name is preserved for diagnostic value.
+        assert "EXITED_TO_FREEFORM" in exc_message
 
 
 class TestBuildContextStringRedaction:

--- a/tests/unit/web/sessions/test_routes.py
+++ b/tests/unit/web/sessions/test_routes.py
@@ -1061,6 +1061,8 @@ class TestIDORCoverageDrift:
             "revert_state",
             "get_state_yaml",
             "fork_from_message",
+            "get_guided",
+            "post_guided_respond",
         }
     )
 
@@ -1214,6 +1216,8 @@ class TestIDORProtection:
     - ``POST /{session_id}/state/revert``    (revert_state)
     - ``GET  /{session_id}/state/yaml``      (get_state_yaml)
     - ``POST /{session_id}/fork``            (fork_from_message)
+    - ``GET  /{session_id}/guided``          (get_guided)
+    - ``POST /{session_id}/guided/respond``  (post_guided_respond)
 
     Counter-test: alice's own access continues to return 200 at the end,
     guarding against the regression where an over-eager 404 breaks
@@ -1338,6 +1342,26 @@ class TestIDORProtection:
                 "from_message_id": str(uuid.uuid4()),
                 "new_message_content": "hijacked",
             },
+        )
+        assert resp.status_code == 404
+
+        # Bob tries to GET guided state -- should be 404.  The guided
+        # endpoint reveals wizard step, history, and pending turn payloads.
+        # An ownership bypass would let an attacker read Alice's pipeline
+        # wizard state without authorization.  The ownership check in
+        # ``get_guided`` runs before the compose lock or catalog access.
+        resp = bob_client.get(f"/api/sessions/{session_id}/guided")
+        assert resp.status_code == 404
+
+        # Bob tries to POST guided/respond — should be 404.  The respond
+        # endpoint can mutate pipeline state by driving step handlers.
+        # An ownership bypass would let an attacker submit guided responses
+        # against Alice's session and corrupt her pipeline state.  The
+        # ownership check in ``post_guided_respond`` runs before any state
+        # load or dispatch.
+        resp = bob_client.post(
+            f"/api/sessions/{session_id}/guided/respond",
+            json={"control_signal": "exit_to_freeform"},
         )
         assert resp.status_code == 404
 

--- a/tests/unit/web/sessions/test_routes.py
+++ b/tests/unit/web/sessions/test_routes.py
@@ -167,8 +167,9 @@ class _BlockingRecordingComposer:
         session_id: str | None = None,
         user_id: str | None = None,
         progress=None,
+        guided_terminal=None,
     ) -> ComposerResult:
-        del state, session_id, user_id, progress
+        del state, session_id, user_id, progress, guided_terminal
 
         self.calls.append(
             {
@@ -204,8 +205,9 @@ class _ProgressAwareComposer:
         session_id: str | None = None,
         user_id: str | None = None,
         progress=None,
+        guided_terminal=None,
     ) -> ComposerResult:
-        del message, chat_messages, session_id, user_id
+        del message, chat_messages, session_id, user_id, guided_terminal
         assert progress is not None, "session routes must pass a composer progress sink"
         self.progress_sink_seen = True
         await progress(


### PR DESCRIPTION
## Summary

This umbrella PR delivers the **Composer Guided Mode** feature end-to-end across ten phases of work (87 commits on `feat/composer-guided-mode`). Guided mode is a structured-protocol wizard that lets first-time pipeline authors build a working ELSPETH pipeline in three steps (source → sink → transforms), with a deterministic recipe pre-match at Step 2.5 that can complete a CSV-classification pipeline in nine clicks without ever invoking the LLM.

The implementation ships alongside the unmodified freeform composer; mode transitions use progressive disclosure. The LLM is read-only with respect to pipeline state — only typed turn responses (from the closed six-turn taxonomy) mutate composition state.

**Demo SLA — verified GREEN:** `tests/e2e/composer-guided.spec.ts` passes at **9 clicks / 3.5s** (budget: ≤9 / <30s).

## Phase-by-phase commit map

| Phase | Range | Title | Commits |
|---|---|---|---|
| 1 | `88c754dd..f7e29fc4` | Protocol + state machine | 7 (+ 1 plan typo fix) |
| 2 | `4a192ef3..5b28fed4` | `step_advance` dispatcher + recipe matcher + integration fixtures | 9 |
| 3 | `5eb1f735..795477d2` | HTTP endpoints + step handlers + default-guided | 7 |
| 4 | `e0217edc..89286d0d` | LLM chain solver + Step 3 wiring | 5 |
| 5 | `8c132210..8c0f7527` | Auto-drop to freeform + progressive disclosure + audit emission | 7 |
| 6 | `80bee5dd..cc074420` | Frontend foundation (types + API client + sessionStore) | 6 |
| 7 | `6703e47d..acf712d2` | Frontend widgets (6 leaf widgets + dispatcher + peer components) | 20 |
| 8 | `a46f05c9..cdee530f` | ChatPanel mode discriminator + spec §7.4 a11y pass | 5 |
| 9 | `2b692cab..888624d8` | Integration bugs at the seams + recipe-match E2E (5 bugs fixed in-session) | 8 |
| 10 | `c7cb7ee9..05ace416` | Gap 6 (RecipeOfferTurn editable slots) + un-fixme demo SLA + user docs + close handover | 4 |

Plan + handovers are at `docs/superpowers/plans/2026-05-11-composer-guided-mode.md` and `docs/superpowers/handovers/2026-05-12-phase-*-complete.md` (Phases 5, 6, 7, 8, 9, 10).

## Spec + design reference

- **Spec:** `docs/superpowers/specs/2026-05-11-composer-guided-mode-design.md` — wire protocol (§4), legal-turn matrix, step-by-step contract.
- **User manual:** `docs/guides/user-manual.md` — new "Web Composer: Guided Mode" section added in Phase 10.
- **Troubleshooting:** `docs/guides/troubleshooting.md` — three new entries (auto-drop, schema mismatch, recipe didn't appear).
- **CHANGELOG:** `[Unreleased]` section at top of `CHANGELOG.md` with the verbatim feature entry.

## ⚠️ DB migration note

**This PR requires deleting your sessions DB before running the branch.** Phase 9 added a `step_2_sink_intent` field to `GuidedSession` with strict `from_dict`; pre-Phase-9 sessions are not forward-compatible. Phase 10 added `unsatisfied_slots` to `RecipeOfferPayload` — same trust-tier rule (Tier-1 internal state, crash on schema anomaly, no compatibility shims).

The project's stated migration policy (`project_db_migration_policy` memory) is: **delete the old DB, no Alembic migrations on session/audit data, no schema-version probes.** This is intentional.

## Demo SLA verification

The recipe-match happy path (CSV → `classify-rows-llm-jsonl` → JSON) is verified end-to-end via `tests/e2e/composer-guided.spec.ts`:

- **Click budget:** ≤9 user clicks (actual: 9 — exactly at the threshold).
- **Wall-clock:** <30s (actual: 3.5s).
- **LLM calls:** 0 (the recipe-match path is fully deterministic).

The spec is one of four passing E2E specs in the composer-guided suite (4 passed / 9 skipped at PR-open).

## Open observations the PR does NOT close

These were carried forward from Phase 9 and are surfaced here so the merge reviewer doesn't think they were missed. Each is a refinement, not a defect:

- `elspeth-obs-134474dfcb` (P2) — InspectAndConfirmTurn unreachable on the live emission path. Cosmetic UX gap; polish phase.
- `elspeth-obs-83d97315a7` (P3) — `forkFromMessage` doesn't restart guided state for the new session. Edge case in session-fork flows.
- `elspeth-obs-a076365f64` (P3) — test-file fixture extraction. Cosmetic.
- `elspeth-obs-510a4fbdeb` — TurnPayload discriminated-union refactor. No urgency.
- `elspeth-obs-f9e991f517` — `useNonInitialEffect` hook extraction. No urgency.
- `elspeth-611fc01d94` — GuidedHistory rich step summaries (Phase 7 follow-up). Cosmetic.
- `elspeth-2c08408170` — Step-3 backend handler completion. Gates a future hand-built-path E2E (Task 9.2).
- `elspeth-obs-06854f0842` (P3) — \`RecipeMatch\` lifecycle ambiguity at apply-time reconstruction (filed in this phase by the code-quality reviewer; comment-only safety net today).

## Deferred to a future phase

Per Phase 9 close, the following are explicitly out of this umbrella PR's scope and inherit to a polish or Phase 11:

- **Task 9.2 — Hand-built path (LLM-driven Step 3) E2E.** Hard-blocked on \`elspeth-2c08408170\`.
- **Task 9.3 — Auto-drop path E2E.** Failure-path coverage, not demo-anchor.
- **ChaosLLM Playwright fixture.** Required by 9.2 + 9.3; not built.

Phase 10's deliverable was *demo SLA assertion green + umbrella PR opens for review* — none of these blocks that outcome.

## Test plan

- [ ] Local: `git checkout feat/composer-guided-mode && rm -rf .e2e-data sessions.db audit.db && uv pip install -e ".[all]"` to refresh the env.
- [ ] Local: `.venv/bin/python -m pytest tests/ -q` — should be green.
- [ ] Local: `.venv/bin/python -m mypy src/` — should report 0 issues across 391 source files.
- [ ] Local: `.venv/bin/python scripts/cicd/enforce_tier_model.py check --root src/elspeth --allowlist config/cicd/enforce_tier_model` — should pass.
- [ ] Local: `cd src/elspeth/web/frontend && npm test -- --run` — should report 427 passed.
- [ ] Local: `cd src/elspeth/web/frontend && npx tsc -p tsconfig.app.json --noEmit` — should be clean.
- [ ] Local: `cd src/elspeth/web/frontend && npx playwright test composer-guided` — should report 4 passed / 9 skipped.
- [ ] Demo walk-through: create a new session in the web composer, upload a small CSV (e.g., \`id,name,value\n1,widget,42\n\`), click \"csv\" → fill source schema-form → click \"json\" → fill sink schema-form → add a required field with a classifier-keyword (e.g., \"category\") → fill in classifier_template / model / api_key_secret on the recipe_offer → Apply recipe → Save and exit. Should complete in 9 clicks with zero LLM round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)