### PR TITLE
fix(plugins): fingerprint sensitive HTTP query parameters in audit trail

### DIFF
--- a/src/elspeth/plugins/infrastructure/clients/fingerprinting.py
+++ b/src/elspeth/plugins/infrastructure/clients/fingerprinting.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from elspeth.contracts.errors import FrameworkBugError
 
@@ -156,3 +159,117 @@ def filter_response_headers(headers: dict[str, str]) -> dict[str, str]:
         Headers dict with sensitive headers removed
     """
     return {k: v for k, v in headers.items() if not is_sensitive_header(k)}
+
+
+def is_sensitive_query_param(param_name: str) -> bool:
+    """Check if a query parameter name indicates sensitive content.
+
+    Checks exact match lists and word boundary patterns similar to headers.
+    """
+    lower_name = param_name.lower()
+    if lower_name in SENSITIVE_HEADERS_EXACT:
+        return True
+    segments = [seg for seg in re.split(r"[^a-z0-9]+", lower_name) if seg]
+    if any(seg in SENSITIVE_HEADER_WORDS for seg in segments):
+        return True
+    # Support common abbreviations in query parameters
+    additional_sensitive_words = {"sig", "signature", "pwd", "pass", "sid"}
+    return any(seg in additional_sensitive_words for seg in segments)
+
+
+def fingerprint_params(params: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Fingerprint sensitive query parameters for audit recording.
+
+    Sensitive parameters (auth, api keys, tokens, signatures) are replaced
+    with HMAC fingerprints so that:
+    1. Raw secrets are NEVER stored in the audit trail
+    2. Different credentials produce different fingerprints
+    3. Replay/verify can distinguish requests by credential identity
+
+    In dev mode (ELSPETH_ALLOW_RAW_SECRETS=true), sensitive parameters are
+    removed entirely (no fingerprint key required).
+    """
+    if params is None:
+        return None
+
+    from elspeth.core.security import get_fingerprint_key, secret_fingerprint
+
+    allow_raw = os.environ.get("ELSPETH_ALLOW_RAW_SECRETS", "").lower() == "true"
+
+    try:
+        get_fingerprint_key()
+        have_key = True
+    except ValueError:
+        have_key = False
+
+    result: dict[str, Any] = {}
+
+    for k, v in params.items():
+        if is_sensitive_query_param(k):
+            if allow_raw:
+                # Dev mode: remove query parameter
+                pass
+            elif have_key:
+                # Fingerprint the sensitive value (convert value to str for hashing)
+                fp = secret_fingerprint(str(v))
+                result[k] = f"<fingerprint:{fp}>"
+            else:
+                raise FrameworkBugError(
+                    f"Sensitive query parameter '{k}' cannot be fingerprinted: "
+                    f"ELSPETH_FINGERPRINT_KEY is not set and ELSPETH_ALLOW_RAW_SECRETS is not 'true'. "
+                    f"Authenticated HTTP calls require a fingerprint key for audit integrity. "
+                    f"Set ELSPETH_FINGERPRINT_KEY or ELSPETH_ALLOW_RAW_SECRETS=true for dev mode."
+                )
+        else:
+            result[k] = v
+
+    return result
+
+
+def fingerprint_url(url: str) -> str:
+    """Fingerprint sensitive query parameters inside a URL string for audit recording."""
+    if not url:
+        return url
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+
+    if not parsed.query:
+        return url
+
+    from elspeth.core.security import get_fingerprint_key, secret_fingerprint
+
+    allow_raw = os.environ.get("ELSPETH_ALLOW_RAW_SECRETS", "").lower() == "true"
+
+    try:
+        get_fingerprint_key()
+        have_key = True
+    except ValueError:
+        have_key = False
+
+    query_params = parse_qsl(parsed.query, keep_blank_values=True)
+    fingerprinted_qsl = []
+
+    for k, v in query_params:
+        if is_sensitive_query_param(k):
+            if allow_raw:
+                # Dev mode: remove parameter
+                continue
+            elif have_key:
+                fp = secret_fingerprint(v)
+                fingerprinted_qsl.append((k, f"<fingerprint:{fp}>"))
+            else:
+                raise FrameworkBugError(
+                    f"Sensitive URL query parameter '{k}' cannot be fingerprinted: "
+                    f"ELSPETH_FINGERPRINT_KEY is not set and ELSPETH_ALLOW_RAW_SECRETS is not 'true'. "
+                    f"Authenticated HTTP calls require a fingerprint key for audit integrity. "
+                    f"Set ELSPETH_FINGERPRINT_KEY or ELSPETH_ALLOW_RAW_SECRETS=true for dev mode."
+                )
+        else:
+            fingerprinted_qsl.append((k, v))
+
+    new_query = urlencode(fingerprinted_qsl)
+    new_parsed = parsed._replace(query=new_query)
+    return urlunparse(new_parsed)

