### PR TITLE
fix(auth): rate limit auth failure audit writes

### DIFF
--- a/src/elspeth/web/auth/middleware.py
+++ b/src/elspeth/web/auth/middleware.py
@@ -10,10 +10,12 @@ from typing import cast
 
 from fastapi import HTTPException, Request
 
+from elspeth.contracts.auth import AuthProviderType
 from elspeth.web.auth.audit import AuthAuditWriter, classify_authentication_failure
 from elspeth.web.auth.models import AuthenticationError, AuthProviderUnavailable, UserIdentity
 from elspeth.web.auth.protocol import AuthProvider
 from elspeth.web.config import WebSettings
+from elspeth.web.middleware.rate_limit import check_auth_rate_limit
 
 
 def _auth_audit_recorder(request: Request) -> AuthAuditWriter:
@@ -22,6 +24,37 @@ def _auth_audit_recorder(request: Request) -> AuthAuditWriter:
 
 def _settings(request: Request) -> WebSettings:
     return cast(WebSettings, request.app.state.settings)
+
+
+async def _record_auth_failure_after_rate_limit(
+    request: Request,
+    *,
+    provider: AuthProviderType,
+    failure_category: str,
+    failure_stage: str,
+    user_id: str | None,
+    username: str | None,
+    exception_class: str | None,
+) -> None:
+    """Rate-limit attacker-triggerable auth failure audit writes.
+
+    ``get_current_user`` is shared by protected API routes, so missing,
+    malformed, or invalid Authorization headers are reachable before a caller
+    has authenticated. Reuse the auth endpoint's per-client limiter before the
+    durable audit write so repeated unauthenticated failures cannot force
+    unbounded synchronous database work. If the limiter raises 429, the audit
+    write for that over-limit attempt is intentionally skipped.
+    """
+    await check_auth_rate_limit(request)
+    _auth_audit_recorder(request).record_auth_failure(
+        request,
+        provider=provider,
+        failure_category=failure_category,
+        failure_stage=failure_stage,
+        user_id=user_id,
+        username=username,
+        exception_class=exception_class,
+    )
 
 
 async def get_current_user(request: Request) -> UserIdentity:
