### PR TITLE
fix(execution): isolate inline blob env expansion

### DIFF
--- a/src/elspeth/core/config.py
+++ b/src/elspeth/core/config.py
@@ -2154,7 +2154,18 @@ def load_settings(config_path: Path) -> ElspethSettings:
     return ElspethSettings(**raw_config)
 
 
-def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
+def expand_env_vars_in_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Expand environment variables in an operator-authored config tree.
+
+    Runtime-only values such as resolved web secrets or fetched inline blob
+    content must not be passed through this helper after substitution; those
+    values are not operator-authored YAML and may contain literal ``${...}``
+    text that must remain data, not host environment lookups.
+    """
+    return _expand_env_vars(config)
+
+
+def load_settings_from_yaml_string(yaml_content: str, *, expand_env_vars: bool = True) -> ElspethSettings:
     """Load settings from a YAML string without touching disk.
 
     This is used by the web execution service to load pipeline configs
@@ -2164,6 +2175,11 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
 
     Args:
         yaml_content: YAML configuration as a string.
+        expand_env_vars: Whether to expand ``${VAR}`` and ``${VAR:-default}``
+            placeholders in string values. Keep this enabled for
+            operator-authored YAML; disable it only after the caller has
+            already expanded the operator-authored tree and then inserted
+            runtime-only secret or blob values.
 
     Returns:
         Validated ElspethSettings instance.
@@ -2179,7 +2195,8 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
         raise ValueError(f"Unknown configuration keys: {unknown_keys}. Valid top-level keys: {sorted(known_fields)}")
 
     raw_config = {k: v for k, v in raw_config.items() if k in known_fields}
-    raw_config = _expand_env_vars(raw_config)
+    if expand_env_vars:
+        raw_config = _expand_env_vars(raw_config)
     return ElspethSettings(**raw_config)
 
 

--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -41,7 +41,7 @@ from elspeth.core.blobs_inline import (
     _fetch_blob_contents,
     _substitute_blob_content_refs,
 )
-from elspeth.core.config import load_settings_from_yaml_string
+from elspeth.core.config import expand_env_vars_in_config, load_settings_from_yaml_string
 from elspeth.core.events import EventBus
 from elspeth.core.landscape.database import LandscapeDB
 from elspeth.core.landscape.run_lifecycle_repository import is_valid_sha256_hex
@@ -960,6 +960,7 @@ class ExecutionServiceImpl:
             resolved_yaml = pipeline_yaml
             resolved_dict: dict[str, Any] | None = None
             secret_resolution_inputs: list[SecretResolutionInput] = []
+            inline_refs = []
             inline_blob_candidate = "blob_ref" in pipeline_yaml and "inline_content" in pipeline_yaml
             needs_config_tree = (self._secret_service is not None and user_id is not None) or inline_blob_candidate
             if needs_config_tree:
@@ -970,7 +971,13 @@ class ExecutionServiceImpl:
                     raise TypeError(
                         f"generate_yaml() produced non-dict YAML (got {type(config_dict).__name__}) — this is a bug in the YAML generator"
                     )
-                resolved_dict = cast(dict[str, Any], config_dict)
+                # Expand environment variables only across the operator-authored
+                # YAML tree. Runtime substitutions performed below (resolved web
+                # secrets and fetched inline blob bytes) are intentionally loaded
+                # with env expansion disabled so attacker-controlled blob text like
+                # `${OPENAI_API_KEY}` remains literal data rather than a host
+                # environment lookup.
+                resolved_dict = expand_env_vars_in_config(cast(dict[str, Any], config_dict))
 
                 if self._secret_service is not None and user_id is not None:
                     from elspeth.core.secrets import resolve_secret_refs
@@ -1086,7 +1093,10 @@ class ExecutionServiceImpl:
             # Load settings from YAML string — never write resolved secrets
             # to disk.  load_settings_from_yaml_string() parses in-process,
             # bypassing Dynaconf file I/O.
-            settings = load_settings_from_yaml_string(resolved_yaml)
+            if secret_resolution_inputs or inline_refs:
+                settings = load_settings_from_yaml_string(resolved_yaml, expand_env_vars=False)
+            else:
+                settings = load_settings_from_yaml_string(resolved_yaml)
             runtime_graph = build_validated_runtime_graph(settings)
             bundle = runtime_graph.plugin_bundle
             graph = runtime_graph.graph

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -3595,6 +3595,37 @@ class TestEnvVarExpansion:
 
         assert result["prefix"] == ""
 
