### PR TITLE
fix(web): reject env templates in source validation routes

### DIFF
--- a/src/elspeth/plugins/infrastructure/config_base.py
+++ b/src/elspeth/plugins/infrastructure/config_base.py
@@ -14,6 +14,7 @@ Example usage:
     path = cfg.path  # Direct access, fails fast if missing
 """
 
+import re
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Self
 
@@ -23,6 +24,37 @@ from elspeth.contracts.header_modes import HeaderMode, parse_header_mode
 from elspeth.contracts.schema import SchemaConfig
 
 OutputCollisionPolicy = Literal["fail_if_exists", "auto_increment", "append_or_create"]
+
+# Source validation-failure routing is serialized into runtime YAML under
+# source.options. Runtime YAML loading expands ${VAR} templates before plugin
+# config validation, so this field must be restricted to engine route/sink
+# identifiers rather than arbitrary text. Keep this local instead of importing
+# core.config private helpers: plugin infrastructure is a lower-level shared
+# surface and must not depend on the full settings module.
+_MAX_SOURCE_VALIDATION_FAILURE_DESTINATION_LENGTH = 64
+_SOURCE_VALIDATION_FAILURE_DESTINATION_RE = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_-]*$")
+_SOURCE_VALIDATION_FAILURE_RESERVED_DESTINATIONS = frozenset({"continue", "fork", "on_success"})
+
+
+def validate_source_validation_failure_destination(value: str) -> str:
+    """Validate source validation-failure routing destination syntax."""
+    if not value or not value.strip():
+        raise ValueError("on_validation_failure must be a sink name or 'discard'")
+    destination = value.strip()
+    if destination == "discard":
+        return destination
+    if len(destination) > _MAX_SOURCE_VALIDATION_FAILURE_DESTINATION_LENGTH:
+        raise ValueError("on_validation_failure sink name exceeds max length 64")
+    if not _SOURCE_VALIDATION_FAILURE_DESTINATION_RE.match(destination):
+        raise ValueError(
+            "on_validation_failure must be 'discard' or a sink name containing only "
+            "letters, digits, underscores, and hyphens"
+        )
+    if destination in _SOURCE_VALIDATION_FAILURE_RESERVED_DESTINATIONS:
+        raise ValueError("on_validation_failure sink name is reserved for engine routing")
+    if destination.startswith("__"):
+        raise ValueError("on_validation_failure sink name must not start with '__'")
+    return destination
 
 
 def _plugin_config_field_title(field_name: str, _field_info: Any) -> str:
@@ -376,10 +408,8 @@ class SourceDataConfig(PathConfig):
     @field_validator("on_validation_failure")
     @classmethod
     def validate_on_validation_failure(cls, v: str) -> str:
-        """Ensure on_validation_failure is not empty."""
-        if not v or not v.strip():
-            raise ValueError("on_validation_failure must be a sink name or 'discard'")
-        return v.strip()
+        """Ensure on_validation_failure is a safe route/sink destination."""
+        return validate_source_validation_failure_destination(v)
 
 
 class TabularSourceDataConfig(SourceDataConfig):

--- a/src/elspeth/plugins/sources/azure_blob_source.py
+++ b/src/elspeth/plugins/sources/azure_blob_source.py
@@ -30,7 +30,7 @@ from elspeth.contracts.wire_visible_identity import reject_placeholder_value
 from elspeth.core.identifiers import validate_field_names
 from elspeth.plugins.infrastructure.azure_auth import AzureAuthConfig
 from elspeth.plugins.infrastructure.base import BaseSource
-from elspeth.plugins.infrastructure.config_base import DataPluginConfig
+from elspeth.plugins.infrastructure.config_base import DataPluginConfig, validate_source_validation_failure_destination
 from elspeth.plugins.infrastructure.schema_factory import create_schema_from_config
 from elspeth.plugins.sources.field_normalization import (
     ExternalHeaderError,
@@ -297,10 +297,8 @@ class AzureBlobSourceConfig(DataPluginConfig):
     @field_validator("on_validation_failure")
     @classmethod
     def validate_on_validation_failure(cls, v: str) -> str:
-        """Ensure on_validation_failure is not empty."""
-        if not v or not v.strip():
-            raise ValueError("on_validation_failure must be a sink name or 'discard'")
-        return v.strip()
+        """Ensure on_validation_failure is a safe route/sink destination."""
+        return validate_source_validation_failure_destination(v)
 
 
 # Rebuild model to resolve forward references for dynamic module loading

--- a/src/elspeth/plugins/sources/dataverse.py
+++ b/src/elspeth/plugins/sources/dataverse.py
@@ -33,7 +33,7 @@ from elspeth.plugins.infrastructure.clients.dataverse import (
     DataversePageResponse,
     validate_additional_domain,
 )
-from elspeth.plugins.infrastructure.config_base import DataPluginConfig
+from elspeth.plugins.infrastructure.config_base import DataPluginConfig, validate_source_validation_failure_destination
 from elspeth.plugins.infrastructure.schema_factory import create_schema_from_config
 from elspeth.plugins.infrastructure.url_validation import validate_credential_safe_https_url
 from elspeth.plugins.sources.field_normalization import (
@@ -168,9 +168,8 @@ class DataverseSourceConfig(DataPluginConfig):
     @field_validator("on_validation_failure")
     @classmethod
     def validate_on_validation_failure(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("on_validation_failure must be a sink name or 'discard'")
-        return v.strip()
+        """Ensure on_validation_failure is a safe route/sink destination."""
+        return validate_source_validation_failure_destination(v)
 
     @field_validator("fetch_xml")
     @classmethod

--- a/src/elspeth/web/composer/tools/_common.py
+++ b/src/elspeth/web/composer/tools/_common.py
@@ -1027,8 +1027,18 @@ _DEFAULT_SOURCE_VALIDATION_FAILURE: Final[str] = "discard"
 
 _SOURCE_VALIDATION_FAILURE_DESCRIPTION: Final[str] = (
     "How to handle source validation failures. Use 'discard' to drop invalid rows without routing. "
-    "Any other value, including 'quarantine', must match a configured output/sink name."
+    "Any other value, including 'quarantine', must match a configured output/sink name. "
+    "Sink names may contain only letters, digits, underscores, and hyphens."
 )
+
+_SOURCE_VALIDATION_FAILURE_PATTERN: Final[str] = r"^(?:discard|[a-zA-Z0-9_][a-zA-Z0-9_-]{0,63})$"
+
+_SOURCE_VALIDATION_FAILURE_JSON_SCHEMA: Final[dict[str, Any]] = {
+    "type": "string",
+    "description": _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
+    "pattern": _SOURCE_VALIDATION_FAILURE_PATTERN,
+    "maxLength": 64,
+}
 
 
 def _credential_wiring_contract_failure(

--- a/src/elspeth/web/composer/tools/sessions.py
+++ b/src/elspeth/web/composer/tools/sessions.py
@@ -45,7 +45,7 @@ from elspeth.web.composer.state import (
 )
 from elspeth.web.composer.tools._common import (
     _DEFAULT_SOURCE_VALIDATION_FAILURE,
-    _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
+    _SOURCE_VALIDATION_FAILURE_JSON_SCHEMA,
     ToolContext,
     ToolResult,
     _credential_wiring_contract_failure,
@@ -808,10 +808,7 @@ _SET_PIPELINE_DECLARATION = ToolDeclaration(
                         ),
                         "examples": ["raw_url_rows", "csv_rows", "fetched_text"],
                     },
-                    "on_validation_failure": {
-                        "type": "string",
-                        "description": _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
-                    },
+                    "on_validation_failure": dict(_SOURCE_VALIDATION_FAILURE_JSON_SCHEMA),
                     "inline_blob": {
                         "type": "object",
                         "description": (

--- a/src/elspeth/web/composer/tools/sources.py
+++ b/src/elspeth/web/composer/tools/sources.py
@@ -34,7 +34,7 @@ from elspeth.web.composer.state import (
 )
 from elspeth.web.composer.tools._common import (
     _DEFAULT_SOURCE_VALIDATION_FAILURE,
-    _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
+    _SOURCE_VALIDATION_FAILURE_JSON_SCHEMA,
     ToolContext,
     ToolResult,
     _apply_merge_patch,
@@ -122,10 +122,7 @@ _SET_SOURCE_DECLARATION = ToolDeclaration(
                 "examples": ["raw_url_rows", "csv_rows", "fetched_text"],
             },
             "options": {"type": "object", "description": "Plugin-specific config."},
-            "on_validation_failure": {
-                "type": "string",
-                "description": _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
-            },
+            "on_validation_failure": dict(_SOURCE_VALIDATION_FAILURE_JSON_SCHEMA),
         },
         "required": ["plugin", "on_success", "options", "on_validation_failure"],
     },
@@ -533,8 +530,7 @@ _SET_SOURCE_FROM_BLOB_DECLARATION = ToolDeclaration(
                 "examples": ["raw_url_rows", "csv_rows", "fetched_text"],
             },
             "on_validation_failure": {
-                "type": "string",
-                "description": _SOURCE_VALIDATION_FAILURE_DESCRIPTION,
+                **_SOURCE_VALIDATION_FAILURE_JSON_SCHEMA,
                 "default": _DEFAULT_SOURCE_VALIDATION_FAILURE,
             },
             "options": {

--- a/tests/unit/web/composer/test_tools.py
+++ b/tests/unit/web/composer/test_tools.py
@@ -441,6 +441,28 @@ class TestSetSource:
         assert result.updated_state.source is not None
         assert result.updated_state.source.on_validation_failure == "bad_rows_sink"
 
+    def test_on_validation_failure_rejects_env_template(self) -> None:
+        """Reject env-template routing before generated YAML can expand secrets."""
+        state = _empty_state()
+        catalog = _mock_catalog()
+        result = execute_tool(
+            "set_source",
+            {
+                "plugin": "csv",
+                "on_success": "t1",
+                "options": {"path": "/data/in.csv", "schema": {"mode": "observed"}},
+                "on_validation_failure": "${ELSPETH_LEAK_TEST}",
+            },
+            state,
+            catalog,
+        )
+        assert result.success is False
+        assert result.updated_state.source is None
+        assert result.data is not None
+        assert "on_validation_failure" in result.data["error"]
+        assert "ELSPETH_LEAK_TEST" not in result.data["error"]
+        assert "${" not in result.data["error"]
+
     def test_unknown_plugin_fails(self) -> None:
         state = _empty_state()
         catalog = _mock_catalog()
@@ -537,10 +559,11 @@ class TestSetSource:
 class TestVfDestinationAdvisory:
     """Advisory note when on_validation_failure references an unknown output.
 
