### PR TITLE
release(0.5.4): maintenance line — correctness fixes post-RC5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to ELSPETH are documented here.
 
 ---
 
-## [Unreleased]
+## [0.5.4] - Unreleased
 
-_No unreleased changes recorded._
+Maintenance line opened on top of RC-5.3, carrying correctness fixes that
+post-date the 0.5.3 cut.
+
+### Fixed
+
+- **`tier_1_decoration` lint no longer crashes on vendored trees** — the
+  repo-wide TDE2 pass and its candidate scan now walk the tree through the
+  shared `iter_python_files` excluded-dir filter instead of a raw
+  `rglob("*.py")`, so an unparseable third-party file under `.venv` / cache
+  directories can no longer hard-crash the gate.
 
 ---
 

--- a/elspeth-lints/src/elspeth_lints/rules/audit_evidence/tier_1_decoration/rule.py
+++ b/elspeth-lints/src/elspeth_lints/rules/audit_evidence/tier_1_decoration/rule.py
@@ -6,7 +6,13 @@ import ast
 from dataclasses import dataclass
 from pathlib import Path
 
-from elspeth_lints.core.ast_walker import ParsedPythonFile, PythonFileReadError, PythonSyntaxError, parse_python_file
+from elspeth_lints.core.ast_walker import (
+    ParsedPythonFile,
+    PythonFileReadError,
+    PythonSyntaxError,
+    iter_python_files,
+    parse_python_file,
+)
 from elspeth_lints.core.protocols import Finding, RuleContext, RuleMetadata, RuleScope
 from elspeth_lints.rules.audit_evidence.shared import (
     allowlist_path_for_root,
@@ -60,7 +66,11 @@ def scan_root(root: Path, *, allowlist_dir_override: Path | None = None) -> list
         parsed = _parse_or_raise(path)
         display = repo_relative_display_path(path, root) if path.name == "errors.py" else display_path(path, root)
         findings.extend(scan_tree(parsed.tree, display, parsed.source.splitlines()))
-    for path in sorted(root.rglob("*.py")):
+    # iter_python_files applies the shared excluded-dir filter (.venv, .uv-cache,
+    # .git, build, dist, node_modules, __pycache__, ...). A raw rglob here would
+    # descend into a vendored tree and let _parse_or_raise turn one third-party
+    # file (BOM prefix, py2 syntax) into a hard crash of the whole gate.
+    for path in iter_python_files(root):
         if path.resolve() in candidate_set:
             continue
         parsed = _parse_or_raise(path)
@@ -108,7 +118,9 @@ def _scan_candidates(root: Path) -> list[Path]:
     source_target = root / "contracts" / "errors.py"
     if source_target.exists():
         return [source_target]
-    return sorted(root.rglob("*.py"))
+    # Same excluded-dir discipline as the TDE2 pass: never raw-rglob a tree that
+    # may contain a vendored / cache subdir whose files do not parse.
+    return list(iter_python_files(root))
 
 
 def _tde1_finding(file_path: str, node: ast.ClassDef, source_lines: list[str]) -> Finding | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elspeth"
-version = "0.5.3"
+version = "0.5.4"
 description = "Auditable Sense/Decide/Act pipelines for high-reliability systems"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/elspeth_lints/test_audit_evidence_rules.py
+++ b/tests/unit/elspeth_lints/test_audit_evidence_rules.py
@@ -338,6 +338,63 @@ def test_tier_1_decoration_enforces_tde2_outside_errors_py(tmp_path: Path) -> No
     assert not any(f.rule_id == "TDE1" for f in findings)
 
 
+def test_tier_1_decoration_tde2_pass_skips_excluded_dirs_with_unparseable_files(tmp_path: Path) -> None:
+    # The repo-wide TDE2 pass must reuse the shared excluded-dir filter, NOT a
+    # raw rglob. A vendored tree (.venv, .uv-cache, ...) routinely contains files
+    # that do not parse as py313 source (BOM prefixes, py2 syntax). If the walk
+    # descends into them, _parse_or_raise turns one third-party file into a hard
+    # crash of the entire gate. With --root pointed at a repo that has a .venv,
+    # the scan must simply skip it.
+    contracts_dir = tmp_path / "contracts"
+    contracts_dir.mkdir(parents=True)
+    (contracts_dir / "errors.py").write_text("# canonical target — no classes\n", encoding="utf-8")
+    vendored = tmp_path / ".venv" / "lib" / "thirdparty"
+    vendored.mkdir(parents=True)
+    (vendored / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+    # Must not raise — the unparseable vendored file is excluded from the walk.
+    findings = list(
+        TIER_1_DECORATION_RULE.analyze(
+            ast.Module(body=[], type_ignores=[]),
+            tmp_path,
+            RuleContext(root=tmp_path),
+        )
+    )
+
+    assert findings == []
+
+
+def test_tier_1_decoration_tde2_pass_does_not_scan_excluded_dirs(tmp_path: Path) -> None:
+    # Exclusion is semantic, not merely crash-avoidance: a tier_1_error call site
+    # inside an excluded vendored tree is out of scope and must NOT be flagged,
+    # even though the file parses cleanly.
+    contracts_dir = tmp_path / "contracts"
+    contracts_dir.mkdir(parents=True)
+    (contracts_dir / "errors.py").write_text("# canonical target — no classes\n", encoding="utf-8")
+    vendored = tmp_path / ".venv" / "lib" / "pkg"
+    vendored.mkdir(parents=True)
+    (vendored / "vendored.py").write_text(
+        textwrap.dedent("""
+            from elspeth.contracts.tier_registry import tier_1_error
+
+            @tier_1_error(reason="vendored, no caller module")
+            class VendoredError(Exception):
+                pass
+        """),
+        encoding="utf-8",
+    )
+
+    findings = list(
+        TIER_1_DECORATION_RULE.analyze(
+            ast.Module(body=[], type_ignores=[]),
+            tmp_path,
+            RuleContext(root=tmp_path),
+        )
+    )
+
+    assert findings == []
+
+
 def test_tier_1_decoration_accepts_caller_module_name(tmp_path: Path) -> None:
     findings = _tier_1_findings_from_file(
         tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "elspeth"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Opens the **0.5.4 maintenance line** on top of RC-5.3 (merged via #57). Collects correctness fixes that post-date the 0.5.3 cut. Kept open as the 0.5.4 train; not for immediate merge.

## In this line so far
- **`tier_1_decoration` lint no longer crashes on vendored trees** — the repo-wide TDE2 pass and its candidate scan now use the shared `iter_python_files` excluded-dir filter instead of a raw `rglob`, so an unparseable third-party file under `.venv`/cache can't hard-crash the gate. (Carried over from RC-5.3 work not committed before #57 merged.)
- Version bump `0.5.3 → 0.5.4` (pyproject + uv.lock); `[0.5.4]` CHANGELOG section opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)