### PR TITLE
fix: constrain web Chroma boundaries

### DIFF
--- a/src/elspeth/web/execution/chroma_boundaries.py
+++ b/src/elspeth/web/execution/chroma_boundaries.py
@@ -1,0 +1,174 @@
+"""Web execution boundary checks for Chroma-backed plugins.
+
+Chroma plugins are available when the optional ``chromadb`` dependency is
+installed. In the web app their storage and network targets are still Tier-3
+user-controlled execution inputs, so they must pass the same filesystem and
+SSRF boundaries as first-class web source/sink options before the runtime SDK
+is allowed to touch disk or open sockets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from elspeth.core.security.web import NetworkError, SSRFBlockedError, validate_url_for_ssrf
+from elspeth.web.composer.state import CompositionState
+from elspeth.web.paths import allowed_sink_directories, resolve_data_path
+
+_CHROMA_SINK_PLUGIN = "chroma_sink"
+_RAG_RETRIEVAL_PLUGIN = "rag_retrieval"
+_CHROMA_PROVIDER = "chroma"
+
+ComponentType = Literal["sink", "transform"]
+
+
+@dataclass(frozen=True, slots=True)
+class ChromaBoundaryViolation:
+    """A web-authored Chroma target escaped a web boundary."""
+
+    component_id: str
+    component_type: ComponentType
+    message: str
+    detail: str
+    suggestion: str
+
+
+def find_chroma_boundary_violations(
+    state: CompositionState,
+    *,
+    data_dir: str,
+) -> tuple[ChromaBoundaryViolation, ...]:
+    """Return Chroma filesystem/network boundary violations in a composition.
+
+    The checks are deliberately web-scoped. CLI and test pipelines may still
+    configure Chroma as general infrastructure, but authenticated web users may
+    only use persistent storage under the web sink directories and may only use
+    client hosts that pass the central SSRF DNS/IP policy.
+    """
+    violations: list[ChromaBoundaryViolation] = []
+
+    for output in state.outputs or ():
+        if output.plugin != _CHROMA_SINK_PLUGIN:
+            continue
+        violations.extend(
+            _validate_chroma_options(
+                options=output.options,
+                component_id=output.name,
+                component_type="sink",
+                data_dir=data_dir,
+            )
+        )
+
+    for node in state.nodes or ():
+        if node.plugin != _RAG_RETRIEVAL_PLUGIN:
+            continue
+        options = node.options
+        if options.get("provider") != _CHROMA_PROVIDER:
+            continue
+        provider_config = options.get("provider_config")
+        if not isinstance(provider_config, Mapping):
+            # Runtime config validation owns malformed provider_config shape.
+            continue
+        violations.extend(
+            _validate_chroma_options(
+                options=provider_config,
+                component_id=node.id,
+                component_type="transform",
+                data_dir=data_dir,
+            )
+        )
+
+    return tuple(violations)
+
+
+def _validate_chroma_options(
+    *,
+    options: Mapping[str, Any],
+    component_id: str,
+    component_type: ComponentType,
+    data_dir: str,
+) -> tuple[ChromaBoundaryViolation, ...]:
+    mode = options.get("mode")
+    if mode == "persistent":
+        persist_directory = options.get("persist_directory")
+        if persist_directory is None:
+            return ()
+        return _validate_persist_directory(
+            value=str(persist_directory),
+            component_id=component_id,
+            component_type=component_type,
+            data_dir=data_dir,
+        )
+    if mode == "client":
+        host = options.get("host")
+        if host is None:
+            return ()
+        return _validate_client_target(
+            host=str(host),
+            port=options.get("port", 8000),
+            ssl=options.get("ssl", True),
+            component_id=component_id,
+            component_type=component_type,
+        )
+    return ()
+
+
+def _validate_persist_directory(
+    *,
+    value: str,
+    component_id: str,
+    component_type: ComponentType,
+    data_dir: str,
+) -> tuple[ChromaBoundaryViolation, ...]:
+    resolved = resolve_data_path(value, data_dir)
+    allowed_dirs = allowed_sink_directories(data_dir)
+    if any(resolved.is_relative_to(allowed) for allowed in allowed_dirs):
+        return ()
+    return (
+        ChromaBoundaryViolation(
+            component_id=component_id,
+            component_type=component_type,
+            message=(
+                f"Chroma persist_directory blocked: {component_type} "
+                f"'{component_id}' persist_directory='{value}' resolves outside allowed output directories"
+            ),
+            detail=(
+                f"{component_type} {component_id} persist_directory resolves outside "
+                "data_dir/outputs and data_dir/blobs"
+            ),
+            suggestion="Use a Chroma persist_directory under the outputs or blobs directory.",
+        ),
+    )
+
+
+def _validate_client_target(
+    *,
+    host: str,
+    port: object,
+    ssl: object,
+    component_id: str,
+    component_type: ComponentType,
+) -> tuple[ChromaBoundaryViolation, ...]:
+    scheme = "https" if ssl is not False else "http"
+    host_for_url = host
+    if "://" not in host_for_url and ":" in host_for_url and not host_for_url.startswith("["):
+        host_for_url = f"[{host_for_url}]"
+    url = f"{scheme}://{host_for_url}:{port}/"
+    try:
+        validate_url_for_ssrf(url)
+    except (SSRFBlockedError, NetworkError) as exc:
+        return (
+            ChromaBoundaryViolation(
+                component_id=component_id,
+                component_type=component_type,
+                message=(
+                    f"Chroma client target blocked: {component_type} "
+                    f"'{component_id}' host='{host}' port='{port}' failed SSRF validation"
+                ),
+                detail=f"{component_type} {component_id} Chroma client target failed SSRF validation: {exc}",
+                suggestion="Use a publicly resolvable Chroma endpoint that passes the web SSRF policy.",
+            ),
+        )
+    return ()

--- a/src/elspeth/web/execution/preflight.py
+++ b/src/elspeth/web/execution/preflight.py
@@ -92,6 +92,30 @@ def resolve_runtime_yaml_paths(pipeline_yaml: str, data_dir: str) -> str:
                     for key in ("path", "file"):
                         if key in opts and not Path(str(opts[key])).is_absolute():
                             opts[key] = str(resolve_data_path(str(opts[key]), data_dir))
+                    if sink_cfg.get("plugin") == "chroma_sink" and opts.get("mode") == "persistent":
+                        key = "persist_directory"
+                        if key in opts and not Path(str(opts[key])).is_absolute():
+                            opts[key] = str(resolve_data_path(str(opts[key]), data_dir))
+
+    transforms = config.get("transforms")
+    if transforms is not None:
+        if not isinstance(transforms, list):
+            raise TypeError(f"YAML generator produced non-list 'transforms' value (got {type(transforms).__name__})")
+        for index, transform_cfg in enumerate(transforms):
+            if not isinstance(transform_cfg, dict):
+                raise TypeError(f"YAML generator produced non-dict transform at index {index} (got {type(transform_cfg).__name__})")
+            opts = transform_cfg.get("options")
+            if not isinstance(opts, dict):
+                continue
+            if opts.get("provider") != "chroma":
+                continue
+            provider_config = opts.get("provider_config")
+            if not isinstance(provider_config, dict):
+                continue
+            if provider_config.get("mode") == "persistent":
+                key = "persist_directory"
+                if key in provider_config and not Path(str(provider_config[key])).is_absolute():
+                    provider_config[key] = str(resolve_data_path(str(provider_config[key]), data_dir))
 
     return yaml.dump(config, default_flow_style=False)
 

--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -64,6 +64,7 @@ from elspeth.web.composer._semantic_validator import validate_semantic_contracts
 from elspeth.web.composer.state import CompositionState
 from elspeth.web.config import WebSettings
 from elspeth.web.execution.accounting import load_run_accounting_from_db
+from elspeth.web.execution.chroma_boundaries import find_chroma_boundary_violations
 from elspeth.web.execution.errors import (
     BlobSourcePathMismatchError,
     MalformedBlobRefError,
@@ -549,6 +550,13 @@ class ExecutionServiceImpl:
                             raise PathAllowlistViolationError(
                                 f"Sink '{output.name}' {key}='{value}' resolves outside allowed output directories"
                             )
+
+        chroma_violations = find_chroma_boundary_violations(
+            composition_state,
+            data_dir=str(self._settings.data_dir),
+        )
+        if chroma_violations:
+            raise PathAllowlistViolationError(chroma_violations[0].message)
 
         pipeline_yaml = self._yaml_generator.generate_yaml(composition_state)
 

--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -66,6 +66,7 @@ from elspeth.web.execution._semantic_helpers import (
     assistance_suggestion_for,
     serialize_semantic_contracts,
 )
+from elspeth.web.execution.chroma_boundaries import find_chroma_boundary_violations
 from elspeth.web.execution.preflight import (
     RUNTIME_CHECK_GRAPH_STRUCTURE,
     RUNTIME_CHECK_PLUGIN_INSTANTIATION,
@@ -805,6 +806,38 @@ def validate_pipeline(
                             component_type="sink",
                         ),
                     )
+
+    chroma_violations = find_chroma_boundary_violations(state, data_dir=str(settings.data_dir))
+    if chroma_violations:
+        violation = chroma_violations[0]
+        return ValidationResult(
+            is_valid=False,
+            checks=[
+                ValidationCheck(
+                    name=_CHECK_PATH_ALLOWLIST,
+                    passed=False,
+                    detail=violation.detail,
+                    affected_nodes=(),
+                    outcome_code=None,
+                ),
+                *_skipped_checks(_CHECK_PATH_ALLOWLIST),
+            ],
+            errors=[
+                ValidationError(
+                    component_id=violation.component_id,
+                    component_type=violation.component_type,
+                    message=violation.message,
+                    suggestion=violation.suggestion,
+                    error_code=None,
+                ),
+            ],
+            readiness=_blocked_readiness(
+                code="path_allowlist",
+                detail=violation.detail,
+                component_id=violation.component_id,
+                component_type=violation.component_type,
+            ),
+        )
 
     # B11 fix: Always record the path_allowlist check
     if path_checked:

--- a/tests/unit/web/execution/test_service.py
+++ b/tests/unit/web/execution/test_service.py
@@ -3772,6 +3772,60 @@ class TestSinkPathRestriction:
             run_id = await service.execute(session_id=uuid4())
         assert isinstance(run_id, UUID)
 
+    @pytest.mark.asyncio
+    async def test_chroma_persist_directory_outside_allowed_dirs_raises(
+        self,
+        service: ExecutionServiceImpl,
+        mock_session_service: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        """Chroma persist_directory cannot bypass /execute sink directory guards."""
+        mock_settings.data_dir = "/tmp/elspeth_data"
+        state = mock_session_service.get_current_state.return_value
+        state.source = None
+        state.outputs = [
+            {
+                "name": "chroma",
+                "plugin": "chroma_sink",
+                "options": {"mode": "persistent", "persist_directory": "/tmp/outside_chroma"},
+                "on_write_failure": "discard",
+            }
+        ]
+        state.nodes = None
+        state.edges = None
+
+        from elspeth.web.execution.errors import PathAllowlistViolationError
+
+        with pytest.raises(PathAllowlistViolationError, match="persist_directory"):
+            await service.execute(session_id=uuid4())
+
+    @pytest.mark.asyncio
+    async def test_chroma_client_loopback_raises(
+        self,
+        service: ExecutionServiceImpl,
+        mock_session_service: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        """Chroma client hosts use the same central SSRF blocklist at /execute."""
+        mock_settings.data_dir = "/tmp/elspeth_data"
+        state = mock_session_service.get_current_state.return_value
+        state.source = None
+        state.outputs = [
+            {
+                "name": "chroma",
+                "plugin": "chroma_sink",
+                "options": {"mode": "client", "host": "169.254.169.254", "port": 8000, "ssl": True},
+                "on_write_failure": "discard",
+            }
+        ]
+        state.nodes = None
+        state.edges = None
+
+        from elspeth.web.execution.errors import PathAllowlistViolationError
+
+        with pytest.raises(PathAllowlistViolationError, match="SSRF validation"):
+            await service.execute(session_id=uuid4())
+
 
 # ── Transform Framing Restriction ─────────────────────────────────────
 

--- a/tests/unit/web/execution/test_validation.py
+++ b/tests/unit/web/execution/test_validation.py
@@ -660,6 +660,69 @@ class TestValidatePipelineSinkPathAllowlist:
         path_check = next(c for c in result.checks if c.name == "path_allowlist")
         assert path_check.passed is True
 
+    def test_chroma_sink_persist_directory_outside_outputs_blocked(self) -> None:
+        state = _make_state(
+            source_options={},
+            outputs=(
+                _make_output(
+                    name="chroma",
+                    plugin="chroma_sink",
+                    options={
+                        "mode": "persistent",
+                        "persist_directory": "/tmp/outside_chroma",
+                    },
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        result = validate_pipeline(state, settings, MagicMock(spec=YamlGenerator))
+        assert result.is_valid is False
+        assert any("persist_directory" in e.message for e in result.errors)
+        assert any("chroma" in e.message for e in result.errors)
+
+    def test_chroma_sink_client_loopback_blocked_by_ssrf_policy(self) -> None:
+        state = _make_state(
+            source_options={},
+            outputs=(
+                _make_output(
+                    name="chroma",
+                    plugin="chroma_sink",
+                    options={
+                        "mode": "client",
+                        "host": "127.0.0.1",
+                        "port": 8000,
+                        "ssl": False,
+                    },
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        result = validate_pipeline(state, settings, MagicMock(spec=YamlGenerator))
+        assert result.is_valid is False
+        assert any("SSRF validation" in e.message for e in result.errors)
+
+    def test_rag_chroma_persist_directory_outside_outputs_blocked(self) -> None:
+        state = _make_state(
+            source_options={},
+            nodes=(
+                _make_node(
+                    plugin="rag_retrieval",
+                    options={
+                        "provider": "chroma",
+                        "provider_config": {
+                            "mode": "persistent",
+                            "persist_directory": "/tmp/outside_chroma",
+                        },
+                    },
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        result = validate_pipeline(state, settings, MagicMock(spec=YamlGenerator))
+        assert result.is_valid is False
+        assert any(e.component_type == "transform" for e in result.errors)
+        assert any("persist_directory" in e.message for e in result.errors)
+
 
 class TestValidatePipelineSemanticContractsLegacy:
     """Validation must catch transform pairings that violate line framing.


