### PR TITLE
fix(composer): avoid unsafe schema prefill headers

### DIFF
--- a/src/elspeth/web/composer/guided/emitters.py
+++ b/src/elspeth/web/composer/guided/emitters.py
@@ -23,6 +23,7 @@ data constructed from system-owned state; the Turn dict itself is not persisted
 
 from __future__ import annotations
 
+import keyword
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -153,16 +154,43 @@ def _merge_inspection_into_prefill(
 ) -> None:
     """Conservatively prefill source schema from inspection facts."""
     if facts.observed_headers and facts.inferred_types:
-        fields: list[str] = []
-        for header in facts.observed_headers:
-            inferred = facts.inferred_types[header]
-            field_type = "any" if inferred == "null" else inferred
-            fields.append(f"{header}: {field_type}")
-        prefilled["schema"] = {"mode": "flexible", "fields": fields}
+        fields = _schema_field_specs_from_inspection_headers(facts)
+        if fields is not None:
+            prefilled["schema"] = {"mode": "flexible", "fields": fields}
+        else:
+            prefilled["schema"] = {"mode": "observed"}
     elif facts.observed_headers:
         prefilled["schema"] = {"mode": "observed"}
     # Delimiter and encoding are deliberately not prefilled here: the live
     # SourceInspectionFacts model does not carry those fields yet.