-    The set_source tool schema accepts any string for on_validation_failure
-    (not just 'discard'/'quarantine'). When the value doesn't match a
-    configured output, ToolResult.data includes a note so the LLM can
-    self-correct before pipeline validation fails at engine startup.
+    The set_source tool schema accepts valid sink-name strings for
+    on_validation_failure (not just 'discard'/'quarantine'). When the
+    value doesn't match a configured output, ToolResult.data includes a
+    note so the LLM can self-correct before pipeline validation fails at
+    engine startup.
     """
 
     def test_set_source_unknown_vf_sink_includes_note(self) -> None:
@@ -625,6 +648,20 @@ class TestVfDestinationAdvisory:
         assert result.success is True
         assert result.data is not None
         assert "typo_sink" in result.data["note"]
+
+    def test_set_pipeline_rejects_env_template_vf_destination(self) -> None:
+        """set_pipeline rejects env-template source failure routes before YAML generation."""
+        state = _empty_state()
+        catalog = _mock_catalog()
+        args = _valid_pipeline_args()
+        args["source"]["on_validation_failure"] = "${ELSPETH_LEAK_TEST}"
+        result = execute_tool("set_pipeline", args, state, catalog)
+        assert result.success is False
+        assert result.updated_state.source is None
+        assert result.data is not None
+        assert "on_validation_failure" in result.data["error"]
+        assert "ELSPETH_LEAK_TEST" not in result.data["error"]
+        assert "${" not in result.data["error"]
 
     def test_set_pipeline_vf_matches_output_no_note(self) -> None:
         """set_pipeline with on_validation_failure matching an output — no note."""
@@ -1964,6 +2001,18 @@ class TestToolDefinitions:
         for defn in get_tool_definitions():
             self._assert_no_enum_on_validation_failure(defn.get("parameters", {}), defn["name"])
 
+    def test_on_validation_failure_schema_rejects_env_templates_without_enum(self) -> None:
+        """Tool schemas allow sink names but not arbitrary env-template strings."""
+        schemas: list[tuple[str, dict[str, object]]] = []
+        for defn in get_tool_definitions():
+            self._collect_on_validation_failure_schemas(defn.get("parameters", {}), defn["name"], schemas)
+
+        assert schemas, "expected at least one on_validation_failure schema"
+        for tool_name, schema in schemas:
+            assert "enum" not in schema, tool_name
+            assert schema.get("pattern") == r"^(?:discard|[a-zA-Z0-9_][a-zA-Z0-9_-]{0,63})$", tool_name
+            assert schema.get("maxLength") == 64, tool_name
+
     def test_on_validation_failure_descriptions_match_runtime_contract(self) -> None:
         """Tool docs must not advertise a non-existent built-in quarantine sink."""
         descriptions: list[tuple[str, str]] = []
@@ -1976,6 +2025,7 @@ class TestToolDefinitions:
             assert "built-in quarantine" not in lowered, tool_name
             assert "discard" in description, tool_name
             assert "Any other value, including 'quarantine', must match a configured output/sink name." in description, tool_name
+            assert "letters, digits, underscores, and hyphens" in description, tool_name
 
     def test_upsert_node_trigger_schema_documents_end_of_source_only_shape(self) -> None:
         """Aggregation trigger schema must expose the end-of-source-only shape."""
@@ -2032,6 +2082,23 @@ class TestToolDefinitions:
         elif isinstance(schema, list):
             for item in schema:
                 self._assert_no_enum_on_validation_failure(item, tool_name)
+
+    def _collect_on_validation_failure_schemas(
+        self,
+        schema: object,
+        tool_name: str,
+        schemas: list[tuple[str, dict[str, object]]],
+    ) -> None:
+        """Collect on_validation_failure schemas from nested tool schemas."""
+        if isinstance(schema, dict):
+            for key, value in schema.items():
+                if key == "on_validation_failure" and isinstance(value, dict):
+                    schemas.append((tool_name, value))
+                elif isinstance(value, (dict, list)):
+                    self._collect_on_validation_failure_schemas(value, tool_name, schemas)
+        elif isinstance(schema, list):
+            for item in schema:
+                self._collect_on_validation_failure_schemas(item, tool_name, schemas)
 
     def _collect_on_validation_failure_descriptions(
         self,


### PR DESCRIPTION
### Motivation
- Prevent authenticated composer authors from supplying `${...}` env-template strings in `on_validation_failure` that get expanded at runtime and can leak environment secrets. 
- Restore a safe contract between the web composer surface and engine routing by validating routing identifiers early instead of relying only on preflight warnings or runtime errors.

### Description
- Add a shared validator `validate_source_validation_failure_destination()` with a tight character class, max-length, reserved-name checks, and explicit rejection of `${...}`-style templates in `src/elspeth/plugins/infrastructure/config_base.py` and wire it into `SourceDataConfig` validation. 
- Apply the same validator to source configs that bypass the base (`azure_blob_source`, `dataverse`) so all source plugin validators enforce the same rule. 
- Export JSON-Schema metadata (`_SOURCE_VALIDATION_FAILURE_JSON_SCHEMA`) with `pattern` and `maxLength` and use it in composer tool declarations for `set_source`, `set_pipeline`, and `set_source_from_blob` so the tool surface documents and rejects env-template strings while still allowing arbitrary valid sink names (no enum). 
- Add regression coverage that asserts `set_source`/`set_pipeline` reject `${...}` templates and that published tool schemas include the `pattern`/`maxLength` guards and keep no `enum` constraint.

### Testing
- Ran byte-compile smoke checks with `PYTHONPATH=src .venv/bin/python -m compileall ...` over changed modules and the modified tests, which succeeded. 
- Exercised the new validator and tool-schema introspection via small `PYTHONPATH=src .venv/bin/python - <<'PY' ... PY` smoke scripts (valid cases accepted, `${...}` cases rejected), which succeeded. 
- Attempted to run the focused test selection with `uv run --extra dev pytest ...` but the test run could not complete due to an external dependency download failure (`types-pytz`) caused by network tunneling restrictions. 
- Lint/check invocation (`ruff`) was not available in the local `.venv` so that check was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227cb1c9cc8323b1d11f6654d5432d)