### PR TITLE
fix: constrain Chroma filesystem and host targets

### DIFF
--- a/src/elspeth/plugins/infrastructure/clients/retrieval/connection.py
+++ b/src/elspeth/plugins/infrastructure/clients/retrieval/connection.py
@@ -7,10 +7,57 @@ validators) and discarding the instance.
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from elspeth.core.security.web import NetworkError, SSRFBlockedError, validate_url_for_ssrf
+
+_LOOPBACK_HOSTS = {"localhost"}
+_LOOPBACK_ALLOWED_RANGES = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+)
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower().removesuffix(".")
+    if normalized in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(normalized.strip("[]")).is_loopback
+    except ValueError:
+        return False
+
+
+def _host_url(host: str, port: int, *, ssl: bool) -> str:
+    if "://" in host or "/" in host or "?" in host or "#" in host:
+        raise ValueError(f"host must be a bare hostname or IP address, got {host!r}")
+    try:
+        parsed_ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        url_host = host
+    else:
+        url_host = f"[{parsed_ip}]" if parsed_ip.version == 6 else str(parsed_ip)
+    scheme = "https" if ssl else "http"
+    return f"{scheme}://{url_host}:{port}/"
+
+
+def _validate_chroma_http_target(host: str, port: int, *, ssl: bool) -> None:
+    """Apply the project SSRF policy before handing the target to Chroma SDK.
+
+    The SDK owns the actual HTTP transport, so we cannot use
+    AuditedHTTPClient's pinned-IP request path here. This preflight still
+    enforces the same host/IP blocklist for user-authored Chroma targets and
+    keeps loopback-only local development explicitly bounded.
+    """
+    allowed_ranges = _LOOPBACK_ALLOWED_RANGES if _is_loopback_host(host) else ()
+    try:
+        validate_url_for_ssrf(_host_url(host, port, ssl=ssl), allowed_ranges=allowed_ranges)
+    except (SSRFBlockedError, NetworkError) as exc:
+        raise ValueError(f"ChromaDB host {host!r} is blocked by the SSRF policy: {exc}") from exc
 
 
 class ChromaConnectionConfig(BaseModel):
@@ -68,10 +115,11 @@ class ChromaConnectionConfig(BaseModel):
                 raise ValueError("host is required when mode='client'")
             if self.persist_directory is not None:
                 raise ValueError("persist_directory must not be set when mode='client'")
-            if not self.ssl and self.host not in ("localhost", "127.0.0.1", "::1"):
+            if not self.ssl and not _is_loopback_host(self.host):
                 raise ValueError(
                     f"HTTPS (ssl=True) is required for remote ChromaDB hosts, "
                     f"got host={self.host!r} with ssl=False. "
                     f"Non-SSL connections are only permitted for localhost."
                 )
+            _validate_chroma_http_target(self.host, self.port, ssl=self.ssl)
         return self

--- a/src/elspeth/web/execution/preflight.py
+++ b/src/elspeth/web/execution/preflight.py
@@ -13,7 +13,7 @@ import yaml
 from elspeth.cli_helpers import PluginBundle, instantiate_plugins_from_config
 from elspeth.core.dag.graph import ExecutionGraph
 from elspeth.web.execution.protocol import ValidationSettings
-from elspeth.web.paths import resolve_data_path
+from elspeth.web.paths import NESTED_PATH_OPTION_KEYS, SINK_PATH_OPTION_KEYS, SOURCE_PATH_OPTION_KEYS, resolve_data_path
 
 RUNTIME_CHECK_PLUGIN_INSTANTIATION = "plugin_instantiation"
 RUNTIME_CHECK_GRAPH_STRUCTURE = "graph_structure"
@@ -73,9 +73,31 @@ def resolve_runtime_yaml_paths(pipeline_yaml: str, data_dir: str) -> str:
         opts = source["options"]
         if not isinstance(opts, dict):
             raise TypeError(f"YAML generator produced non-dict 'source.options' value (got {type(opts).__name__})")
-        for key in ("path", "file"):
+        for key in SOURCE_PATH_OPTION_KEYS:
             if key in opts and not Path(str(opts[key])).is_absolute():
                 opts[key] = str(resolve_data_path(str(opts[key]), data_dir))