+
+
+def _schema_field_specs_from_inspection_headers(facts: SourceInspectionFacts) -> list[str] | None:
+    """Return safe explicit schema field specs, or ``None`` to stay observed.
+
+    Blob inspection facts originate from Tier-3 uploaded bytes.  Explicit
+    ``schema.fields`` are later loaded through the runtime YAML settings loader,
+    whose string values intentionally support ``${VAR}`` expansion for trusted
+    configuration.  Do not place raw external headers into those strings unless
+    the header is already a safe schema field identifier; otherwise the source
+    runtime's mandatory header normalization remains the authoritative boundary.
+    Safe names must already match the CSV source normalization convention
+    (lowercase Python identifiers) so the prefill does not declare fields that
+    runtime header normalization will rename.
+    """
+    fields: list[str] = []
+    for header in facts.observed_headers or ():
+        if not _is_safe_schema_field_name(header):
+            return None
+        inferred = facts.inferred_types[header]
+        field_type = "any" if inferred == "null" else inferred
+        fields.append(f"{header}: {field_type}")
+    return fields
+
+
+def _is_safe_schema_field_name(header: str) -> bool:
+    """Return whether ``header`` can safely appear in ``schema.fields``."""
+    return header.isidentifier() and header == header.lower() and not keyword.iskeyword(header)
 
 
 def build_step_2_single_select_turn(

--- a/tests/integration/web/composer/guided/test_step1_prefill.py
+++ b/tests/integration/web/composer/guided/test_step1_prefill.py
@@ -80,3 +80,25 @@ def test_step1_prefill_survives_guided_get_rebuild(composer_test_client: TestCli
     assert rebuilt["next_turn"]["type"] == "schema_form"
     rebuilt_prefill = rebuilt["next_turn"]["payload"]["prefilled"]["schema"]
     assert rebuilt_prefill["fields"] == ["name: str", "age: int"]
+
+
+def test_step1_prefill_does_not_emit_field_specs_for_env_var_header(composer_test_client: TestClient) -> None:
+    sess = _create_session(composer_test_client, "step1-prefill-env-header")
+    resp = composer_test_client.post(
+        f"/api/sessions/{sess}/blobs/inline",
+        json={
+            "filename": "secrets.csv",
+            "content": "${AWS_SECRET_ACCESS_KEY},ok\nsecret,1\n",
+            "mime_type": "text/csv",
+        },
+    )
+    assert resp.status_code == 201, resp.json()
+
+    initial = _get_guided(composer_test_client, sess)
+    assert initial["next_turn"]["type"] == "single_select"
+
+    selected = _select_source(composer_test_client, sess, "csv")
+
+    assert selected["next_turn"]["type"] == "schema_form"
+    schema_prefill = selected["next_turn"]["payload"]["prefilled"]["schema"]
+    assert schema_prefill == {"mode": "observed"}

--- a/tests/unit/web/composer/guided/test_emitters.py
+++ b/tests/unit/web/composer/guided/test_emitters.py
@@ -70,6 +70,40 @@ class TestBuildSchemaFormTurns:
         schema_prefill = turn["payload"]["prefilled"]["schema"]
         assert schema_prefill == {"mode": "flexible", "fields": ["name: str", "age: int"]}
 
+    def test_step_1_schema_form_keeps_observed_mode_for_unsafe_inspected_header(self) -> None:
+        facts = SourceInspectionFacts(
+            source_kind="csv",
+            redacted_identity={"filename": "input.csv"},
+            byte_range_inspected=(0, 64),
+            sample_row_count=1,
+            observed_headers=("${AWS_SECRET_ACCESS_KEY}", "ok"),
+            inferred_types={"${AWS_SECRET_ACCESS_KEY}": "str", "ok": "int"},
+            url_candidates=(),
+            warnings=(),
+        )
+
+        turn = build_step_1_schema_form_turn("csv", _Catalog(), inspection_facts=facts)
+
+        schema_prefill = turn["payload"]["prefilled"]["schema"]
+        assert schema_prefill == {"mode": "observed"}
+
+    def test_step_1_schema_form_keeps_observed_mode_for_keyword_header(self) -> None:
+        facts = SourceInspectionFacts(
+            source_kind="csv",
+            redacted_identity={"filename": "input.csv"},
+            byte_range_inspected=(0, 64),
+            sample_row_count=1,
+            observed_headers=("class", "ok"),
+            inferred_types={"class": "str", "ok": "int"},
+            url_candidates=(),
+            warnings=(),
+        )
+
+        turn = build_step_1_schema_form_turn("csv", _Catalog(), inspection_facts=facts)
+
+        schema_prefill = turn["payload"]["prefilled"]["schema"]
+        assert schema_prefill == {"mode": "observed"}
+
     def test_step_2_schema_form_uses_sink_knobs(self) -> None:
         turn = build_step_2_schema_form_turn("json", _Catalog())
 


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled uploaded headers (e.g. `${AWS_SECRET_ACCESS_KEY}`) from being interpolated into generated `schema.fields` strings that later pass through the runtime YAML loader and expand `${VAR}` values.
- Preserve the existing UX of emitting a flexible prefill when inspected headers are already safe normalized field names, but fall back to observed mode for anything that could trigger env-var expansion or invalid identifiers.

### Description
- Change `src/elspeth/web/composer/guided/emitters.py` to only emit explicit `schema.fields` when every inspected header is already a safe, source-normalized identifier by adding `_schema_field_specs_from_inspection_headers()` and `_is_safe_schema_field_name()` and importing `keyword`.
- The safety predicate requires `header.isidentifier()`, `header == header.lower()`, and `not keyword.iskeyword(header)`, otherwise the prefill remains `{"mode": "observed"}`.
- Add unit tests in `tests/unit/web/composer/guided/test_emitters.py` covering env-var-style and keyword headers staying in observed mode for prefill.
- Add an integration test `tests/integration/web/composer/guided/test_step1_prefill.py` exercising an uploaded CSV whose header is `${AWS_SECRET_ACCESS_KEY}` to assert the guided Step-1 prefill does not emit field specs.

### Testing
- Ran style/static checks with `uv run ruff check ...` on the modified modules and it passed.
- Verified bytecode compile with `python -m py_compile` for the modified files and it passed.
- Ran a lightweight Python smoke assertion script exercising safe/unsafe prefill behavior and it passed locally (assertions succeeded).
- Attempted to run `pytest` for the updated tests but the environment lacked `hypothesis` and full `pytest` execution could not be completed; dependency installation from PyPI was blocked in this environment so full test collection could not be executed here.
- Attempted to run the `trust_tier.tier_model` linter but verification of signed allowlist metadata failed in this agent environment because `ELSPETH_JUDGE_METADATA_HMAC_KEY` is not available; lint invocation therefore did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2188c3071c83238f94a385c8515548)