### PR DESCRIPTION
### Motivation
- Prevent web-authenticated pipeline authors from using Chroma plugins to write persistent data outside the web allowlisted sink directories or to target internal/loopback hosts, closing the boundary bypass introduced when `chromadb` became a default dependency.
- Ensure `/validate` and `/execute` enforce the same filesystem and SSRF rules so validation cannot be skipped to reach unsafe Chroma code paths.

### Description
- Add `src/elspeth/web/execution/chroma_boundaries.py` which implements web-scoped checks that require Chroma `persist_directory` to resolve under `data_dir/outputs` or `data_dir/blobs` and that validate Chroma client hosts via the central SSRF DNS/IP validator. 
- Wire the checks into runtime execution by calling `find_chroma_boundary_violations()` from `/execute` (`ExecutionServiceImpl`) and raising `PathAllowlistViolationError` when violations are found. 
- Surface the same checks in `/validate` (`validate_pipeline`) and return a structured `ValidationResult` with component attribution and remediation suggestion when a violation is detected. 
- Extend `resolve_runtime_yaml_paths()` in `preflight.py` to resolve relative `persist_directory` occurrences for `chroma_sink` and RAG provider `provider_config.persist_directory` to absolute paths under `data_dir` before plugin construction. 
- Add unit-level regression coverage (tests updated) exercising Chroma persist-directory blocking and client SSRF blocking for both sinks and RAG provider configs.

### Testing
- Ran static checks with `uv run ruff check` against the changed files and the linter passed. 
- Compiled modified modules with `python -m compileall` to verify syntax and import-time failures and compilation succeeded. 
- Executed targeted, in-tree Python smoke checks that build `CompositionState` objects and invoked `find_chroma_boundary_violations()`, `validate_pipeline()` and `resolve_runtime_yaml_paths()` and these manual checks passed. 
- Attempted to run the targeted pytest vectors but the test runner could not be executed in this environment because dev test dependencies (e.g. `pytest-asyncio` / `hypothesis`) could not be fetched; this prevented running the full pytest selection here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cde7fe0c8323b21276bebf28bfc2)