+
+    transforms = config.get("transforms")
+    if transforms is not None:
+        if not isinstance(transforms, list):
+            raise TypeError(f"YAML generator produced non-list 'transforms' value (got {type(transforms).__name__})")
+        for index, transform_cfg in enumerate(transforms):
+            if not isinstance(transform_cfg, dict):
+                raise TypeError(f"YAML generator produced non-dict transform at index {index} (got {type(transform_cfg).__name__})")
+            opts = transform_cfg.get("options")
+            if opts is not None:
+                if not isinstance(opts, dict):
+                    raise TypeError(f"YAML generator produced non-dict 'transforms[{index}].options' value (got {type(opts).__name__})")
+                provider_config = opts.get("provider_config")
+                if provider_config is not None:
+                    if not isinstance(provider_config, dict):
+                        raise TypeError(
+                            f"YAML generator produced non-dict 'transforms[{index}].options.provider_config' value "
+                            f"(got {type(provider_config).__name__})"
+                        )
+                    for key in NESTED_PATH_OPTION_KEYS:
+                        if key in provider_config and not Path(str(provider_config[key])).is_absolute():
+                            provider_config[key] = str(resolve_data_path(str(provider_config[key]), data_dir))
 
     sinks = config.get("sinks")
     if sinks is not None:
@@ -89,7 +111,7 @@ def resolve_runtime_yaml_paths(pipeline_yaml: str, data_dir: str) -> str:
                 if opts is not None:
                     if not isinstance(opts, dict):
                         raise TypeError(f"YAML generator produced non-dict 'sinks.{sink_name}.options' value (got {type(opts).__name__})")
-                    for key in ("path", "file"):
+                    for key in SINK_PATH_OPTION_KEYS:
                         if key in opts and not Path(str(opts[key])).is_absolute():
                             opts[key] = str(resolve_data_path(str(opts[key]), data_dir))
 

--- a/src/elspeth/web/execution/service.py
+++ b/src/elspeth/web/execution/service.py
@@ -523,10 +523,10 @@ class ExecutionServiceImpl:
         # authenticated user could skip validation and execute a state that
         # reads files outside the allowed directories.
         if composition_state.source is not None:
-            from elspeth.web.paths import allowed_source_directories, resolve_data_path
+            from elspeth.web.paths import SOURCE_PATH_OPTION_KEYS, allowed_source_directories, resolve_data_path
 
             allowed_dirs = allowed_source_directories(str(self._settings.data_dir))
-            for key in ("path", "file"):
+            for key in SOURCE_PATH_OPTION_KEYS:
                 value = composition_state.source.options.get(key)
                 if value is not None:
                     resolved = resolve_data_path(value, str(self._settings.data_dir))
@@ -535,13 +535,29 @@ class ExecutionServiceImpl:
 
         # Sink path allowlist — prevents arbitrary file writes via sink options.
         # Without this, a client can set sink options.path to any absolute or
-        # ../ path and /execute will write there.
-        if composition_state.outputs:
-            from elspeth.web.paths import allowed_sink_directories, resolve_data_path
+        # ../ path and /execute will write there. Chroma's RAG provider and
+        # sink also expose persist_directory, which is likewise a write/read
+        # path for local vector-store files.
+        from elspeth.web.paths import NESTED_PATH_OPTION_KEYS, SINK_PATH_OPTION_KEYS, allowed_sink_directories, resolve_data_path
 
-            allowed_sink_dirs = allowed_sink_directories(str(self._settings.data_dir))
+        allowed_sink_dirs = allowed_sink_directories(str(self._settings.data_dir))
+
+        for node in composition_state.nodes:
+            provider_config = node.options.get("provider_config")
+            if not isinstance(provider_config, dict):
+                continue
+            for nested_key in NESTED_PATH_OPTION_KEYS:
+                value = provider_config.get(nested_key)
+                if value is not None:
+                    resolved = resolve_data_path(value, str(self._settings.data_dir))
+                    if not any(resolved.is_relative_to(d) for d in allowed_sink_dirs):
+                        raise PathAllowlistViolationError(
+                            f"Node '{node.id}' provider_config.{nested_key}='{value}' resolves outside allowed output directories"
+                        )
+
+        if composition_state.outputs:
             for output in composition_state.outputs:
