### PR TITLE
fix(web): prevent env var expansion after inline blob substitution

### DIFF
--- a/src/elspeth/core/config.py
+++ b/src/elspeth/core/config.py
@@ -2154,7 +2154,7 @@ def load_settings(config_path: Path) -> ElspethSettings:
     return ElspethSettings(**raw_config)
 
 
-def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
+def load_settings_from_yaml_string(yaml_content: str, *, expand_env_vars: bool = True) -> ElspethSettings:
     """Load settings from a YAML string without touching disk.
 
     This is used by the web execution service to load pipeline configs
@@ -2164,6 +2164,10 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
 
     Args:
         yaml_content: YAML configuration as a string.
+        expand_env_vars: Whether to expand ``${VAR}`` and
+            ``${VAR:-default}`` patterns from the server environment.
+            Web execution disables this after inline blob substitution so
+            user-authored blob bytes cannot resolve host secrets.
 
     Returns:
         Validated ElspethSettings instance.
@@ -2179,7 +2183,8 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
         raise ValueError(f"Unknown configuration keys: {unknown_keys}. Valid top-level keys: {sorted(known_fields)}")
 
     raw_config = {k: v for k, v in raw_config.items() if k in known_fields}
-    raw_config = _expand_env_vars(raw_config)
+    if expand_env_vars:
+        raw_config = _expand_env_vars(raw_config)
     return ElspethSettings(**raw_config)
 
 

--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -29,6 +29,7 @@ from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
 from elspeth.contracts.audit import SecretResolutionInput
+from elspeth.contracts.blobs_inline import BlobInlineRef
 from elspeth.contracts.cli import ProgressEvent
 from elspeth.contracts.enums import RunStatus
 from elspeth.contracts.errors import GracefulShutdownError
@@ -960,6 +961,7 @@ class ExecutionServiceImpl:
             resolved_yaml = pipeline_yaml
             resolved_dict: dict[str, Any] | None = None
             secret_resolution_inputs: list[SecretResolutionInput] = []
+            inline_refs: list[BlobInlineRef] = []
             inline_blob_candidate = "blob_ref" in pipeline_yaml and "inline_content" in pipeline_yaml
             needs_config_tree = (self._secret_service is not None and user_id is not None) or inline_blob_candidate
             if needs_config_tree:
@@ -1085,8 +1087,10 @@ class ExecutionServiceImpl:
 
             # Load settings from YAML string — never write resolved secrets
             # to disk.  load_settings_from_yaml_string() parses in-process,
-            # bypassing Dynaconf file I/O.
-            settings = load_settings_from_yaml_string(resolved_yaml)
+            # bypassing Dynaconf file I/O. Disable server env expansion when
+            # inline blobs were substituted: blob bytes are user-authored and
+            # must not resolve host ``${VAR}`` values after secret controls.
+            settings = load_settings_from_yaml_string(resolved_yaml, expand_env_vars=not inline_refs)
             runtime_graph = build_validated_runtime_graph(settings)
             bundle = runtime_graph.plugin_bundle
             graph = runtime_graph.graph

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -3595,6 +3595,53 @@ class TestEnvVarExpansion:
 
         assert result["prefix"] == ""
 
+    def test_load_settings_from_yaml_string_expands_env_vars_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The YAML-string loader preserves historical env expansion by default."""
+        from elspeth.core.config import load_settings_from_yaml_string
+
+        monkeypatch.setenv("INLINE_PROMPT_SECRET", "server-secret-value")
+
+        settings = load_settings_from_yaml_string(
+            """
+source:
+  plugin: csv_local
+  on_success: output
+  options:
+    prompt_template: prefix-${INLINE_PROMPT_SECRET}-suffix
+sinks:
+  output:
+    plugin: json
+    on_write_failure: discard
+    options: {}
+"""
+        )
+
+        assert settings.source.options["prompt_template"] == "prefix-server-secret-value-suffix"
+
+    def test_load_settings_from_yaml_string_can_preserve_env_syntax(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Web execution uses this opt-out after inline blob substitution."""
+        from elspeth.core.config import load_settings_from_yaml_string
+
+        monkeypatch.setenv("INLINE_PROMPT_SECRET", "server-secret-value")
+
+        settings = load_settings_from_yaml_string(
+            """
+source:
+  plugin: csv_local
+  on_success: output
+  options:
+    prompt_template: prefix-${INLINE_PROMPT_SECRET}-suffix
+sinks:
+  output:
+    plugin: json
+    on_write_failure: discard
+    options: {}
+""",
+            expand_env_vars=False,
+        )
+
+        assert settings.source.options["prompt_template"] == "prefix-${INLINE_PROMPT_SECRET}-suffix"
+
 
 class TestSinkNameCasing:
     """Sink names must be lowercase - explicit validation, no silent transformation."""

--- a/tests/unit/web/execution/test_service.py
+++ b/tests/unit/web/execution/test_service.py
@@ -928,8 +928,9 @@ class TestInlineBlobRuntimePreflight:
         cast(Any, service)._blob_service = blob_service
         mock_session_service.record_blob_inline_resolutions = AsyncMock(side_effect=record_blob_inline_resolutions)
 
-        def load_settings(yaml_text: str) -> MagicMock:
+        def load_settings(yaml_text: str, *, expand_env_vars: bool = True) -> MagicMock:
             assert "record" in order, "audit row must be recorded before settings/plugin construction"
+            assert expand_env_vars is False
             assert "You are an audited prompt." in yaml_text
             assert "blob_ref" not in yaml_text
             assert "inline_content" not in yaml_text


### PR DESCRIPTION
### Motivation

- Inline blob authoring allowed user-supplied bytes to be substituted into a YAML-shaped runtime config, and the YAML loader then unconditionally expanded `${VAR}` patterns from `os.environ`, enabling uploaded blobs to resolve server secrets at runtime.

### Description

- Add an opt-out flag `expand_env_vars: bool = True` to `load_settings_from_yaml_string()` so callers can disable `${VAR}` expansion when desired.  
- Update `ExecutionServiceImpl._run_pipeline()` to track whether inline blob bytes were substituted and call `load_settings_from_yaml_string(resolved_yaml, expand_env_vars=not inline_refs)` to disable server env expansion when inline blobs are present.  
- Add a typed `inline_refs: list[BlobInlineRef]` local and import `BlobInlineRef` to make the intent explicit.  
- Add regression tests verifying the loader still expands env vars by default and that callers can preserve literal `${VAR}` syntax via `expand_env_vars=False`, and update the inline-blob preflight test to assert the execution path calls the loader with `expand_env_vars=False` after audit recording.

### Testing

- Performed static sanity checks and byte-compile on modified files which succeeded (`python -m py_compile` for changed modules).  
- Ran a smoke script exercising `load_settings_from_yaml_string(..., expand_env_vars=...)` that verified both expansion-by-default and the opt-out behavior (passed).  
- Attempted targeted `pytest` for the modified test classes but the test run was blocked by a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`) and by network restrictions when attempting to install test deps, so full test-suite verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21deeddd5c83239067b46ce207c4ed)