### PR TITLE
🧹 Replace print statement with stdout.write in prompt_drafter.py

### DIFF
--- a/evals/lib/prompt_drafter.py
+++ b/evals/lib/prompt_drafter.py
@@ -5,7 +5,7 @@ produce the natural-language opening message that persona would type to
 ask the composer to build the workflow this YAML describes.
 
 Why this exists (not just hand-author every prompt):
-  * 33 examples × 2-4 personas = 66-132 opening prompts. Hand-authoring is
+  * 33 examples x 2-4 personas = 66-132 opening prompts. Hand-authoring is
     16-33 hours of writing work the operator confirmed is too costly.
   * LLM drafting from settings.yaml + persona spec produces in-character
     asks at ~$0.001 per draft. Operator spot-checks smoke cohort,
@@ -195,14 +195,12 @@ def _strip_chrome(text: str) -> str:
     if fence_match:
         text = fence_match.group(1).strip()
     # Wrapping double-quotes
-    if (text.startswith('"') and text.endswith('"')) or (
-        text.startswith("“") and text.endswith("”")
-    ):
+    if (text.startswith('"') and text.endswith('"')) or (text.startswith("“") and text.endswith("”")):
         text = text[1:-1].strip()
     # Common preamble patterns
     for prefix in ("Here is the message:", "Opening message:", "Message:"):
         if text.lower().startswith(prefix.lower()):
-            text = text[len(prefix):].strip()
+            text = text[len(prefix) :].strip()
     return text
 
 
@@ -229,10 +227,7 @@ def draft_opening_prompt(
     """
     detected = _detect_provider()
     if detected is None:
-        raise DrafterError(
-            "no OPENROUTER_API_KEY or ANTHROPIC_API_KEY in env — "
-            "cannot draft opening prompt without an LLM call"
-        )
+        raise DrafterError("no OPENROUTER_API_KEY or ANTHROPIC_API_KEY in env — cannot draft opening prompt without an LLM call")
     provider, api_key = detected
     system = SYSTEM_PROMPT
     user = _build_user_prompt(persona_spec, settings_yaml, example_name)
@@ -247,11 +242,9 @@ def draft_opening_prompt(
             return _strip_chrome(raw)
         except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
             last_err = exc
-            sys.stderr.write(
-                f"prompt_drafter: API attempt {attempt} failed: {exc}\n"
-            )
+            sys.stderr.write(f"prompt_drafter: API attempt {attempt} failed: {exc}\n")
             if attempt < max_tries:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
     raise DrafterError(f"API failed after {max_tries} attempts: {last_err}")
 
 
@@ -262,9 +255,7 @@ def draft_opening_prompt(
 
 def _main(argv: list[str]) -> int:
     if len(argv) != 3 or argv[1] in {"-h", "--help"}:
-        sys.stderr.write(
-            "usage: python -m evals.lib.prompt_drafter <persona_spec_md> <settings_yaml>\n"
-        )
+        sys.stderr.write("usage: python -m evals.lib.prompt_drafter <persona_spec_md> <settings_yaml>\n")
         return 64
     persona_path = pathlib.Path(argv[1])
     settings_path = pathlib.Path(argv[2])
@@ -282,7 +273,7 @@ def _main(argv: list[str]) -> int:
     except DrafterError as exc:
         sys.stderr.write(f"drafter error: {exc}\n")
         return 71
-    print(msg)
+    sys.stdout.write(f"{msg}\n")
     return 0
 
 


### PR DESCRIPTION
🎯 **What:** Replaced the `print(msg)` statement with `sys.stdout.write(f"{msg}\n")` in the `_main` entrypoint of `evals/lib/prompt_drafter.py`. Also addressed a preexisting lint issue (replacing `×` with `x`).
💡 **Why:** This improves maintainability and code consistency by ensuring standard output and standard error mechanisms (`sys.stdout.write` and `sys.stderr.write`) are used symmetrically in the CLI logic.
✅ **Verification:** Verified that tests pass (e.g. `uv run pytest tests/unit/web/composer/test_prompts.py`) and that formatting and linting pass (`uv run ruff check` and `uv run ruff format`). Code review also passed.
✨ **Result:** A slightly cleaner and more explicit module entrypoint without modifying expected CLI behavior.

---
*PR created automatically by Jules for task [975140858160978740](https://jules.google.com/task/975140858160978740) started by @tachyon-beep*