-                for key in ("path", "file"):
+                for key in SINK_PATH_OPTION_KEYS:
                     value = output.options.get(key)
                     if value is not None:
                         resolved = resolve_data_path(value, str(self._settings.data_dir))

--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -723,10 +723,17 @@ def validate_pipeline(
             ),
         )
 
-    # Step 1: Source + sink path allowlist check (C3/S2 defense-in-depth)
-    # Any `path` or `file` key in source/sink options must resolve under
-    # an allowed directory. Uses the shared helpers from AD-4.
-    from elspeth.web.paths import allowed_sink_directories, allowed_source_directories, resolve_data_path
+    # Step 1: Source + sink path allowlist check (C3/S2 defense-in-depth).
+    # Known filesystem option keys must resolve under allowed directories,
+    # including Chroma persist_directory in sink options and RAG provider_config.
+    from elspeth.web.paths import (
+        NESTED_PATH_OPTION_KEYS,
+        SINK_PATH_OPTION_KEYS,
+        SOURCE_PATH_OPTION_KEYS,
+        allowed_sink_directories,
+        allowed_source_directories,
+        resolve_data_path,
+    )
 
     allowed_source_dirs = allowed_source_directories(str(settings.data_dir))
     allowed_sink_dirs = allowed_sink_directories(str(settings.data_dir))
@@ -734,7 +741,7 @@ def validate_pipeline(
     # SourceSpec with typed .options attribute (Mapping[str, Any]).
     source_options = dict(state.source.options) if state.source is not None else {}
     path_checked = False
-    for key in ("path", "file"):
+    for key in SOURCE_PATH_OPTION_KEYS:
         value = source_options.get(key)
         if value is not None:
             path_checked = True
@@ -769,9 +776,51 @@ def validate_pipeline(
                     ),
                 )
 
+    for node in state.nodes or ():
+        provider_config = node.options.get("provider_config")
+        if not isinstance(provider_config, dict):
+            continue
+        for nested_key in NESTED_PATH_OPTION_KEYS:
+            value = provider_config.get(nested_key)
+            if value is not None:
+                path_checked = True
+                resolved = resolve_data_path(value, str(settings.data_dir))
+                if not any(resolved.is_relative_to(d) for d in allowed_sink_dirs):
+                    return ValidationResult(
+                        is_valid=False,
+                        checks=[
+                            ValidationCheck(
+                                name=_CHECK_PATH_ALLOWLIST,
+                                passed=False,
+                                detail=f"Node '{node.id}' provider_config.{nested_key} '{value}' is outside allowed output directories",
+                                affected_nodes=(node.id,),
+                                outcome_code=None,
+                            ),
+                            *_skipped_checks(_CHECK_PATH_ALLOWLIST),
+                        ],
+                        errors=[
+                            ValidationError(
+                                component_id=node.id,
+                                component_type=node.node_type,
+                                message=(
+                                    f"Path traversal blocked: node '{node.id}' provider_config.{nested_key}='{value}' "
+                                    "resolves outside allowed directories"
+                                ),
+                                suggestion="Use a path within the outputs or blobs directory.",
+                                error_code=None,
+                            ),
+                        ],
+                        readiness=_blocked_readiness(
+                            code="path_allowlist",
+                            detail=f"node {node.id} provider_config.{nested_key} resolves outside allowed output directories",
+                            component_id=node.id,
+                            component_type=node.node_type,
+                        ),
+                    )
+
     # Sink path allowlist — prevents arbitrary file writes via sink options.
     for output in state.outputs or ():
-        for key in ("path", "file"):
+        for key in SINK_PATH_OPTION_KEYS:
             value = output.options.get(key)
             if value is not None:
                 path_checked = True