@@ -36,10 +69,9 @@ async def get_current_user(request: Request) -> UserIdentity:
     Authorization header.
     """
     settings = _settings(request)
-    recorder = _auth_audit_recorder(request)
 
     if "Authorization" not in request.headers:
-        recorder.record_auth_failure(
+        await _record_auth_failure_after_rate_limit(
             request,
             provider=settings.auth_provider,
             failure_category="missing_authorization_header",
@@ -56,7 +88,7 @@ async def get_current_user(request: Request) -> UserIdentity:
 
     parts = auth_header.split(" ", 1)
     if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1].strip():
-        recorder.record_auth_failure(
+        await _record_auth_failure_after_rate_limit(
             request,
             provider=settings.auth_provider,
             failure_category="invalid_authorization_header",
@@ -90,7 +122,7 @@ async def get_current_user(request: Request) -> UserIdentity:
     try:
         return await auth_provider.authenticate(token)
     except AuthProviderUnavailable as exc:
-        recorder.record_auth_failure(
+        await _record_auth_failure_after_rate_limit(
             request,
             provider=settings.auth_provider,
             failure_category="provider_unavailable",
@@ -101,7 +133,7 @@ async def get_current_user(request: Request) -> UserIdentity:
         )
         raise HTTPException(status_code=503, detail=exc.detail) from exc
     except AuthenticationError as exc:
-        recorder.record_auth_failure(
+        await _record_auth_failure_after_rate_limit(
             request,
             provider=settings.auth_provider,
             failure_category=classify_authentication_failure(exc),

--- a/tests/unit/web/auth/test_middleware.py
+++ b/tests/unit/web/auth/test_middleware.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, Request
 from elspeth.web.auth.middleware import get_current_user
 from elspeth.web.auth.models import AuthenticationError, AuthProviderUnavailable, UserIdentity
 from elspeth.web.config import WebSettings
+from elspeth.web.middleware.rate_limit import ComposerRateLimiter
 
 
 class _NoopAuthAuditRecorder:
@@ -17,8 +18,20 @@ class _NoopAuthAuditRecorder:
         return None
 
 
-def _make_request(auth_provider, authorization: str | None = None) -> Request:
-    """Create a Starlette request carrying the auth provider under app.state."""
+class _CountingAuthAuditRecorder:
+    def __init__(self) -> None:
+        self.failures: list[dict[str, object]] = []
+
+    def record_auth_failure(self, *args, **kwargs) -> None:
+        self.failures.append(kwargs)
+
+
+def _make_app(
+    auth_provider,
+    *,
+    recorder=None,
+    auth_rate_limit: int = 100,
+) -> FastAPI:
     app = FastAPI()
     app.state.auth_provider = auth_provider
     app.state.settings = WebSettings(
@@ -29,7 +42,22 @@ def _make_request(auth_provider, authorization: str | None = None) -> Request:
         composer_rate_limit_per_minute=10,
         shareable_link_signing_key=b"\x00" * 32,
     )
-    app.state.auth_audit_recorder = _NoopAuthAuditRecorder()
+    app.state.auth_audit_recorder = recorder if recorder is not None else _NoopAuthAuditRecorder()
+    app.state.auth_rate_limiter = ComposerRateLimiter(limit=auth_rate_limit)
+    return app
+
+
+def _make_request(
+    auth_provider,
+    authorization: str | None = None,
+    *,
+    app: FastAPI | None = None,
+    recorder=None,
+    auth_rate_limit: int = 100,
+) -> Request:
+    """Create a Starlette request carrying the auth provider under app.state."""
+    if app is None:
+        app = _make_app(auth_provider, recorder=recorder, auth_rate_limit=auth_rate_limit)
     headers: list[tuple[bytes, bytes]] = []
     if authorization is not None:
         headers.append((b"authorization", authorization.encode("latin-1")))
@@ -40,6 +68,7 @@ def _make_request(auth_provider, authorization: str | None = None) -> Request:
             "path": "/protected",
             "headers": headers,
             "app": app,
+            "client": ("127.0.0.1", 12345),
         }
     )
     request.state.request_id = "test-request"
@@ -75,6 +104,24 @@ class TestGetCurrentUser:
         assert exc_info.value.status_code == 401
         assert exc_info.value.detail == "Missing or invalid Authorization header"
 
+    async def test_missing_authorization_header_rate_limits_audit_writes(self) -> None:
+        mock_provider = AsyncMock()
+        recorder = _CountingAuthAuditRecorder()
+        app = _make_app(mock_provider, recorder=recorder, auth_rate_limit=1)
+
+        first_request = _make_request(mock_provider, app=app)
+        with pytest.raises(HTTPException) as first_exc_info:
+            await get_current_user(first_request)
+
+        second_request = _make_request(mock_provider, app=app)
+        with pytest.raises(HTTPException) as second_exc_info:
+            await get_current_user(second_request)
+
+        assert first_exc_info.value.status_code == 401
+        assert second_exc_info.value.status_code == 429
+        assert len(recorder.failures) == 1
+        assert recorder.failures[0]["failure_category"] == "missing_authorization_header"
+
     async def test_non_bearer_scheme(self) -> None:
         mock_provider = AsyncMock()
         request = _make_request(mock_provider, "Basic dXNlcjpwYXNz")
@@ -83,6 +130,24 @@ class TestGetCurrentUser:
             await get_current_user(request)
 
         assert exc_info.value.status_code == 401
+
+    async def test_invalid_authorization_header_rate_limits_audit_writes(self) -> None:
+        mock_provider = AsyncMock()
+        recorder = _CountingAuthAuditRecorder()
+        app = _make_app(mock_provider, recorder=recorder, auth_rate_limit=1)
+
+        first_request = _make_request(mock_provider, "Basic dXNlcjpwYXNz", app=app)
+        with pytest.raises(HTTPException) as first_exc_info:
+            await get_current_user(first_request)
+
+        second_request = _make_request(mock_provider, "Basic dXNlcjpwYXNz", app=app)
+        with pytest.raises(HTTPException) as second_exc_info:
+            await get_current_user(second_request)
+
+        assert first_exc_info.value.status_code == 401
+        assert second_exc_info.value.status_code == 429
+        assert len(recorder.failures) == 1
+        assert recorder.failures[0]["failure_category"] == "invalid_authorization_header"
 
     async def test_bearer_with_no_token(self) -> None:
         mock_provider = AsyncMock()
@@ -103,6 +168,41 @@ class TestGetCurrentUser:
 
         assert exc_info.value.status_code == 401
         assert exc_info.value.detail == "Token expired"
+
+    async def test_authentication_error_rate_limits_audit_writes(self) -> None:
+        mock_provider = AsyncMock()
+        mock_provider.authenticate.side_effect = AuthenticationError("Token expired")
+        recorder = _CountingAuthAuditRecorder()
+        app = _make_app(mock_provider, recorder=recorder, auth_rate_limit=1)
+
+        first_request = _make_request(mock_provider, "Bearer expired-token", app=app)
+        with pytest.raises(HTTPException) as first_exc_info:
+            await get_current_user(first_request)
+
+        second_request = _make_request(mock_provider, "Bearer expired-token", app=app)
+        with pytest.raises(HTTPException) as second_exc_info:
+            await get_current_user(second_request)
+
+        assert first_exc_info.value.status_code == 401
+        assert second_exc_info.value.status_code == 429
+        assert len(recorder.failures) == 1
+        assert recorder.failures[0]["failure_category"] == "authentication_error"
+
+    async def test_valid_bearer_token_does_not_consume_auth_failure_limiter(self) -> None:
+        mock_provider = AsyncMock()
+        mock_provider.authenticate.return_value = UserIdentity(
+            user_id="alice",
+            username="alice",
+        )
+        recorder = _CountingAuthAuditRecorder()
+        app = _make_app(mock_provider, recorder=recorder, auth_rate_limit=1)
+
+        first_user = await get_current_user(_make_request(mock_provider, "Bearer valid-token-one", app=app))
+        second_user = await get_current_user(_make_request(mock_provider, "Bearer valid-token-two", app=app))
+
+        assert first_user.user_id == "alice"
+        assert second_user.user_id == "alice"
+        assert recorder.failures == []
 
     async def test_provider_unavailable_returns_503_with_detail(self) -> None:
         mock_provider = AsyncMock()

--- a/tests/unit/web/auth/test_routes.py
+++ b/tests/unit/web/auth/test_routes.py
@@ -912,6 +912,32 @@ class TestRegisterRequestValidation:
 class TestAuthRateLimiting:
     """Tests that auth endpoints are rate-limited by client IP."""
 
+    async def test_me_unauthenticated_rate_limit_bounds_durable_auth_failure_rows(self, tmp_path) -> None:
+        """Protected route auth failures stop writing audit rows after per-IP limit."""
+        from elspeth.web.middleware.rate_limit import ComposerRateLimiter
+
+        audit_url = f"sqlite:///{tmp_path / 'audit.db'}"
+        provider = LocalAuthProvider(db_path=tmp_path / "auth.db", secret_key="test-key")
+        app = _create_test_app(provider, landscape_url=audit_url)
+        _enable_auth_audit(app)
+        app.state.auth_rate_limiter = ComposerRateLimiter(limit=1)
+
+        async with _client_for(app) as client:
+            first_response = await client.get("/api/auth/me")
+            second_response = await client.get("/api/auth/me")
+
+        rows = _read_auth_event_rows(audit_url)
+        auth_failure_rows = [row for row in rows if row.event_type == "auth_failure"]
+
+        assert first_response.status_code == 401
+        assert second_response.status_code == 429
+        assert len(auth_failure_rows) == 1
+
+        event = auth_failure_rows[0]
+        metadata = json.loads(event.metadata_json)
+        assert event.failure_category == "missing_authorization_header"
+        assert metadata["failure_stage"] == "authorization_header"
+
     async def test_login_returns_429_when_rate_limited(self, tmp_path) -> None:
         """Login returns 429 after exceeding per-IP rate limit."""
         from elspeth.web.middleware.rate_limit import ComposerRateLimiter


### PR DESCRIPTION
### Motivation

- The shared `get_current_user` dependency performed synchronous, durable audit writes for missing/malformed/invalid Authorization headers, which an unauthenticated attacker could repeatedly trigger and cause unbounded audit DB load and denial-of-service.
- The goal is to bound attacker-triggerable durable audit writes without removing the must-fire audit for legitimate failure events and without charging successful authentications against the unauthenticated failure budget.

### Description

- Add an async helper `_record_auth_failure_after_rate_limit(request, ...)` in `src/elspeth/web/auth/middleware.py` that calls the existing `check_auth_rate_limit(request)` before invoking the audit recorder, and wire the helper into every attacker-triggerable failure site in `get_current_user` (missing header, malformed header, provider unavailable, authentication errors).
- Reuse the existing per-IP `auth_rate_limiter` so over-limit unauthenticated attempts raise `429` and intentionally skip the durable audit write for that over-limit attempt, preserving existing limiter semantics.
- Add test scaffolding and unit tests in `tests/unit/web/auth/test_middleware.py` to provide an auth-rate-limiter in the request app state, a counting/spying audit recorder, and coverage asserting that the first failure audits and the second same-client attempt returns `429` with no second audit write; and add an integration-style route test in `tests/unit/web/auth/test_routes.py` that verifies `/api/auth/me` writes at most one persisted `auth_failure` row when the per-IP limit is 1.
- Modified files: `src/elspeth/web/auth/middleware.py`, `tests/unit/web/auth/test_middleware.py`, and `tests/unit/web/auth/test_routes.py`.

### Testing

- Ran Python compile checks on the modified sources with `python -m py_compile` which succeeded for `src/elspeth/web/auth/middleware.py` and the updated tests.
- Ran static/format checks with `ruff` over the changed files which passed.
- Attempted to run the unit tests with `pytest`, but full execution was blocked in the environment due to a missing test dependency (`hypothesis`) and a blocked package download in the sandbox, so end-to-end pytest runs could not complete here.
- Local automated checks performed (compile + linter) passed; added unit and route tests exercise the new behavior and are included in the PR for CI execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2173bed22083238a1f9829d0b4a1a3)