--- a/src/elspeth/plugins/infrastructure/clients/http.py
+++ b/src/elspeth/plugins/infrastructure/clients/http.py
@@ -33,6 +33,12 @@ from elspeth.plugins.infrastructure.clients.fingerprinting import (
     fingerprint_headers as _fingerprint_headers,
 )
 from elspeth.plugins.infrastructure.clients.fingerprinting import (
+    fingerprint_params as _fingerprint_params,
+)
+from elspeth.plugins.infrastructure.clients.fingerprinting import (
+    fingerprint_url as _fingerprint_url,
+)
+from elspeth.plugins.infrastructure.clients.fingerprinting import (
     is_sensitive_header as _is_sensitive_header_fn,
 )
 from elspeth.plugins.infrastructure.clients.json_utils import parse_json_strict as _parse_json_strict
@@ -353,10 +359,10 @@ class AuditedHTTPClient(AuditedClientBase):
         # DTO stays alive for typed telemetry payload; dict form used for Landscape hashing.
         request_dto = HTTPCallRequest(
             method=method,
-            url=full_url,
+            url=_fingerprint_url(full_url),
             headers=self._filter_request_headers(merged_headers),
             json=json,
-            params=params,
+            params=_fingerprint_params(params),
             audit_metadata=audit_request_metadata,
         )
         request_data = request_dto.to_dict()
@@ -566,7 +572,7 @@ class AuditedHTTPClient(AuditedClientBase):
         # DTO stays alive for typed telemetry payload; dict form used for Landscape hashing.
         request_dto = HTTPCallRequest(
             method="GET",
-            url=request.original_url,
+            url=_fingerprint_url(request.original_url),
             headers=self._filter_request_headers(merged_headers),
             resolved_ip=request.resolved_ip,
         )
@@ -755,10 +761,10 @@ class AuditedHTTPClient(AuditedClientBase):
 
             blocked_hop_request_dto = HTTPCallRequest(
                 method="GET",
-                url=redirect_url,
+                url=_fingerprint_url(redirect_url),
                 headers=self._filter_request_headers(hop_headers),
                 hop_number=hop_number,
-                redirect_from=redirect_from,
+                redirect_from=_fingerprint_url(redirect_from),
             )
 
             # CRITICAL: Validate the redirect target for SSRF
@@ -803,11 +809,11 @@ class AuditedHTTPClient(AuditedClientBase):
             # both success and failure paths can record the hop in the audit trail.
             hop_request_dto = HTTPCallRequest(
                 method="GET",
-                url=redirect_url,
+                url=_fingerprint_url(redirect_url),
                 headers=self._filter_request_headers(hop_headers),
                 resolved_ip=redirect_request.resolved_ip,
                 hop_number=hop_number,
-                redirect_from=redirect_from,
+                redirect_from=_fingerprint_url(redirect_from),
             )
             redirects_followed += 1
 

--- a/tests/unit/plugins/clients/test_audited_http_client.py
+++ b/tests/unit/plugins/clients/test_audited_http_client.py
@@ -1450,3 +1450,76 @@ class TestAuditedHTTPClientGet:
         assert recorded_body["_json_parse_failed"] is True
         assert "NaN" in recorded_body["_error"] or "non-finite" in recorded_body["_error"]
         assert recorded_body["_raw_text"] == json_with_nan
