### PR TITLE
fix(web): gate runtime validation on composer authoring state

### DIFF
--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -66,6 +66,7 @@ from elspeth.web.config import WebSettings
 from elspeth.web.execution.accounting import load_run_accounting_from_db
 from elspeth.web.execution.errors import (
     BlobSourcePathMismatchError,
+    ExecuteRequestValidationError,
     MalformedBlobRefError,
     PathAllowlistViolationError,
     SemanticContractViolationError,
@@ -480,6 +481,15 @@ class ExecutionServiceImpl:
         # Bridge CompositionStateRecord → CompositionState for generate_yaml().
         # The record stores raw dicts; generate_yaml() needs the typed domain object.
         composition_state = state_from_record(state_record)
+
+        # /execute is callable without first visiting /validate. Composer
+        # authoring validation is therefore a mandatory pre-YAML gate here too:
+        # invalid Tier-3 state must not reach load_settings_from_yaml_string(),
+        # where server-side environment expansion is available.
+        authoring = composition_state.validate()
+        if not authoring.is_valid:
+            detail = "; ".join(entry.message for entry in authoring.errors)
+            raise ExecuteRequestValidationError(f"Composition state is not executable: {detail}")
 
         semantic_errors, semantic_contracts = validate_semantic_contracts(composition_state)
         if semantic_errors:

--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -104,6 +104,7 @@ _CHECK_BLOB_INLINE_REFS = "blob_inline_refs"
 _CHECK_SEMANTIC_CONTRACTS = "semantic_contracts"
 _CHECK_BATCH_TRANSFORM_OPTIONS = "batch_transform_options"
 _CHECK_INTERPRETATION_REVIEW = "interpretation_review"
+_CHECK_AUTHORING_STATE = "authoring_state"
 _CHECK_SETTINGS = "settings_load"
 _CHECK_PLUGINS = RUNTIME_CHECK_PLUGIN_INSTANTIATION
 _CHECK_VALUE_SOURCE_COMPLIANCE = "value_source_compliance"
@@ -162,6 +163,7 @@ _ALL_CHECKS = [
     _CHECK_PATH_ALLOWLIST,
     _CHECK_SECRET_REFS,
     _CHECK_SEMANTIC_CONTRACTS,
+    _CHECK_AUTHORING_STATE,
     _CHECK_BATCH_TRANSFORM_OPTIONS,
     _CHECK_INTERPRETATION_REVIEW,
     _CHECK_BLOB_INLINE_REFS,
@@ -1027,6 +1029,82 @@ def validate_pipeline(
             detail=(
                 f"All {len(semantic_contracts)} semantic contract(s) satisfied" if semantic_contracts else "No semantic contracts to check"
             ),
+            affected_nodes=(),
+            outcome_code=None,
+        )
+    )
+
+    # Step 1d: Composer authoring validation
+    #
+    # ``validate_pipeline()`` is also exposed directly by the authenticated
+    # ``/validate`` endpoint and by YAML export/runtime-preflight callers. Do
+    # not assume the caller already ran ``CompositionState.validate()``: an
+    # invalid state can be persisted for repair feedback. Blocking here keeps
+    # Tier-3 composer-authored fields (notably aggregation trigger.condition)
+    # from reaching the settings loader, whose environment expansion is a
+    # server-side capability and must not be reachable through invalid authoring
+    # input.
+    authoring = state.validate()
+    if not authoring.is_valid:
+        affected_nodes = tuple(
+            dict.fromkeys(
+                entry.component.removeprefix("node:")
+                for entry in authoring.errors
+                if entry.component.startswith("node:")
+            )
+        )
+        checks.append(
+            ValidationCheck(
+                name=_CHECK_AUTHORING_STATE,
+                passed=False,
+                detail="Composer authoring validation failed",
+                affected_nodes=affected_nodes,
+                outcome_code=None,
+            )
+        )
+        node_component_types = {node.id: node.node_type for node in state.nodes}
+
+        def _authoring_component(entry_component: str) -> tuple[str | None, str | None]:
+            if entry_component.startswith("node:"):
+                node_id = entry_component.removeprefix("node:")
+                return node_id, node_component_types.get(node_id, "transform")
+            if entry_component in {"source", "metadata"}:
+                return entry_component, entry_component
+            if entry_component.startswith("output:"):
+                return entry_component.removeprefix("output:"), "sink"
+            return entry_component, None
+
+        errors.extend(
+            ValidationError(
+                component_id=_authoring_component(entry.component)[0],
+                component_type=_authoring_component(entry.component)[1],
+                message=entry.message,
+                suggestion="Fix the composer authoring error before running runtime validation.",
+                error_code="authoring_state_invalid",
+            )
+            for entry in authoring.errors
+        )
+        checks.extend(_skipped_checks(_CHECK_AUTHORING_STATE))
+        first_error = authoring.errors[0] if authoring.errors else None
+        first_component = first_error.component if first_error is not None else None
+        first_component_id, first_component_type = _authoring_component(first_component) if first_component is not None else (None, None)
+        return ValidationResult(
+            is_valid=False,
+            checks=checks,
+            errors=errors,
+            readiness=_blocked_readiness(
+                code="authoring_state_invalid",
+                detail="Composer authoring validation failed.",
+                component_id=first_component_id,
+                component_type=first_component_type,
+            ),
+            semantic_contracts=serialize_semantic_contracts(semantic_contracts),
+        )
+    checks.append(
+        ValidationCheck(
+            name=_CHECK_AUTHORING_STATE,
+            passed=True,
+            detail="Composer authoring state is valid",
             affected_nodes=(),
             outcome_code=None,
         )

--- a/tests/unit/web/execution/test_validation.py
+++ b/tests/unit/web/execution/test_validation.py
@@ -199,6 +199,67 @@ class TestValidatePipelineEmptyComposition:
         assert all(err.error_code != "empty_pipeline" for err in result.errors)
 
 
+class TestValidatePipelineAuthoringGate:
+    """Authoring validation must gate runtime YAML generation."""
+
+    def test_invalid_aggregation_trigger_env_placeholder_never_reaches_yaml_generation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for aggregation trigger.condition env-expansion disclosure.
+
+        Composer-authored trigger fields are Tier-3 input. If an invalid
+        trigger condition can reach ``load_settings_from_yaml_string()``, the
+        core loader expands ``${VAR}`` placeholders using the server process
+        environment before Pydantic reports the invalid expression. The
+        validation endpoint must therefore stop at authoring validation and
+        never generate/load YAML for this state.
+        """
+        monkeypatch.setenv("ELSPETH_SECRET_KEY", "SUPERSECRETLEAK")
+        state = _make_state(
+            nodes=(
+                NodeSpec(
+                    id="agg",
+                    node_type="aggregation",
+                    plugin="batch_stats",
+                    input="transform_in",
+                    on_success="results",
+                    on_error="discard",
+                    options={},
+                    condition=None,
+                    routes=None,
+                    fork_to=None,
+                    branches=None,
+                    policy=None,
+                    merge=None,
+                    trigger={"condition": "${ELSPETH_SECRET_KEY}"},
+                ),
+            ),
+            outputs=(_make_output(name="results"),),
+        )
+        settings = _make_settings()
+        mock_yaml_gen = MagicMock(spec=YamlGenerator)
+
+        with (
+            patch(
+                "elspeth.web.composer.state._known_batch_aware_transform_plugins",
+                return_value=frozenset({"batch_stats"}),
+            ),
+            patch(
+                "elspeth.web.composer.state._known_batch_aware_transform_plugins_requiring_aggregation",
+                return_value=frozenset({"batch_stats"}),
+            ),
+        ):
+            result = validate_pipeline(state, settings, mock_yaml_gen)
+
+        assert result.is_valid is False
+        assert result.errors[0].error_code == "authoring_state_invalid"
+        assert result.errors[0].component_id == "agg"
+        assert result.errors[0].component_type == "aggregation"
+        assert "Aggregation 'agg' trigger is invalid" in result.errors[0].message
+        assert "SUPERSECRETLEAK" not in yaml.safe_dump(result.model_dump())
+        assert _check(result, "authoring_state").passed is False
+        assert result.readiness.authoring_valid is False
+        mock_yaml_gen.generate_yaml.assert_not_called()
+
+
 class TestValidatePipelinePathAllowlist:
     """C3/S2: Source path allowlist check — defense-in-depth."""
 


### PR DESCRIPTION
### Motivation

- Prevent composer-authored, Tier-3 invalid state from reaching the engine settings loader (which expands `${VAR}` from server env) and thereby avoid possible disclosure of expanded environment secrets.  

### Description

- Add an explicit authoring-state gate to `validate_pipeline()` that runs `CompositionState.validate()` and returns a structured `ValidationResult`/readiness blocker when authoring validation fails, skipping downstream runtime checks and YAML generation.  
- Apply the same pre-YAML authoring check to the `/execute` path so execution (which can be invoked without a prior `/validate`) cannot reach `load_settings_from_yaml_string()` for invalid composer state.  
- Add a focused regression unit test that constructs an aggregation node with `trigger.condition = "${ELSPETH_SECRET_KEY}"` and asserts the authoring gate blocks YAML generation, does not call the YAML generator, and the server secret value is not leaked.  
- Modified files: `src/elspeth/web/execution/validation.py`, `src/elspeth/web/execution/service.py`, and `tests/unit/web/execution/test_validation.py`.

### Testing

- Ran static sanity checks and linters: `python -m py_compile src/elspeth/web/execution/validation.py src/elspeth/web/execution/service.py tests/unit/web/execution/test_validation.py` succeeded.  
- Ran code-style checks: `uv run ruff check src/elspeth/web/execution/validation.py src/elspeth/web/execution/service.py tests/unit/web/execution/test_validation.py` succeeded.  
- Executed a direct regression harness (calling `validate_pipeline()` with a patched plugin-discovery surface) which returned `is_valid == False`, reported `error_code == "authoring_state_invalid"` for the aggregation node, did not call the YAML generator, and the expanded secret value was not present in the returned payload; this confirms the authoring gate blocks the env-expansion path.  
- Attempted to run the unit test via `pytest` but the test run was blocked by missing test dependencies in the environment (`hypothesis`), and `uv sync` failed to download a dependency (`pycparser`) due to a network/tunnel error; these CI/test installs are environment-dependent and are documented as blocked in the test summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22380a4ff483239c2903843add0d97)