--- a/src/elspeth/web/paths.py
+++ b/src/elspeth/web/paths.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+SOURCE_PATH_OPTION_KEYS: tuple[str, ...] = ("path", "file")
+SINK_PATH_OPTION_KEYS: tuple[str, ...] = ("path", "file", "persist_directory")
+# Nested under transform options.provider_config for retrieval providers that
+# read/write local indexes. Keep this list deliberately narrow: broader nested
+# scanning would treat arbitrary plugin dictionaries as filesystem contracts.
+NESTED_PATH_OPTION_KEYS: tuple[str, ...] = ("persist_directory",)
+
 
 def resolve_data_path(value: str, data_dir: str) -> Path:
     """Resolve a path value against data_dir (relative) or as-is (absolute).

--- a/tests/unit/plugins/infrastructure/clients/retrieval/test_chroma.py
+++ b/tests/unit/plugins/infrastructure/clients/retrieval/test_chroma.py
@@ -81,6 +81,26 @@ class TestChromaSearchProviderConfig:
                 ssl=False,
             )
 
+    def test_client_mode_blocks_metadata_service_host(self):
+        with pytest.raises(ValueError, match="SSRF policy"):
+            ChromaSearchProviderConfig(
+                collection="test",
+                mode="client",
+                host="169.254.169.254",
+                port=8000,
+                ssl=True,
+            )
+
+    def test_client_mode_rejects_host_with_scheme(self):
+        with pytest.raises(ValueError, match="bare hostname"):
+            ChromaSearchProviderConfig(
+                collection="test",
+                mode="client",
+                host="https://chroma.example.com",
+                port=443,
+                ssl=True,
+            )
+
     def test_client_mode_allows_http_for_localhost(self):
         config = ChromaSearchProviderConfig(
             collection="test",

--- a/tests/unit/plugins/infrastructure/test_probe_factory.py
+++ b/tests/unit/plugins/infrastructure/test_probe_factory.py
@@ -149,7 +149,7 @@ class TestChromaCollectionProbeBehavior:
 
     def test_client_mode_uses_http_client(self) -> None:
         """Client mode should use HttpClient instead of PersistentClient."""
-        probe = ChromaCollectionProbe("remote", {"mode": "client", "host": "chroma.local", "port": 8000, "ssl": True})
+        probe = ChromaCollectionProbe("remote", {"mode": "client", "host": "localhost", "port": 8000, "ssl": True})
 
         mock_collection = MagicMock()
         mock_collection.count.return_value = 5
@@ -160,7 +160,7 @@ class TestChromaCollectionProbeBehavior:
         with patch("chromadb.HttpClient", return_value=mock_client) as mock_http_cls:
             result = probe.probe()
 
-        mock_http_cls.assert_called_once_with(host="chroma.local", port=8000, ssl=True)
+        mock_http_cls.assert_called_once_with(host="localhost", port=8000, ssl=True)
         assert result.reachable is True
         assert result.count == 5
 
@@ -193,7 +193,7 @@ class TestChromaCollectionProbeConfigValidation:
 
     def test_valid_client_config_accepted(self) -> None:
         """Valid client config should construct successfully."""
-        probe = ChromaCollectionProbe("test-col", {"mode": "client", "host": "chroma.local"})
+        probe = ChromaCollectionProbe("test-col", {"mode": "client", "host": "localhost"})
         assert probe.collection_name == "test-col"
 
 

--- a/tests/unit/web/execution/test_service.py
+++ b/tests/unit/web/execution/test_service.py
@@ -3747,6 +3747,65 @@ class TestSinkPathRestriction:
         assert isinstance(run_id, UUID)
 
     @pytest.mark.asyncio
+    async def test_rag_provider_persist_directory_outside_allowed_dirs_raises(
+        self,
+        service: ExecutionServiceImpl,
+        mock_session_service: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        """Execution rejects nested Chroma provider persistence paths."""
+        mock_settings.data_dir = "/tmp/elspeth_data"
+        state = mock_session_service.get_current_state.return_value
+        state.source = None
+        state.outputs = None
+        state.nodes = [
+            {
+                "id": "rag",
+                "node_type": "transform",
+                "plugin": "rag_retrieval",
+                "input": "in",
+                "on_success": "out",
+                "on_error": "discard",
+                "options": {"provider_config": {"mode": "persistent", "persist_directory": "/tmp/rag-chroma-outside"}},
+            }
+        ]
+        state.edges = None
+
+        from elspeth.web.execution.errors import PathAllowlistViolationError
+
+        with pytest.raises(
+            PathAllowlistViolationError, match=r"provider_config.persist_directory=.*resolves outside allowed output directories"
+        ):
+            await service.execute(session_id=uuid4())
+
+    @pytest.mark.asyncio
+    async def test_sink_persist_directory_outside_allowed_dirs_raises(
+        self,
+        service: ExecutionServiceImpl,
+        mock_session_service: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        """Chroma persist_directory is a sink write path, not a generic option."""
+        mock_settings.data_dir = "/tmp/elspeth_data"
+        state = mock_session_service.get_current_state.return_value
+        state.source = None
+        state.outputs = [
+            {
+                "name": "chroma",
+                "plugin": "chroma_sink",
+                "options": {"persist_directory": "/tmp/chroma-outside"},
+                "on_write_failure": "discard",
+            }
+        ]
+        state.nodes = None
+        state.edges = None
+
+        from elspeth.web.execution.errors import PathAllowlistViolationError
+
+        with pytest.raises(PathAllowlistViolationError, match=r"persist_directory=.*resolves outside allowed output directories"):
+            await service.execute(session_id=uuid4())
+
+    @pytest.mark.asyncio
     async def test_sink_without_path_option_passes(
         self,
         service: ExecutionServiceImpl,
@@ -4832,6 +4891,20 @@ class TestResolveYamlPaths:
         yaml_str = "source:\n  plugin: csv\n  options:\n    path: /abs/in.csv\nsinks:\n  primary:\n    plugin: csv\n    options:\n      file: output/results.csv\n"
         result = _resolve_yaml_paths(yaml_str, "/srv/data")
         assert "/srv/data/output/results.csv" in result
+
+    def test_transform_relative_provider_persist_directory_rewritten(self) -> None:
+        from elspeth.web.execution.preflight import resolve_runtime_yaml_paths as _resolve_yaml_paths
+
+        yaml_str = "transforms:\n  - name: rag\n    plugin: rag_retrieval\n    options:\n      provider_config:\n        mode: persistent\n        persist_directory: outputs/chroma-rag\n"
+        result = _resolve_yaml_paths(yaml_str, "/srv/data")
+        assert "/srv/data/outputs/chroma-rag" in result
+
+    def test_sink_relative_persist_directory_rewritten(self) -> None:
+        from elspeth.web.execution.preflight import resolve_runtime_yaml_paths as _resolve_yaml_paths
+
+        yaml_str = "source:\n  plugin: csv\n  options:\n    path: /abs/in.csv\nsinks:\n  chroma:\n    plugin: chroma_sink\n    options:\n      persist_directory: outputs/chroma-index\n"
+        result = _resolve_yaml_paths(yaml_str, "/srv/data")
+        assert "/srv/data/outputs/chroma-index" in result
 
     def test_non_string_input_raises_type_error(self) -> None:
         from elspeth.web.execution.preflight import resolve_runtime_yaml_paths as _resolve_yaml_paths

--- a/tests/unit/web/execution/test_validation.py
+++ b/tests/unit/web/execution/test_validation.py
@@ -236,6 +236,72 @@ class TestValidatePipelinePathAllowlist:
         result = validate_pipeline(state, settings, mock_yaml_gen)
         assert result.is_valid is False
 
+    def test_rag_provider_persist_directory_outside_outputs_blocked(self) -> None:
+        """Chroma RAG provider persistence is covered by the web path allowlist."""
+        state = _make_state(
+            source_options={},
+            nodes=(
+                _make_node(
+                    {
+                        "provider_config": {"mode": "persistent", "persist_directory": "/tmp/rag-chroma-outside"},
+                        "schema": {"mode": "observed"},
+                    },
+                    plugin="rag_retrieval",
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        result = validate_pipeline(state, settings, MagicMock(spec=YamlGenerator))
+
+        assert result.is_valid is False
+        assert _check(result, "path_allowlist").passed is False
+        assert any("provider_config.persist_directory" in e.message for e in result.errors)
+
+    def test_sink_persist_directory_outside_outputs_blocked(self) -> None:
+        """Chroma persistent storage is a sink write path and must be allowlisted."""
+        state = _make_state(
+            source_options={},
+            outputs=(
+                _make_output(
+                    {
+                        "persist_directory": "/tmp/chroma-outside",
+                        "schema": {"mode": "observed"},
+                    },
+                    name="chroma",
+                    plugin="chroma_sink",
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        result = validate_pipeline(state, settings, MagicMock(spec=YamlGenerator))
+
+        assert result.is_valid is False
+        assert _check(result, "path_allowlist").passed is False
+        assert any("persist_directory" in e.message for e in result.errors)
+
+    def test_sink_persist_directory_under_outputs_passes_allowlist(self) -> None:
+        state = _make_state(
+            source_options={},
+            outputs=(
+                _make_output(
+                    {
+                        "persist_directory": "/tmp/test_data/outputs/chroma",
+                        "schema": {"mode": "observed"},
+                    },
+                    name="chroma",
+                    plugin="chroma_sink",
+                ),
+            ),
+        )
+        settings = _make_settings(data_dir="/tmp/test_data")
+        mock_yaml_gen = MagicMock(spec=YamlGenerator)
+        mock_yaml_gen.generate_yaml.return_value = "source:\n  plugin: csv_source\n  options: {}"
+        with patch("elspeth.web.execution.validation.load_settings_from_yaml_string") as mock_load:
+            mock_load.side_effect = ValueError("invalid settings")
+            result = validate_pipeline(state, settings, mock_yaml_gen)
+
+        assert _check(result, "path_allowlist").passed is True
+
     def test_no_path_option_records_skipped_check(self) -> None:
         """B11 fix: path allowlist check is always recorded, even when skipped."""
         state = _make_state(source_options={})


### PR DESCRIPTION
### Motivation
- The Chroma plugins expose `persist_directory` (filesystem) and `host` (network) options that were not covered by the web path allowlist or the project's SSRF validation, allowing an authenticated pipeline to create files outside `data_dir/outputs` or to point the SDK at unsafe hosts.\n
### Description
- Add shared option-key constants (`SOURCE_PATH_OPTION_KEYS`, `SINK_PATH_OPTION_KEYS`, `NESTED_PATH_OPTION_KEYS`) in `src/elspeth/web/paths.py` so filesystem option handling is mechanical and reusable.\n
- Extend composer/validation and execution guards to treat `persist_directory` as a filesystem path: `validate_pipeline` now checks `provider_config.persist_directory` (RAG providers) and sink `persist_directory` against `allowed_sink_directories`, and `ExecutionServiceImpl.execute` raises `PathAllowlistViolationError` at runtime if these resolve outside allowed dirs.\n
- Extend `resolve_runtime_yaml_paths` to rewrite relative `provider_config.persist_directory` and sink `persist_directory` values to absolute paths resolved against `data_dir` so the YAML the runtime sees matches what validation approved.\n
- Add SSRF preflight for Chroma HTTP targets in `ChromaConnectionConfig` by validating `host:port` with `validate_url_for_ssrf()` (preserving loopback/http-for-localhost allowances) to block metadata-service and other unsafe hosts before creating the Chroma SDK `HttpClient`.\n
- Add regression tests covering blocked `persist_directory` in validation and execution, runtime YAML rewriting for nested `persist_directory`, and Chroma host blocking; adjust a few probe tests to use `localhost` where appropriate.\n
### Testing
- Ran static/style checks with `ruff` and fixed formatting issues, and `ruff check` passed for changed files.\n
- Compiled updated modules and tests with `python -m compileall` which succeeded for the modified files.\n
- Executed a targeted security smoke script that exercised `ChromaSearchProviderConfig` host blocking, `resolve_data_path`/`allowed_sink_directories` checks, and `resolve_runtime_yaml_paths` rewriting, which printed `security_smoke_ok`.\n
- Attempted to run the targeted `pytest` slice for the modified validation and execution tests, but full test execution was blocked by the environment being unable to fetch dev/test dependencies from PyPI (network/tunnel failures), so the run could not complete here.\n
- Ran `elspeth-lints` trust-tier rule invocation locally but it failed to run to completion because `ELSPETH_JUDGE_METADATA_HMAC_KEY` is not available in this environment (expected operator-held key); this is an env constraint, not a code failure.\n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bd591d888323982dc8a95464dc16)