+
+    def test_get_with_sensitive_query_params_fingerprinted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GET with sensitive query params fingerprints params in the recorded audit request, but sends original over the wire."""
+        monkeypatch.setenv("ELSPETH_FINGERPRINT_KEY", "test-key-for-http-client")
+        monkeypatch.delenv("ELSPETH_ALLOW_RAW_SECRETS", raising=False)
+
+        mock_execution = self._create_mock_execution()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.content = b""
+
+        with patch("httpx.Client") as mock_client_class:
+            client = AuditedHTTPClient(
+                execution=mock_execution,
+                state_id="state_123",
+                run_id="run_abc",
+                telemetry_emit=lambda event: None,
+            )
+            mock_client = mock_client_class.return_value
+            mock_client.get.return_value = mock_response
+
+            client.get("https://api.example.com/search", params={"q": "hello", "api_key": "SECRET123", "non_sensitive": "val"})
+
+        # Verify raw parameters were passed to httpx (not fingerprinted)
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert call_args[1]["params"] == {"q": "hello", "api_key": "SECRET123", "non_sensitive": "val"}
+
+        # Verify sensitive parameters were fingerprinted in the audit trail
+        call_kwargs = mock_execution.record_call.call_args[1]
+        recorded_params = call_kwargs["request_data"].to_dict()["params"]
+        assert recorded_params["q"] == "hello"
+        assert recorded_params["non_sensitive"] == "val"
+        assert recorded_params["api_key"] != "SECRET123"
+        assert str(recorded_params["api_key"]).startswith("<fingerprint:")
+
+    def test_get_with_sensitive_url_query_params_fingerprinted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GET with sensitive params in URL query string fingerprints them in recorded audit request, but sends original over the wire."""
+        monkeypatch.setenv("ELSPETH_FINGERPRINT_KEY", "test-key-for-http-client")
+        monkeypatch.delenv("ELSPETH_ALLOW_RAW_SECRETS", raising=False)
+
+        mock_execution = self._create_mock_execution()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.content = b""
+
+        with patch("httpx.Client") as mock_client_class:
+            client = AuditedHTTPClient(
+                execution=mock_execution,
+                state_id="state_123",
+                run_id="run_abc",
+                telemetry_emit=lambda event: None,
+            )
+            mock_client = mock_client_class.return_value
+            mock_client.get.return_value = mock_response
+
+            client.get("https://api.example.com/search?q=hello&token=SECRET_TOKEN")
+
+        # Verify raw URL was passed to httpx (not fingerprinted)
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "https://api.example.com/search?q=hello&token=SECRET_TOKEN"
+
+        # Verify sensitive parameters in URL query string were fingerprinted in the audit trail
+        call_kwargs = mock_execution.record_call.call_args[1]
+        recorded_url = call_kwargs["request_data"].to_dict()["url"]
+        assert "q=hello" in recorded_url
+        assert "token=SECRET_TOKEN" not in recorded_url
+        assert "token=%3Cfingerprint%3A" in recorded_url or "token=<fingerprint:" in recorded_url


### PR DESCRIPTION
Resolves issue elspeth-73d794a29c.

This PR ensures that sensitive query parameters (API keys, tokens, signatures) or sensitive parameter patterns embedded in URLs are HMAC-fingerprinted before saving them to the audit database via `HTTPCallRequest`, preventing credentials from leaking to the audit logs while still passing raw credentials to external services.

Summary of changes:
- Created helper functions `fingerprint_params` and `fingerprint_url` in `fingerprinting.py` using SHA256 HMAC or removing in dev mode.
- Integrated these helpers at all `HTTPCallRequest` construction boundaries in `AuditedHTTPClient` in `http.py`.
- Added unit tests in `test_audited_http_client.py` to verify outgoing vs audited payload correctness.