### PR TITLE
fix(auth): bound audit principal fields

### DIFF
--- a/src/elspeth/core/landscape/auth_audit_repository.py
+++ b/src/elspeth/core/landscape/auth_audit_repository.py
@@ -19,6 +19,17 @@ AUTH_AUDIT_EVENT_TYPES: tuple[AuthAuditEventType, ...] = ("login", "token_issued
 AUTH_AUDIT_SUCCESS: AuthAuditOutcome = "success"
 AUTH_AUDIT_FAILURE: AuthAuditOutcome = "failure"
 AUTH_AUDIT_OUTCOMES: tuple[AuthAuditOutcome, ...] = (AUTH_AUDIT_SUCCESS, AUTH_AUDIT_FAILURE)
+AUTH_AUDIT_PRINCIPAL_MAX_LENGTH = 256
+"""Maximum stored length for auth_events.user_id and auth_events.username."""
+
+
+def _bounded_principal(value: str | None) -> str | None:
+    """Constrain auth principal text to the auth_events schema length."""
+    if value is None:
+        return None
+    if len(value) <= AUTH_AUDIT_PRINCIPAL_MAX_LENGTH:
+        return value
+    return value[:AUTH_AUDIT_PRINCIPAL_MAX_LENGTH]
 
 
 class AuthAuditRepository:
@@ -59,8 +70,8 @@ class AuthAuditRepository:
                 event_type=event_type,
                 outcome=outcome,
                 provider=provider,
-                user_id=user_id,
-                username=username,
+                user_id=_bounded_principal(user_id),
+                username=_bounded_principal(username),
                 failure_category=failure_category,
                 request_id=request_id,
                 client_host=client_host,

--- a/tests/unit/web/auth/test_routes.py
+++ b/tests/unit/web/auth/test_routes.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, Response
 from sqlalchemy import select
 
+from elspeth.core.landscape.auth_audit_repository import AUTH_AUDIT_PRINCIPAL_MAX_LENGTH
 from elspeth.core.landscape.database import LandscapeDB
 from elspeth.core.landscape.schema import auth_events_table
 from elspeth.web.auth.audit import AuthAuditRecorder
@@ -240,6 +241,33 @@ class TestLoginEndpoint:
         assert "wrong-password" not in serialized
         assert "password123" not in serialized
         assert "eyJ" not in serialized
+
+    async def test_login_invalid_credentials_bounds_persisted_username(self, tmp_path) -> None:
+        audit_url = f"sqlite:///{tmp_path / 'audit.db'}"
+        provider = LocalAuthProvider(
+            db_path=tmp_path / "auth.db",
+            secret_key="test-key",
+        )
+        app = _create_test_app(provider, landscape_url=audit_url)
+        _enable_auth_audit(app)
+        oversized_username = "a" * (AUTH_AUDIT_PRINCIPAL_MAX_LENGTH + 1)
+
+        async with _client_for(app) as client:
+            response = await client.post(
+                "/api/auth/login",
+                json={"username": oversized_username, "password": "wrong-password"},
+                headers={"x-request-id": "login-failure-bounded"},
+            )
+
+        assert response.status_code == 401
+        rows = _read_auth_event_rows(audit_url)
+        assert len(rows) == 1
+        event = rows[0]
+        assert event.event_type == "login"
+        assert event.outcome == "failure"
+        assert event.user_id is None
+        assert event.username == oversized_username[:AUTH_AUDIT_PRINCIPAL_MAX_LENGTH]
+        assert len(event.username) == AUTH_AUDIT_PRINCIPAL_MAX_LENGTH
 
     async def test_login_not_available_for_oidc(self, tmp_path) -> None:
         provider = AsyncMock()


### PR DESCRIPTION
### Motivation

- A vulnerability allowed unbounded `username`/`user_id` values from unauthenticated login requests to be persisted into the audit DB, which can exhaust disk on SQLite or cause writes to fail on length-enforcing backends; the change bounds persisted principal text to the schema length.

### Description

- Add `AUTH_AUDIT_PRINCIPAL_MAX_LENGTH = 256` and a helper `_bounded_principal()` to enforce the schema-backed maximum for audit principals.
- Apply `_bounded_principal()` to `user_id` and `username` in `record_auth_event()` so persisted values are truncated before insertion. 
- Add a regression test `test_login_invalid_credentials_bounds_persisted_username` that sends an oversized username and asserts the route still returns `401` while the stored `username` is the truncated value.
- Preserve existing semantics: the auth route behavior and audit metadata remain unchanged except that caller-controlled principal text is now length-constrained before storage.

### Testing

- Ran `python -m compileall` on the modified files and it succeeded. 
- Executed a smoke test script that uses `RecorderFactory(...).auth_audit.record_login_outcome(...)` against a temporary SQLite `audit.db`, which verified an oversized username is truncated to `AUTH_AUDIT_PRINCIPAL_MAX_LENGTH` when read back. 
- Attempted to run the targeted `pytest` selection, but the test runner could not be executed in this environment because test dependencies (`pytest`, `hypothesis`, etc.) are not installed in the available runtime and `uv`-driven dev dependency installation failed due to a PyPI network error. 
- Static/lint checks (`ruff`) could not be run here because the checked-out `.venv` does not contain them; local CI should run full test matrix and linters before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217491e28083238b2f691fa4b3c514)