+    def test_load_settings_from_yaml_string_can_skip_env_expansion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Runtime-inserted values can carry literal ${...} text without host env lookup."""
+        from elspeth.core.config import load_settings_from_yaml_string
+
+        monkeypatch.setenv("ELSPETH_INLINE_BLOB_SECRET", "server-secret-value")
+
+        yaml_content = """
+source:
+  plugin: csv
+  on_success: summarize
+  options:
+    path: input.csv
+aggregations:
+  - name: summarize
+    plugin: report_assemble
+    input: summarize
+    on_error: discard
+    options:
+      title: leaked:${ELSPETH_INLINE_BLOB_SECRET}
+sinks:
+  output:
+    plugin: json
+    on_write_failure: discard
+    options:
+      path: output.jsonl
+"""
+
+        settings = load_settings_from_yaml_string(yaml_content, expand_env_vars=False)
+
+        assert settings.aggregations[0].options["title"] == "leaked:${ELSPETH_INLINE_BLOB_SECRET}"
+
 
 class TestSinkNameCasing:
     """Sink names must be lowercase - explicit validation, no silent transformation."""

--- a/tests/unit/web/execution/test_service.py
+++ b/tests/unit/web/execution/test_service.py
@@ -893,8 +893,10 @@ class TestInlineBlobRuntimePreflight:
         mock_orch_cls: MagicMock,
         service: ExecutionServiceImpl,
         mock_session_service: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        content = b"You are an audited prompt."
+        monkeypatch.setenv("ELSPETH_INLINE_BLOB_SECRET", "server-secret-value")
+        content = b"You are an audited prompt with literal ${ELSPETH_INLINE_BLOB_SECRET}."
         blob_id = uuid4()
         run_id = uuid4()
         sha256 = hashlib.sha256(content).hexdigest()
@@ -928,9 +930,11 @@ class TestInlineBlobRuntimePreflight:
         cast(Any, service)._blob_service = blob_service
         mock_session_service.record_blob_inline_resolutions = AsyncMock(side_effect=record_blob_inline_resolutions)
 
-        def load_settings(yaml_text: str) -> MagicMock:
+        def load_settings(yaml_text: str, *, expand_env_vars: bool = True) -> MagicMock:
             assert "record" in order, "audit row must be recorded before settings/plugin construction"
-            assert "You are an audited prompt." in yaml_text
+            assert "You are an audited prompt with literal ${ELSPETH_INLINE_BLOB_SECRET}." in yaml_text
+            assert "server-secret-value" not in yaml_text
+            assert expand_env_vars is False
             assert "blob_ref" not in yaml_text
             assert "inline_content" not in yaml_text
             order.append("load")


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled inline blob content from being interpreted as host environment expansions during runtime settings loading, which could leak server environment secrets into pipeline outputs.
- Preserve existing behavior for operator-authored YAML while ensuring runtime-substituted values (resolved web secrets or inline blob bytes) are not subject to a second pass of `${VAR}` expansion.

### Description

- Add a helper `expand_env_vars_in_config()` and an `expand_env_vars` switch to `load_settings_from_yaml_string()` so callers can opt out of recursive env-var expansion when loading runtime-mutated YAML in memory (file: `src/elspeth/core/config.py`).
- In the execution service (`src/elspeth/web/execution/service.py`), expand environment variables only over the original operator-authored YAML tree using `expand_env_vars_in_config()` before any runtime substitutions, and disable env expansion when calling `load_settings_from_yaml_string()` if resolved web secrets or inline blob substitutions were performed.
- Keep the inline-blob resolution audit behavior: fetched bytes are still validated, decoded, and recorded via `record_blob_inline_resolutions()`; only the env-expansion step is suppressed for runtime-inserted content.
- Add regression unit test coverage to assert that `load_settings_from_yaml_string(..., expand_env_vars=False)` preserves literal `${...}` text and that the inline-blob execution path invokes the loader with env expansion disabled (files: `tests/unit/core/test_config.py`, `tests/unit/web/execution/test_service.py`).

### Testing

- Ran static/format/lint and sanity checks: `uv run ruff format` and `uv run ruff check` on the modified files, which passed.
- Verified Python byte-compile sanity with `python -m py_compile` on the changed modules, which succeeded.
- Ran `git diff --check` to ensure no whitespace/merge artifacts, which passed.
- Attempted targeted pytest runs for the modified unit tests, but full test execution could not be completed in this environment: a direct `pytest` invocation failed due to missing `hypothesis` in the default environment, and an `uv run --extra dev pytest` attempt failed when a dev dependency (`psycopg2-binary==2.9.12`) could not be downloaded due to a network/tunnel error; these prevented full automated test execution here.
- The change is minimal and limited to controlled call sites (`service._run_pipeline` and the YAML settings loader) and includes unit-level assertions that exercise the new loader flag and inline-blob path. Please run the full test matrix in CI (with dev extras installed) to validate integration-level behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21decfbbf083238f6779164b32ccd8)