### PR TITLE
fix(web): disable host env expansion for web pipeline YAML

### DIFF
--- a/src/elspeth/core/config.py
+++ b/src/elspeth/core/config.py
@@ -2154,7 +2154,7 @@ def load_settings(config_path: Path) -> ElspethSettings:
     return ElspethSettings(**raw_config)
 
 
-def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
+def load_settings_from_yaml_string(yaml_content: str, *, expand_env_vars: bool = True) -> ElspethSettings:
     """Load settings from a YAML string without touching disk.
 
     This is used by the web execution service to load pipeline configs
@@ -2164,6 +2164,10 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
 
     Args:
         yaml_content: YAML configuration as a string.
+        expand_env_vars: Whether to recursively expand ``${VAR}`` and
+            ``${VAR:-default}`` placeholders. Keep this enabled for trusted
+            CLI-authored config files; disable it for web-authored in-memory
+            configs after explicit secret references have already been resolved.
 
     Returns:
         Validated ElspethSettings instance.
@@ -2179,7 +2183,8 @@ def load_settings_from_yaml_string(yaml_content: str) -> ElspethSettings:
         raise ValueError(f"Unknown configuration keys: {unknown_keys}. Valid top-level keys: {sorted(known_fields)}")
 
     raw_config = {k: v for k, v in raw_config.items() if k in known_fields}
-    raw_config = _expand_env_vars(raw_config)
+    if expand_env_vars:
+        raw_config = _expand_env_vars(raw_config)
     return ElspethSettings(**raw_config)
 
 

--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -1085,8 +1085,10 @@ class ExecutionServiceImpl:
 
             # Load settings from YAML string — never write resolved secrets
             # to disk.  load_settings_from_yaml_string() parses in-process,
-            # bypassing Dynaconf file I/O.
-            settings = load_settings_from_yaml_string(resolved_yaml)
+            # bypassing Dynaconf file I/O. Web-authored pipeline YAML must
+            # not expand host ${VAR} placeholders; explicit secret refs were
+            # already resolved above through the audited web secret path.
+            settings = load_settings_from_yaml_string(resolved_yaml, expand_env_vars=False)
             runtime_graph = build_validated_runtime_graph(settings)
             bundle = runtime_graph.plugin_bundle
             graph = runtime_graph.graph

--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -649,8 +649,9 @@ def validate_pipeline(
     1. Source path allowlist check (C3/S2 defense-in-depth)
     1b. Secret ref validation (all referenced secrets exist)
     2. Generate YAML from CompositionState
-    3. Load settings via load_settings_from_yaml_string() — resolve secret
-       refs first if present, matching the execution service path exactly
+    3. Load settings via load_settings_from_yaml_string() with host env
+       expansion disabled — resolve secret refs first if present, matching
+       the execution service path exactly
     4. instantiate_runtime_plugins(settings, preflight_mode=True)
     5. build_runtime_graph(settings, bundle)
     6. graph.validate() + graph.validate_edge_compatibility()
@@ -1213,7 +1214,9 @@ def validate_pipeline(
     # Always uses load_settings_from_yaml_string() — the same loader the
     # execution service uses (in _run_pipeline).  This ensures validation
     # exercises the exact same code path as execution, preventing
-    # false-pass or false-fail results from loader differences.
+    # false-pass or false-fail results from loader differences. Host env
+    # expansion stays disabled for web-authored YAML; explicit secret refs
+    # are resolved through the audited web secret path before loading.
     #
     # When secret refs are present, resolve them before loading.
     # Resolved secrets stay in process memory — never written to disk.
@@ -1237,7 +1240,7 @@ def validate_pipeline(
             )
             settings_yaml = yaml.dump(resolved_dict, default_flow_style=False)
 
-        elspeth_settings = load_settings_from_yaml_string(settings_yaml)
+        elspeth_settings = load_settings_from_yaml_string(settings_yaml, expand_env_vars=False)
         checks.append(
             ValidationCheck(
                 name=_CHECK_SETTINGS,

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -3595,6 +3595,79 @@ class TestEnvVarExpansion:
 
         assert result["prefix"] == ""
 
+    def test_yaml_string_loader_can_disable_env_expansion_for_web_authored_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Web-authored in-memory YAML must not disclose host env vars through plugin options."""
+        from elspeth.core.config import load_settings_from_yaml_string
+
+        monkeypatch.setenv("ELSPETH_WEB__SECRET_KEY", "JWT_SECRET_POC_VALUE")
+
+        yaml_content = """
+source:
+  plugin: value
+  on_success: compute_fields
+  options:
+    rows:
+      - input: attacker-controlled pipeline config
+    schema:
+      mode: observed
+transforms:
+  - name: compute_fields
+    plugin: value_transform
+    input: compute_fields
+    on_success: output
+    on_error: output
+    options:
+      schema:
+        mode: observed
+      operations:
+        - target: leaked_value
+          expression: "'${ELSPETH_WEB__SECRET_KEY}'"
+        - target: "${ELSPETH_WEB__SECRET_KEY}"
+          expression: "'field-name-expanded'"
+sinks:
+  output:
+    plugin: discard
+    on_write_failure: discard
+    options:
+      schema:
+        mode: observed
+"""
+
+        settings = load_settings_from_yaml_string(yaml_content, expand_env_vars=False)
+
+        operations = settings.transforms[0].options["operations"]
+        assert operations[0]["expression"] == "'${ELSPETH_WEB__SECRET_KEY}'"
+        assert operations[1]["target"] == "${ELSPETH_WEB__SECRET_KEY}"
+        assert "JWT_SECRET_POC_VALUE" not in repr(settings.transforms[0].options)
+
+    def test_yaml_string_loader_expands_env_vars_by_default_for_trusted_callers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The new opt-out preserves existing CLI/test helper behavior by default."""
+        from elspeth.core.config import load_settings_from_yaml_string
+
+        monkeypatch.setenv("VALUE_SOURCE_TEXT", "expanded-row-value")
+
+        yaml_content = """
+source:
+  plugin: value
+  on_success: output
+  options:
+    rows:
+      - input: "${VALUE_SOURCE_TEXT}"
+    schema:
+      mode: observed
+sinks:
+  output:
+    plugin: discard
+    on_write_failure: discard
+    options:
+      schema:
+        mode: observed
+"""
+
+        settings = load_settings_from_yaml_string(yaml_content)
+
+        assert settings.source.options["rows"][0]["input"] == "expanded-row-value"
+
 
 class TestSinkNameCasing:
     """Sink names must be lowercase - explicit validation, no silent transformation."""

--- a/tests/unit/web/execution/test_service.py
+++ b/tests/unit/web/execution/test_service.py
@@ -928,7 +928,8 @@ class TestInlineBlobRuntimePreflight:
         cast(Any, service)._blob_service = blob_service
         mock_session_service.record_blob_inline_resolutions = AsyncMock(side_effect=record_blob_inline_resolutions)
 
-        def load_settings(yaml_text: str) -> MagicMock:
+        def load_settings(yaml_text: str, *, expand_env_vars: bool) -> MagicMock:
+            assert expand_env_vars is False
             assert "record" in order, "audit row must be recorded before settings/plugin construction"
             assert "You are an audited prompt." in yaml_text
             assert "blob_ref" not in yaml_text

--- a/tests/unit/web/execution/test_validate_blob_inline.py
+++ b/tests/unit/web/execution/test_validate_blob_inline.py
@@ -175,7 +175,8 @@ def test_validate_substitutes_ready_inline_blob_marker_before_settings_load(
 ) -> None:
     session_id = uuid4()
 
-    def load_settings(yaml_text: str) -> SimpleNamespace:
+    def load_settings(yaml_text: str, *, expand_env_vars: bool) -> SimpleNamespace:
+        assert expand_env_vars is False
         doc = yaml.safe_load(yaml_text)
         prompt_template = doc["transforms"][0]["options"]["prompt_template"]
         assert type(prompt_template) is str


### PR DESCRIPTION
### Motivation
- The web execution path loaded web-authored pipeline YAML with host `${VAR}` expansion enabled, allowing a transform (`value_transform`) to receive environment-expanded expressions and targets and thus exfiltrate host env secrets.
- The intent is to keep CLI/trusted callers' existing `${VAR}` expansion while preventing web-authored, in-memory configs from turning host env vars into pipeline data after audited secret resolution.

### Description
- Add an opt-out flag to the in-memory loader: `load_settings_from_yaml_string(yaml_content: str, *, expand_env_vars: bool = True)` and only call `_expand_env_vars()` when `expand_env_vars` is True (`src/elspeth/core/config.py`).
- Disable host env expansion in the web runtime path by calling `load_settings_from_yaml_string(..., expand_env_vars=False)` in the execution service (`src/elspeth/web/execution/service.py`).
- Keep validation preflight in parity with execution by disabling host env expansion there as well (`src/elspeth/web/execution/validation.py`) and update in-code comments accordingly.
- Add regression tests that verify web-authored YAML preserves `${VAR}` literals when expansion is disabled and that default callers still get expansion; update web loader mocks to assert the safe `expand_env_vars=False` call (`tests/unit/core/test_config.py`, `tests/unit/web/execution/test_service.py`, `tests/unit/web/execution/test_validate_blob_inline.py`).

### Testing
- `git diff --check` succeeded and files were committed.
- Byte-compile checks (`.venv/bin/python -m compileall -q`) and manual regression assertions using `PYTHONPATH=src .venv/bin/python` passed (confirmed that `expand_env_vars=False` preserves `${VAR}` literals and default behavior remains unchanged).
- Configuration contracts check (`PYTHONPATH=src .venv/bin/python -m scripts.check_contracts`) completed successfully.
- `pytest` could not be executed in the agent environment because `pytest` was not available in the existing venv and `uv run --extra dev` could not fetch test dependencies (`pytest-asyncio`) due to network/PyPI fetch failure, so the full test matrix was not run here.
- The `trust_tier.tier_model` lint run could not complete in this environment because `ELSPETH_JUDGE_METADATA_HMAC_KEY` is not available to verify allowlist metadata.  All local assertions and checks above are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225dc24b9c8323bb4b2834136cd2d5)