### PR TITLE
ci: gate workflow_run image publishing

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -61,11 +61,18 @@ jobs:
   build-push:
     name: Build and Push
     runs-on: [self-hosted, Linux, X64, nyx-ci, trusted]
-    # Only run if CI passed (for workflow_run trigger) or always for tags/dispatch
+    # Only run if CI passed for a trusted push in this repository, or always
+    # for tags/dispatch. The workflow_run branch filter alone is not a trust
+    # boundary: fork pull_request runs can report a matching head branch name.
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
 
     permissions:
       actions: read


### PR DESCRIPTION
### Motivation
- Prevent a malicious fork PR from causing the privileged "Build and Push" workflow to check out, publish, and cosign an attacker-controlled commit by hardening the `workflow_run` trust gates. 
- The previous `workflow_run` path allowed any completed `CI` run (including successful fork PR runs that simply had a matching branch name) to be used as the image source, so the privileged job needed explicit checks that the triggering run was a trusted `push` from the same repository.

### Description
- Tightened the `if` condition in `.github/workflows/build-push.yaml` so the `workflow_run` case requires `github.event.workflow_run.event == 'push'` and `github.event.workflow_run.head_repository.full_name == github.repository`, in addition to `workflow_run.conclusion == 'success'` so only successful pushes from this repository may publish/sign images. 
- Added an inline comment explaining that the `workflow_run` branch filter is not a trust boundary and why the extra checks are necessary. 
- Preserved existing behavior for direct `push`, `workflow_dispatch`, and tag triggers and left the checkout/ref usage (`env.IMAGE_SHA`) unchanged.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or index errors, and it passed. 
- Parsed and validated the modified workflow with a small Python/YAML check that confirms the `build-push` job `if` expression contains the required `workflow_run` gate expressions and that the checkout `ref` remains `${{ env.IMAGE_SHA }}`, and the validation succeeded. 
- Verified the edit was committed locally (`git commit`) and a PR was created with the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b1d764e08323ba3d10c13f1849ef)