### PR TITLE
fix(plugins): avoid leaking configured batch labels

### DIFF
--- a/src/elspeth/plugins/transforms/batch_classifier_metrics.py
+++ b/src/elspeth/plugins/transforms/batch_classifier_metrics.py
@@ -48,6 +48,8 @@ _BASE_METRIC_FIELDS = frozenset(
         "weighted_f1",
     }
 )
+_MISSING_POSITIVE_LABEL_EXPECTED = "configured positive_label"
+
 _BINARY_METRIC_FIELDS = frozenset(
     {
         "binary_f1",
@@ -151,7 +153,7 @@ class BatchClassifierMetrics(BaseTransform):
     name = "batch_classifier_metrics"
     determinism = Determinism.DETERMINISTIC
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:128c9eca5770883f"
+    source_file_hash: str | None = "sha256:2be40b56a899e390"
     config_model = BatchClassifierMetricsConfig
     is_batch_aware = True
     capability_tags: tuple[str, ...] = ("narrative-summary",)
@@ -380,7 +382,8 @@ class BatchClassifierMetrics(BaseTransform):
             reason: TransformErrorReason = {
                 "reason": "validation_failed",
                 "cause": "positive_label_missing",
-                "expected": str(self._positive_label),
+                "expected": _MISSING_POSITIVE_LABEL_EXPECTED,
+                "message": "Configured positive_label was not present in the batch.",
                 "errors": [str(label) for label in labels],
             }
             return {}, TransformResult.error(reason, retryable=False)

--- a/src/elspeth/plugins/transforms/batch_experiment_compare.py
+++ b/src/elspeth/plugins/transforms/batch_experiment_compare.py
@@ -28,6 +28,8 @@ from elspeth.plugins.transforms._scalar_buckets import same_scalar_bucket_value
 
 type BatchExperimentComparisonRow = dict[str, object]
 
+_MISSING_BASELINE_VARIANT_EXPECTED = "configured baseline_variant"
+
 _COMPARISON_OUTPUT_FIELDS = frozenset(
     {
         "baseline_count",
@@ -122,7 +124,7 @@ class BatchExperimentCompare(BaseTransform):
     name = "batch_experiment_compare"
     determinism = Determinism.DETERMINISTIC
     plugin_version = "1.0.0"
-    source_file_hash: str | None = "sha256:0f59970e8c643a24"
+    source_file_hash: str | None = "sha256:2ebe898bfa15361c"
     config_model = BatchExperimentCompareConfig
     is_batch_aware = True
 
@@ -403,8 +405,8 @@ class BatchExperimentCompare(BaseTransform):
                 {
                     "reason": "validation_failed",
                     "cause": "baseline_variant_missing",
-                    "expected": str(self._baseline_variant),
-                    "message": f"Baseline variant {self._baseline_variant!r} was not present in the batch.",
+                    "expected": _MISSING_BASELINE_VARIANT_EXPECTED,
+                    "message": "Configured baseline_variant was not present in the batch.",
                     "errors": [str(stats.value) for stats in stats_by_variant],
                 },
                 retryable=False,
@@ -427,8 +429,8 @@ class BatchExperimentCompare(BaseTransform):
                 {
                     "reason": "validation_failed",
                     "cause": "baseline_variant_missing",
-                    "expected": str(baseline_value),
-                    "message": f"Baseline variant {baseline_value!r} was not present in the batch.",
+                    "expected": _MISSING_BASELINE_VARIANT_EXPECTED,
+                    "message": "Configured baseline_variant was not present in the batch.",
                     "errors": [str(stats.value) for stats in stats_by_variant],
                 },
                 retryable=False,

--- a/tests/unit/plugins/transforms/test_batch_classifier_metrics.py
+++ b/tests/unit/plugins/transforms/test_batch_classifier_metrics.py
@@ -185,8 +185,28 @@ class TestBatchClassifierMetrics:
         assert result.reason is not None
         assert result.reason["reason"] == "validation_failed"
         assert result.reason["cause"] == "positive_label_missing"
-        assert result.reason["expected"] == "maybe"
+        assert result.reason["expected"] == "configured positive_label"
+        assert result.reason["message"] == "Configured positive_label was not present in the batch."
         assert result.reason["errors"] == ["yes", "no"]
+
+    def test_missing_positive_label_error_does_not_echo_configured_label(self, ctx: PluginContext) -> None:
+        from elspeth.plugins.transforms.batch_classifier_metrics import BatchClassifierMetrics
+
+        configured_secret = "expanded-secret-positive-label"
+        transform = BatchClassifierMetrics(
+            {
+                "schema": DYNAMIC_SCHEMA,
+                "actual_field": "actual",
+                "predicted_field": "predicted",
+                "positive_label": configured_secret,
+            }
+        )
+
+        result = transform.process([_make_row({"actual": "yes", "predicted": "no"})], ctx)
+
+        assert result.status == "error"
+        assert result.reason is not None
+        assert configured_secret not in str(result.reason)
 
     def test_non_scalar_labels_raise_type_error(self, ctx: PluginContext) -> None:
         from elspeth.plugins.transforms.batch_classifier_metrics import BatchClassifierMetrics

--- a/tests/unit/plugins/transforms/test_batch_experiment_compare.py
+++ b/tests/unit/plugins/transforms/test_batch_experiment_compare.py
@@ -174,7 +174,27 @@ class TestBatchExperimentCompare:
         assert result.reason is not None
         assert result.reason["reason"] == "validation_failed"
         assert result.reason["cause"] == "baseline_variant_missing"
-        assert result.reason["expected"] == "control"
+        assert result.reason["expected"] == "configured baseline_variant"
+        assert result.reason["message"] == "Configured baseline_variant was not present in the batch."
+
+    def test_missing_baseline_error_does_not_echo_configured_variant(self, ctx: PluginContext) -> None:
+        from elspeth.plugins.transforms.batch_experiment_compare import BatchExperimentCompare
+
+        configured_secret = "expanded-secret-baseline-variant"
+        transform = BatchExperimentCompare(
+            {
+                "schema": DYNAMIC_SCHEMA,
+                "variant_field": "variant",
+                "score_field": "score",
+                "baseline_variant": configured_secret,
+            }
+        )
+
+        result = transform.process([_make_row({"variant": "treatment", "score": 1.0})], ctx)
+
+        assert result.status == "error"
+        assert result.reason is not None
+        assert configured_secret not in str(result.reason)
 
     def test_insufficient_variants_returns_error(self, ctx: PluginContext) -> None:
         from elspeth.plugins.transforms.batch_experiment_compare import BatchExperimentCompare


### PR DESCRIPTION
### Motivation
- The new batch aggregation plugins could echo configured options that are expanded from `${VAR}` into error payloads, letting an authenticated run owner exfiltrate environment values via diagnostics.
- The change stops configuration-derived values from being reflected verbatim in failure diagnostics while preserving useful observed/batch context.

### Description
- Replace direct echoing of configured labels with stable non-secret descriptors by returning `"expected": "configured positive_label"` and `"configured baseline_variant"` and generic `"message"` strings instead of the actual configured values in error payloads in `batch_classifier_metrics` and `batch_experiment_compare`.
- Preserve the observed variant/label lists and all other diagnostic details so operational debug information remains useful while secrets are not leaked.
- Add regression assertions in the unit test files to ensure a configured/expanded secret-like value is not present in the error payloads for missing positive label / missing baseline cases. 
- Refresh the plugins' `source_file_hash` declarations to match the modified source files.
- Files changed: `src/elspeth/plugins/transforms/batch_classifier_metrics.py`, `src/elspeth/plugins/transforms/batch_experiment_compare.py`, `tests/unit/plugins/transforms/test_batch_classifier_metrics.py`, and `tests/unit/plugins/transforms/test_batch_experiment_compare.py`.

### Testing
- Ran inline security regression assertions exercising `BatchClassifierMetrics.process()` and `BatchExperimentCompare.process()` that verify configured secret-like values do not appear in `result.reason`; these assertions passed.
- Verified plugin `source_file_hash` values with `scripts.cicd.plugin_hash.compute_source_file_hash` and `extract_plugin_attributes`; verification passed.
- Ran `ruff` style checks against the modified plugin and test files; lint checks passed.
- Attempted to run the repository `pytest` subset but the environment lacked the `hypothesis` dependency and `uv sync --extra dev` failed to fetch it due to a network/tunnel error, so full `pytest` could not be executed in-session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228251c6f48323b8682abb4c4fea9d)