### PR TITLE
fix(config): sanitize database sink DSNs in audit config

### DIFF
--- a/src/elspeth/core/config.py
+++ b/src/elspeth/core/config.py
@@ -1823,6 +1823,37 @@ def _expand_config_templates(
     return config
 
 
+def _sanitize_dsn_option_for_audit(
+    options: dict[str, Any],
+    *,
+    option_name: str,
+    fingerprint_name: str,
+    redacted_name: str,
+    fail_if_no_key: bool,
+) -> None:
+    """Sanitize a DSN-bearing option in-place for audit persistence.
+
+    Plugin-specific secret-ref policy permits some non-secret-named fields
+    (currently database sink ``options.url``) to receive resolved server/user
+    secrets. Those fields must be sanitized by placement, not by key-name
+    heuristics, before settings are written to Landscape audit storage.
+    """
+    value = options.get(option_name)
+    if not isinstance(value, str):
+        return
+
+    sanitized_url, password_fp, had_password = _sanitize_dsn(
+        value,
+        fail_if_no_key=fail_if_no_key,
+    )
+    options[option_name] = sanitized_url
+    if password_fp:
+        options[fingerprint_name] = password_fp
+    elif had_password and not fail_if_no_key:
+        # Dev mode: password was removed but not fingerprinted.
+        options[redacted_name] = True
+
+
 def _fingerprint_config_for_audit(
     config_dict: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1834,6 +1865,7 @@ def _fingerprint_config_for_audit(
     Processes:
     - source.options
     - sinks.*.options
+    - database sink options.url (DSN password)
     - transforms[*].options
     - aggregations[*].options
     - landscape.url (DSN password)
@@ -1860,19 +1892,13 @@ def _fingerprint_config_for_audit(
 
     # === Landscape URL (DSN password) ===
     if "landscape" in config and isinstance(config["landscape"], dict):
-        landscape = config["landscape"]
-        if "url" in landscape and isinstance(landscape["url"], str):
-            # _sanitize_dsn returns (sanitized_url, fingerprint, had_password)
-            sanitized_url, password_fp, had_password = _sanitize_dsn(
-                landscape["url"],
-                fail_if_no_key=fail_if_no_key,
-            )
-            landscape["url"] = sanitized_url
-            if password_fp:
-                landscape["url_password_fingerprint"] = password_fp
-            elif had_password and not fail_if_no_key:
-                # Dev mode: password was removed but not fingerprinted
-                landscape["url_password_redacted"] = True
+        _sanitize_dsn_option_for_audit(
+            config["landscape"],
+            option_name="url",
+            fingerprint_name="url_password_fingerprint",
+            redacted_name="url_password_redacted",
+            fail_if_no_key=fail_if_no_key,
+        )
 
     # === Source options ===
     if "source" in config and isinstance(config["source"], dict):
@@ -1884,7 +1910,18 @@ def _fingerprint_config_for_audit(
     if "sinks" in config and isinstance(config["sinks"], dict):
         for sink in config["sinks"].values():
             if isinstance(sink, dict) and "options" in sink and isinstance(sink["options"], dict):
-                sink["options"] = _fingerprint_secrets(sink["options"], fail_if_no_key=fail_if_no_key)
+                options = _fingerprint_secrets(sink["options"], fail_if_no_key=fail_if_no_key)
+                if sink.get("plugin") == "database":
+                    # Database sink URLs are a plugin-specific secret-ref placement:
+                    # the field is named "url" rather than a heuristic secret name.
+                    _sanitize_dsn_option_for_audit(
+                        options,
+                        option_name="url",
+                        fingerprint_name="url_password_fingerprint",
+                        redacted_name="url_password_redacted",
+                        fail_if_no_key=fail_if_no_key,
+                    )
+                sink["options"] = options
 
     # === Transform plugin options ===
     if "transforms" in config and isinstance(config["transforms"], list):

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -2816,6 +2816,78 @@ sinks:
         assert "url_password_fingerprint" not in result["landscape"]
         assert result["landscape"]["url_password_redacted"] is True
 
+    def test_database_sink_url_password_fingerprinted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """database sink options.url password should be fingerprinted in audit copy."""
+        from elspeth.core.config import _fingerprint_config_for_audit
+
+        monkeypatch.setenv("ELSPETH_FINGERPRINT_KEY", "test-key")
+
+        config_dict = {
+            "source": {"plugin": "csv", "options": {}},
+            "sinks": {
+                "warehouse": {
+                    "plugin": "database",
+                    "options": {"url": "postgresql://user:dbsecret@host/db"},  # secret-scan: allow-this-line
+                }
+            },
+        }
+
+        result = _fingerprint_config_for_audit(config_dict)
+        options = result["sinks"]["warehouse"]["options"]
+
+        assert "dbsecret" not in options["url"]
+        assert "user@host" in options["url"]
+        assert "url_password_fingerprint" in options
+        assert len(options["url_password_fingerprint"]) == 64
+
+    def test_database_sink_url_password_redacted_in_dev_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """database sink options.url password should be redacted in dev mode."""
+        from elspeth.core.config import _fingerprint_config_for_audit
+
+        monkeypatch.delenv("ELSPETH_FINGERPRINT_KEY", raising=False)
+        monkeypatch.setenv("ELSPETH_ALLOW_RAW_SECRETS", "true")
+
+        config_dict = {
+            "source": {"plugin": "csv", "options": {}},
+            "sinks": {
+                "warehouse": {
+                    "plugin": "database",
+                    "options": {"url": "postgresql://user:dbsecret@host/db"},  # secret-scan: allow-this-line
+                }
+            },
+        }
+
+        result = _fingerprint_config_for_audit(config_dict)
+        options = result["sinks"]["warehouse"]["options"]
+
+        assert "dbsecret" not in options["url"]
+        assert "url_password_fingerprint" not in options
+        assert options["url_password_redacted"] is True
+
+    def test_resolve_config_database_sink_url_password_fingerprinted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """resolve_config must not return plaintext database sink DSN passwords."""
+        from elspeth.core.config import ElspethSettings, resolve_config
+
+        monkeypatch.setenv("ELSPETH_FINGERPRINT_KEY", "test-key")
+
+        settings = ElspethSettings(
+            source={"plugin": "csv", "on_success": "warehouse"},
+            sinks={
+                "warehouse": {
+                    "plugin": "database",
+                    "on_write_failure": "discard",
+                    "options": {"url": "postgresql://user:dbsecret@host/db"},  # secret-scan: allow-this-line
+                }
+            },
+        )
+
+        resolved = resolve_config(settings)
+        options = resolved["sinks"]["warehouse"]["options"]
+
+        assert "dbsecret" not in options["url"]
+        assert "url_password_fingerprint" in options
+        assert len(options["url_password_fingerprint"]) == 64
+
     def test_dsn_unparsable_with_credentials_raises(self) -> None:
         """Unparsable URLs with credential patterns must not pass through."""
         from elspeth.core.config import SecretFingerprintError, _sanitize_dsn


### PR DESCRIPTION
### Motivation
- A runtime change caused `resolve_config()` to persist the resolved runtime settings to Landscape; the audit sanitizer only special-cased `landscape.url` and relied on a field-name heuristic for sink options, so a database sink `options.url` DSN password could be stored in plaintext.

### Description
- Add an audit-only helper ` _sanitize_dsn_option_for_audit(options, option_name=..., fingerprint_name=..., redacted_name=..., fail_if_no_key=...)` to centralize DSN password removal and fingerprinting without widening the closed `is_secret_field` heuristic.
- Reuse the helper for existing `landscape.url` handling and apply it to database sink `options.url` after generic `_fingerprint_secrets()` processing, producing `url_password_fingerprint` or `url_password_redacted` as existing semantics prescribe.
- Preserve runtime behavior (do not alter runtime settings objects used for connections) and avoid adding plain `url` to the shared `SECRET_FIELD_NAMES` list; sanitization is audit-path only and placement-based for plugin-specific fields.
- Add regression unit tests in `tests/unit/core/test_config.py` covering fingerprinting, dev-mode redaction, and the `resolve_config()` path for a database sink `options.url`.

### Testing
- Ran linting: `python -m ruff check src/elspeth/core/config.py tests/unit/core/test_config.py` (passed).
- Byte-compiled modified files: `.venv/bin/python -m compileall -q src/elspeth/core/config.py tests/unit/core/test_config.py` (passed).
- Performed a smoke test invoking `resolve_config()` with `PYTHONPATH=src` and `ELSPETH_FINGERPRINT_KEY=test-key`, which produced a sanitized DB URL (`postgresql://user@host/db`) and a 64-char `url_password_fingerprint` as expected (success).
- Attempted to run the unit test class `tests/unit/core/test_config.py::TestSecretFieldFingerprinting` but full `pytest` execution was blocked in the environment because `hypothesis` is not installed; `uv sync --extra dev` also failed to fetch dependencies due to network/PyPI tunnel errors, so full `pytest` could not be executed here.
- Lint/format checks and compile-time checks passed and the added unit tests are present and exercise the public `resolve_config()` path for the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217398bcd883238391656870dddb17)