### PR TITLE
fix(deploy): enforce web secret guard for UDS service

### DIFF
--- a/deploy/elspeth-web.service
+++ b/deploy/elspeth-web.service
@@ -10,9 +10,13 @@ WorkingDirectory=/home/john/elspeth
 RuntimeDirectory=elspeth
 
 # --- Application configuration ---
-# SECRET_KEY: generate with `python3 -c "import secrets; print(secrets.token_urlsafe(48))"`
+# ELSPETH_WEB__SECRET_KEY: generate with `python3 -c "import secrets; print(secrets.token_urlsafe(48))"`
 # Env vars in EnvironmentFile — systemd Environment= mangles JSON quoting.
 EnvironmentFile=/home/john/elspeth/deploy/elspeth-web.env
+# Uvicorn ignores TCP host when --uds is used, but WebSettings.host is the
+# production-secret guard signal. Mark this reverse-proxy deployment non-local
+# so startup fails unless ELSPETH_WEB__SECRET_KEY is explicitly configured.
+Environment=ELSPETH_WEB__HOST=0.0.0.0
 # Pin imports to the served checkout. The venv editable-install .pth has drifted
 # to stale worktrees before, which let /api stay healthy while the SPA root 404ed.
 Environment=PYTHONPATH=/home/john/elspeth/src

--- a/tests/unit/deployment/test_elspeth_web_service.py
+++ b/tests/unit/deployment/test_elspeth_web_service.py
@@ -5,8 +5,32 @@ from __future__ import annotations
 from pathlib import Path
 
 
+_SERVICE_PATH = Path("deploy/elspeth-web.service")
+
+
+def _service_text() -> str:
+    return _SERVICE_PATH.read_text(encoding="utf-8")
+
+
 def test_elspeth_web_service_pins_repo_src_on_pythonpath() -> None:
-    service_text = Path("deploy/elspeth-web.service").read_text(encoding="utf-8")
+    service_text = _service_text()
 
     assert "Environment=PYTHONPATH=/home/john/elspeth/src" in service_text
     assert service_text.index("Environment=PYTHONPATH=/home/john/elspeth/src") < service_text.index("ExecStart=")
+
+
+def test_elspeth_web_service_documents_prefixed_secret_key() -> None:
+    """The env file guidance must name the variable create_app() actually reads."""
+    service_text = _service_text()
+
+    assert "ELSPETH_WEB__SECRET_KEY" in service_text
+    assert "# SECRET_KEY:" not in service_text
+
+
+def test_elspeth_web_service_marks_uds_reverse_proxy_as_non_local() -> None:
+    """UDS startup must trip WebSettings' production secret-key guard."""
+    service_text = _service_text()
+
+    assert "--uds /run/elspeth/uvicorn.sock" in service_text
+    assert "Environment=ELSPETH_WEB__HOST=0.0.0.0" in service_text
+    assert service_text.index("Environment=ELSPETH_WEB__HOST=0.0.0.0") < service_text.index("ExecStart=")


### PR DESCRIPTION
### Motivation
- Prevent a staging/systemd startup path from bypassing the existing WebSettings secret-key guard by documenting the actual `ELSPETH_WEB__SECRET_KEY` variable and signalling the UDS reverse-proxy deployment as non-local. 
- Close the vulnerability where the service comment referenced `SECRET_KEY` (ignored by the factory) while `create_app()` only reads `ELSPETH_WEB__*` env vars and treats loopback hosts as allowed to use the default dev key.

### Description
- Update `deploy/elspeth-web.service` to replace the misleading `# SECRET_KEY:` comment with `# ELSPETH_WEB__SECRET_KEY:` and add an explanatory comment plus `Environment=ELSPETH_WEB__HOST=0.0.0.0` so the WebSettings production guard is triggered for this UDS reverse-proxy deployment. 
- Add unit tests in `tests/unit/deployment/test_elspeth_web_service.py` that (a) continue asserting `Environment=PYTHONPATH=/home/john/elspeth/src` is present before `ExecStart`, (b) assert the service text documents `ELSPETH_WEB__SECRET_KEY` and no longer contains the bare `# SECRET_KEY:`, and (c) assert the UDS `--uds /run/elspeth/uvicorn.sock` line is present and `Environment=ELSPETH_WEB__HOST=0.0.0.0` appears before `ExecStart`. 
- Keep change minimal and backwards-compatible: only service file comments and one explicit prefixed host env var are added, and tests only read and assert on the service file text.

### Testing
- Ran `git diff --check` with no reported issues. (passed)
- Performed local Python assertions that read `deploy/elspeth-web.service` to validate the new `ELSPETH_WEB__` entries and ordering checks. (passed)
- Type-checked/compiled the new test file with `python -m py_compile tests/unit/deployment/test_elspeth_web_service.py`. (passed)
- Attempted to run `python -m pytest tests/unit/deployment/test_elspeth_web_service.py` but execution was blocked by missing test dependencies in the environment (`ModuleNotFoundError: No module named 'hypothesis'`), so full pytest run could not be completed. (blocked)
- Ran `systemd-analyze verify deploy/elspeth-web.service` which failed due to the workspace not containing the host-specific venv binary path (`/home/john/elspeth/.venv/bin/uvicorn`), so full systemd verification could not be performed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217813b30c8323a14068c21f842a2e)