### PR TITLE
feat(website): publish standalone marketing site to main for GitHub Pages

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,12 @@
+# ELSPETH marketing website
+
+Standalone static site built on the ELSPETH design tokens. No build step.
+Serve `website/` with any static server (or GitHub Pages); open `index.html`.
+
+Pages: index (Home), authoring, assurance, use-cases, get-started.
+Shared: `site.css`, `site.js` (Lucide icons + light/dark toggle). Lucide loads
+from the unpkg CDN.
+
+**Token source:** `website/tokens/` + `website/styles.css` are a static MIRROR of
+the frontend's canonical tokens (`src/elspeth/web/frontend/src/styles/tokens.css`).
+They are identical today; if the frontend tokens change, re-copy them here.

--- a/website/assurance.html
+++ b/website/assurance.html
@@ -1,0 +1,107 @@
+<!-- @dsCard group="Website" viewport="1280x720" name="Site — Assurance" subtitle="Landscape audit trail · trust model · terminal statuses" -->
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Assurance — ELSPETH</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="site.css" />
+<script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="index.html">ELSPETH</a>
+      <nav class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="authoring.html">Authoring</a>
+        <a href="assurance.html" class="active">Assurance</a>
+        <a href="use-cases.html">Use cases</a>
+        <a href="get-started.html">Get started</a>
+      </nav>
+    </div>
+    <div class="nav-right">
+      <button class="iconbtn" id="theme-toggle" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
+      <a class="btn-compact" href="#" style="gap:8px"><i data-lucide="github" style="width:15px;height:15px"></i> GitHub</a>
+      <a class="btn-compact btn-primary" href="get-started.html" style="background:var(--color-btn-primary-bg);border-color:var(--color-btn-primary-bg);color:#fff">Get started</a>
+    </div>
+  </div>
+</header>
+
+<div class="page-head dotgrid">
+  <div class="wrap">
+    <span class="eyebrow">Assurance is the product</span>
+    <h1>Validation and audit are core properties.</h1>
+    <p>The Landscape database is the canonical evidentiary record — source rows, node states, external calls, payload hashes, route decisions, terminal outcomes, and artifact provenance. Telemetry and logs are secondary.</p>
+  </div>
+</div>
+
+<section>
+  <div class="wrap">
+    <div class="features" style="margin-top:8px">
+      <div class="feature"><span class="fi"><i data-lucide="scroll-text"></i></span><h4>Landscape audit trail</h4><p>Complete row lineage with content hashes. Export signed (HMAC-SHA256) with a running hash for chain-of-custody review.</p></div>
+      <div class="feature"><span class="fi"><i data-lucide="git-compare-arrows"></i></span><h4>Two-axis terminal model</h4><p>Lifecycle outcome and path/provenance are separated — "did it succeed?" and "how did it get there?" are both explicit.</p></div>
+      <div class="feature"><span class="fi"><i data-lucide="shield-check"></i></span><h4>Declaration-trust + VAL</h4><p>Plugin declarations the graph builder trusts are backed by runtime VAL manifests, invariant tests, and CI scanners.</p></div>
+      <div class="feature"><span class="fi"><i data-lucide="fingerprint"></i></span><h4>Secret discipline</h4><p>Secrets resolve at execution boundaries, are fingerprinted for audit, and are never persisted as raw values.</p></div>
+      <div class="feature"><span class="fi"><i data-lucide="lock"></i></span><h4>Strict response schemas</h4><p>Web execution responses forbid unknown fields, so internal drift fails loudly instead of being silently coerced.</p></div>
+      <div class="feature"><span class="fi"><i data-lucide="list-checks"></i></span><h4>Terminal statuses</h4><p>completed · completed_with_failures · failed · empty · cancelled — run accounting never collapses to one number.</p></div>
+    </div>
+  </div>
+</section>
+
+<hr class="divider" />
+
+<section class="dotgrid">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="eyebrow">Data trust model</span>
+      <h2>Three tiers, one rule: coerce only at the boundary.</h2>
+      <p>Once data enters the pipeline with valid types, downstream transforms trust those types. Wrong types downstream are upstream bugs to fix — not data-quality issues to handle gracefully.</p>
+    </div>
+    <div class="tiers">
+      <div class="tier">
+        <span class="tlabel">Tier 1</span>
+        <h4>Engine-owned records</h4>
+        <p>Audit database, checkpoints, runtime records. A corrupted audit record means tampering — crash immediately.</p>
+        <span class="trust" style="background:var(--color-error-bg);color:var(--color-error)">Full trust · crash on anomaly</span>
+      </div>
+      <div class="tier">
+        <span class="tlabel">Tier 2</span>
+        <h4>Validated pipeline data</h4>
+        <p>Rows after source validation. Types are valid; wrap operations where row content can still fail.</p>
+        <span class="trust" style="background:var(--color-warning-bg);color:var(--color-warning)">Elevated trust</span>
+      </div>
+      <div class="tier">
+        <span class="tlabel">Tier 3</span>
+        <h4>External input</h4>
+        <p>Files, API/LLM responses, source data. Validate at the boundary, coerce where allowed, quarantine malformed rows.</p>
+        <span class="trust" style="background:var(--color-success-bg);color:var(--color-success)">Zero trust · quarantine</span>
+      </div>
+    </div>
+    <div class="cta-row" style="margin-top:40px">
+      <a class="btn btn-primary" href="get-started.html">Get started</a>
+      <a class="btn" href="use-cases.html">Where it's used</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand">ELSPETH</span>
+    <div class="links">
+      <a href="index.html">Home</a>
+      <a href="authoring.html">Authoring</a>
+      <a href="use-cases.html">Use cases</a>
+      <a href="get-started.html">Get started</a>
+      <a href="#">GitHub</a>
+    </div>
+    <span class="copy">MIT licensed · Built for decisions that must be defensible.</span>
+  </div>
+</footer>
+
+<script src="site.js"></script>
+</body>
+</html>

--- a/website/authoring.html
+++ b/website/authoring.html
@@ -1,0 +1,128 @@
+<!-- @dsCard group="Website" viewport="1280x720" name="Site — Authoring" subtitle="Two authoring surfaces · Sense → Decide → Act" -->
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Authoring — ELSPETH</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="site.css" />
+<script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="index.html">ELSPETH</a>
+      <nav class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="authoring.html" class="active">Authoring</a>
+        <a href="assurance.html">Assurance</a>
+        <a href="use-cases.html">Use cases</a>
+        <a href="get-started.html">Get started</a>
+      </nav>
+    </div>
+    <div class="nav-right">
+      <button class="iconbtn" id="theme-toggle" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
+      <a class="btn-compact" href="#" style="gap:8px"><i data-lucide="github" style="width:15px;height:15px"></i> GitHub</a>
+      <a class="btn-compact btn-primary" href="get-started.html" style="background:var(--color-btn-primary-bg);border-color:var(--color-btn-primary-bg);color:#fff">Get started</a>
+    </div>
+  </div>
+</header>
+
+<div class="page-head dotgrid">
+  <div class="wrap">
+    <span class="eyebrow">Two authoring surfaces, one engine</span>
+    <h1>Hand-edit YAML, or build by conversation.</h1>
+    <p>Both surfaces target the same primitives, plugin contracts, graph validation, and Landscape audit trail. The Web Composer is an authoring surface over the substrate — not an alternative engine.</p>
+  </div>
+</div>
+
+<section>
+  <div class="wrap">
+    <div class="surfaces" style="margin-top:8px">
+      <div class="surface-card">
+        <span class="ic"><i data-lucide="file-code-2"></i></span>
+        <h3>YAML operator path</h3>
+        <p>For operators in sensitive, regulated, or defence-adjacent workflows. The pipeline can be read, reviewed, versioned, and explained before it ever runs.</p>
+        <ul>
+          <li><i data-lucide="check"></i> Declarative DAG — every edge explicitly named and validated</li>
+          <li><i data-lucide="check"></i> Hierarchical settings with profile overrides</li>
+          <li><i data-lucide="check"></i> <code>validate</code>, <code>run</code>, <code>explain</code>, <code>resume</code> from the CLI</li>
+        </ul>
+      </div>
+      <div class="surface-card">
+        <span class="ic"><i data-lucide="messages-square"></i></span>
+        <h3>Web Composer</h3>
+        <p>For knowledge workers building document QA, classification, routing, or review workflows. An LLM tool loop mutates pipeline state through audited tools and contracts — never free-form config text.</p>
+        <ul>
+          <li><i data-lucide="check"></i> Preview validation, graph, spec, YAML, and repair hints</li>
+          <li><i data-lucide="check"></i> Blob-backed sources and <code>$secret{}</code> references</li>
+          <li><i data-lucide="check"></i> Background runs streamed over WebSocket, safely cancellable</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<hr class="divider" />
+
+<section class="dotgrid">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="eyebrow">The model</span>
+      <h2>Sense → Decide → Act.</h2>
+      <p>Runtime assembly turns declared primitives into an execution graph; validation checks the wiring, route targets, and schema compatibility before the executor runs it.</p>
+    </div>
+    <div class="sda">
+      <div class="sda-step">
+        <span class="k" style="color:var(--color-badge-source)">Sense</span>
+        <h4>Sources</h4>
+        <p>Load data — CSV, JSON, text/blob, Azure Blob, Dataverse, database, Chroma.</p>
+      </div>
+      <div class="sda-arrow">→</div>
+      <div class="sda-step">
+        <span class="k" style="color:var(--color-badge-transform)">Decide</span>
+        <h4>Transforms &amp; gates</h4>
+        <p>Map, coerce, classify, run LLM queries, evaluate pure-config threshold gates.</p>
+      </div>
+      <div class="sda-arrow">→</div>
+      <div class="sda-step">
+        <span class="k" style="color:var(--color-badge-sink)">Act</span>
+        <h4>Sinks</h4>
+        <p>Route rows to outputs — files, database rows, review queues, alerts.</p>
+      </div>
+    </div>
+    <div class="types">
+      <div class="type-item"><span class="type-badge type-badge-source">Source</span><p>Ingest external data at a zero-trust boundary.</p></div>
+      <div class="type-item"><span class="type-badge type-badge-transform">Transform</span><p>Row-level mapping, coercion, LLM and safety steps.</p></div>
+      <div class="type-item"><span class="type-badge type-badge-gate">Gate</span><p>Pure-config routing by named expression.</p></div>
+      <div class="type-item"><span class="type-badge type-badge-sink">Sink</span><p>Write outputs and route to review.</p></div>
+      <div class="type-item"><span class="type-badge type-badge-aggregation">Aggregation</span><p>Batch-aware, audit-attributable analytics.</p></div>
+      <div class="type-item"><span class="type-badge type-badge-coalesce">Coalesce</span><p>Join branches back into a single stream.</p></div>
+    </div>
+    <div class="cta-row" style="margin-top:40px">
+      <a class="btn btn-primary" href="get-started.html">See a pipeline.yaml</a>
+      <a class="btn" href="assurance.html">How it's audited</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand">ELSPETH</span>
+    <div class="links">
+      <a href="index.html">Home</a>
+      <a href="assurance.html">Assurance</a>
+      <a href="use-cases.html">Use cases</a>
+      <a href="get-started.html">Get started</a>
+      <a href="#">GitHub</a>
+    </div>
+    <span class="copy">MIT licensed · Built for decisions that must be defensible.</span>
+  </div>
+</footer>
+
+<script src="site.js"></script>
+</body>
+</html>

--- a/website/get-started.html
+++ b/website/get-started.html
@@ -1,0 +1,142 @@
+<!-- @dsCard group="Website" viewport="1280x760" name="Site — Get started" subtitle="Install the CLI, write a pipeline, validate & run" -->
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Get started — ELSPETH</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="site.css" />
+<script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="index.html">ELSPETH</a>
+      <nav class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="authoring.html">Authoring</a>
+        <a href="assurance.html">Assurance</a>
+        <a href="use-cases.html">Use cases</a>
+        <a href="get-started.html" class="active">Get started</a>
+      </nav>
+    </div>
+    <div class="nav-right">
+      <button class="iconbtn" id="theme-toggle" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
+      <a class="btn-compact" href="#" style="gap:8px"><i data-lucide="github" style="width:15px;height:15px"></i> GitHub</a>
+      <a class="btn-compact btn-primary" href="get-started.html" style="background:var(--color-btn-primary-bg);border-color:var(--color-btn-primary-bg);color:#fff">Get started</a>
+    </div>
+  </div>
+</header>
+
+<div class="page-head dotgrid">
+  <div class="wrap">
+    <span class="eyebrow">Reviewable by design</span>
+    <h1>From install to a validated run.</h1>
+    <p>Install the CLI, declare a pipeline, and validate it before it runs. What you read is what runs — and what the audit trail records.</p>
+  </div>
+</div>
+
+<section>
+  <div class="wrap">
+    <div class="steps" style="margin-top:8px">
+      <div class="step">
+        <span class="num">1</span>
+        <div>
+          <h4>Install</h4>
+          <p>Python 3.12+. Clone and install with <code>uv</code>.</p>
+          <pre><span class="pr">$</span> git clone https://github.com/johnm-dta/elspeth.git &amp;&amp; cd elspeth
+<span class="pr">$</span> uv venv &amp;&amp; source .venv/bin/activate
+<span class="pr">$</span> uv pip install -e ".[dev]"</pre>
+        </div>
+      </div>
+      <div class="step">
+        <span class="num">2</span>
+        <div>
+          <h4>Validate before you run</h4>
+          <p>Preflight checks graph structure, route targets, schema compatibility, and secret references.</p>
+          <pre><span class="pr">$</span> elspeth validate --settings pipeline.yaml</pre>
+        </div>
+      </div>
+      <div class="step">
+        <span class="num">3</span>
+        <div>
+          <h4>Run &amp; explain</h4>
+          <p>Execute the pipeline, then explore why any row reached its destination.</p>
+          <pre><span class="pr">$</span> elspeth run --settings pipeline.yaml --execute
+<span class="pr">$</span> elspeth explain --run &lt;run_id&gt; --row &lt;row_id&gt;</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<hr class="divider" />
+
+<section class="dotgrid">
+  <div class="wrap">
+    <div class="codewrap">
+      <div class="section-head" style="max-width:38ch">
+        <span class="eyebrow">A pipeline is just declared primitives</span>
+        <h2>pipeline.yaml</h2>
+        <p>Every edge is named; every gate is pure config. Prefer not to write YAML? The Web Composer lets you describe the workflow in conversation instead — it builds the same artifact.</p>
+      </div>
+<pre class="code"><span class="cm"># pipeline.yaml</span>
+<span class="key">source</span>:
+  plugin: <span class="str">csv</span>
+  on_success: validated
+  options: { path: <span class="str">data/submissions.csv</span> }
+
+<span class="key">transforms</span>:
+- name: classify
+  plugin: <span class="str">llm</span>
+  input: validated
+  on_success: classified
+
+<span class="key">gates</span>:
+- name: safety_gate
+  input: classified
+  condition: <span class="str">"row['risk_score'] > 0.8"</span>
+  routes: { <span class="str">"true"</span>: review, <span class="str">"false"</span>: approved }
+
+<span class="key">sinks</span>:
+  approved: { plugin: <span class="str">csv</span> }
+  review:   { plugin: <span class="str">review_queue</span> }
+
+<span class="key">landscape</span>:
+  url: <span class="str">sqlite:///./audit.db</span></pre>
+    </div>
+  </div>
+</section>
+
+<div class="ctaband">
+  <div class="wrap">
+    <span class="eyebrow">Traceable · Reliable · Defensible</span>
+    <h2>Ready when you are.</h2>
+    <p>Read the docs for a complete walkthrough, or jump straight into the Web Composer.</p>
+    <div class="cta-row" style="justify-content:center">
+      <a class="btn btn-primary btn-lg" href="#">Read the docs</a>
+      <a class="btn btn-lg" href="#"><i data-lucide="github" style="width:18px;height:18px"></i>&nbsp; johnm-dta/elspeth</a>
+    </div>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand">ELSPETH</span>
+    <div class="links">
+      <a href="index.html">Home</a>
+      <a href="authoring.html">Authoring</a>
+      <a href="assurance.html">Assurance</a>
+      <a href="use-cases.html">Use cases</a>
+      <a href="#">GitHub</a>
+    </div>
+    <span class="copy">MIT licensed · Built for decisions that must be defensible.</span>
+  </div>
+</footer>
+
+<script src="site.js"></script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,124 @@
+<!-- @dsCard group="Website" viewport="1280x720" name="Site — Home" subtitle="Marketing landing page (multi-page set), in-brand, light/dark" -->
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ELSPETH — High-assurance pipelines for consequential work</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="site.css" />
+<script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="index.html">ELSPETH</a>
+      <nav class="nav-links">
+        <a href="index.html" class="active">Home</a>
+        <a href="authoring.html">Authoring</a>
+        <a href="assurance.html">Assurance</a>
+        <a href="use-cases.html">Use cases</a>
+        <a href="get-started.html">Get started</a>
+      </nav>
+    </div>
+    <div class="nav-right">
+      <button class="iconbtn" id="theme-toggle" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
+      <a class="btn-compact" href="#" style="gap:8px"><i data-lucide="github" style="width:15px;height:15px"></i> GitHub</a>
+      <a class="btn-compact btn-primary" href="get-started.html" style="background:var(--color-btn-primary-bg);border-color:var(--color-btn-primary-bg);color:#fff">Get started</a>
+    </div>
+  </div>
+</header>
+
+<!-- HERO -->
+<div class="hero dotgrid">
+  <div class="wrap hero-grid">
+    <div>
+      <span class="eyebrow">Open source · MIT · Python 3.12+</span>
+      <h1>Pipelines for decisions you have to defend.</h1>
+      <p class="sub">ELSPETH is a high-assurance pipeline substrate for consequential workflows — where the wrong output can cause operational, legal, safety, or financial harm. Author in reviewable YAML or the LLM Web Composer; both run on one audited engine.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary btn-lg" href="get-started.html">Get started</a>
+        <a class="btn btn-lg" href="#"><i data-lucide="github" style="width:18px;height:18px"></i>&nbsp; View on GitHub</a>
+      </div>
+    </div>
+    <div class="term" aria-hidden="true">
+      <div class="term-bar">
+        <i data-lucide="terminal" style="width:14px;height:14px;color:var(--color-text-muted)"></i>
+        <span class="t">elspeth · validate &amp; run</span>
+      </div>
+      <div class="term-body"><span class="pr">$</span> <span class="cmd">elspeth validate --settings pipeline.yaml</span>
+<span class="ok">✓</span> <span class="mut">graph structure · route targets · edge/schema</span>
+<span class="ok">✓</span> <span class="mut">secret references resolved · preflight passed</span>
+
+<span class="pr">$</span> <span class="cmd">elspeth run --settings pipeline.yaml --execute</span>
+<span class="mut">240 rows · 228 approved · 12 → review · 0 failed</span>
+<span class="ok">completed</span> <span class="mut">— audit trail written to Landscape</span></div>
+    </div>
+  </div>
+</div>
+
+<hr class="divider" />
+
+<!-- THREE PROPS -->
+<section>
+  <div class="wrap">
+    <div class="section-head" style="margin-bottom:36px">
+      <span class="eyebrow">Why ELSPETH</span>
+      <h2>Substrate first. Authoring second.</h2>
+      <p>A pipeline is made of declared primitives carrying schema and semantic contracts. Validation and audit are core product properties — not after-the-fact diagnostics.</p>
+    </div>
+    <div class="props">
+      <div class="prop">
+        <span class="pi"><i data-lucide="git-fork"></i></span>
+        <h3>Two surfaces, one engine</h3>
+        <p>Hand-edit reviewable YAML, or build by conversation in the Web Composer. Both target the same runtime, contracts, and audit trail.</p>
+        <a href="authoring.html">Explore authoring <i data-lucide="arrow-right" style="width:14px;height:14px"></i></a>
+      </div>
+      <div class="prop">
+        <span class="pi"><i data-lucide="scroll-text"></i></span>
+        <h3>Audit is the product</h3>
+        <p>The Landscape database records full row lineage — hashes, route decisions, terminal outcomes, and provenance — as the canonical evidentiary record.</p>
+        <a href="assurance.html">See the assurance model <i data-lucide="arrow-right" style="width:14px;height:14px"></i></a>
+      </div>
+      <div class="prop">
+        <span class="pi"><i data-lucide="briefcase"></i></span>
+        <h3>For high-stakes work</h3>
+        <p>Tender evaluation, document QA, content moderation, financial compliance — same framework, different plugins, full audit trail.</p>
+        <a href="use-cases.html">Browse use cases <i data-lucide="arrow-right" style="width:14px;height:14px"></i></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA BAND -->
+<div class="ctaband">
+  <div class="wrap">
+    <span class="eyebrow">Traceable · Reliable · Defensible</span>
+    <h2>Build a pipeline you can stand behind.</h2>
+    <p>Install the CLI, or open the Web Composer and describe what you want. Both end in a pipeline that can be validated, executed, audited, and explained.</p>
+    <div class="cta-row" style="justify-content:center">
+      <a class="btn btn-primary btn-lg" href="get-started.html">Get started</a>
+      <a class="btn btn-lg" href="#"><i data-lucide="github" style="width:18px;height:18px"></i>&nbsp; johnm-dta/elspeth</a>
+    </div>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand">ELSPETH</span>
+    <div class="links">
+      <a href="authoring.html">Authoring</a>
+      <a href="assurance.html">Assurance</a>
+      <a href="use-cases.html">Use cases</a>
+      <a href="get-started.html">Get started</a>
+      <a href="#">GitHub</a>
+    </div>
+    <span class="copy">MIT licensed · Built for decisions that must be defensible.</span>
+  </div>
+</footer>
+
+<script src="site.js"></script>
+</body>
+</html>

--- a/website/site.css
+++ b/website/site.css
@@ -1,0 +1,150 @@
+/* site.css — shared styles for the ELSPETH marketing site (multi-page).
+   Built on the design-system tokens (styles.css). */
+
+html, body { height: auto; overflow-x: hidden; }
+body { background: var(--color-bg); color: var(--color-text); margin: 0; }
+a { color: inherit; text-decoration: none; }
+.wrap { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+.eyebrow { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: .16em; text-transform: uppercase; color: var(--color-text-muted); }
+.dotgrid { background-image: radial-gradient(var(--color-canvas-grid) 1px, transparent 1px); background-size: 22px 22px; }
+.muted { color: var(--color-text-secondary); }
+
+/* Nav */
+.nav { position: sticky; top: 0; z-index: 20; background: color-mix(in srgb, var(--color-surface-nav) 92%, transparent); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+.nav-inner { display: flex; align-items: center; justify-content: space-between; height: 56px; }
+.nav-left { display: flex; align-items: center; gap: 28px; }
+.brand { font-family: var(--font-mono); font-weight: 700; text-transform: uppercase; letter-spacing: .18em; font-size: 15px; color: var(--color-text); }
+.nav-links { display: flex; gap: 22px; }
+.nav-links a { font-size: 14px; color: var(--color-text-secondary); padding: 4px 0; border-bottom: 2px solid transparent; }
+.nav-links a:hover { color: var(--color-text); }
+.nav-links a.active { color: var(--color-text); border-bottom-color: var(--color-accent); }
+.nav-right { display: flex; align-items: center; gap: 10px; }
+.iconbtn { display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface-elevated); color: var(--color-text); cursor: pointer; }
+.iconbtn:hover { border-color: var(--color-border-strong); }
+
+/* Page header (non-home) */
+.page-head { padding: 64px 0 8px; }
+.page-head h1 { font-size: 44px; line-height: 1.08; letter-spacing: -0.02em; margin: 14px 0 0; max-width: 18ch; font-weight: 700; text-wrap: balance; }
+.page-head p { font-size: 18px; line-height: 1.55; color: var(--color-text-secondary); max-width: 60ch; margin: 18px 0 0; }
+
+/* Hero */
+.hero { padding: 76px 0 60px; position: relative; }
+.hero h1 { font-size: 56px; line-height: 1.05; letter-spacing: -0.02em; margin: 18px 0 0; max-width: 16ch; font-weight: 700; text-wrap: balance; }
+.hero .sub { font-size: 19px; line-height: 1.55; color: var(--color-text-secondary); max-width: 56ch; margin: 22px 0 0; }
+.cta-row { display: flex; gap: 12px; margin-top: 32px; flex-wrap: wrap; }
+.hero-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 48px; align-items: center; }
+
+/* Terminal card */
+.term { background: var(--color-surface-nav); border: 1px solid var(--color-border-strong); border-radius: var(--radius-lg); overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.35); }
+.term-bar { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--color-border); background: var(--color-surface-nav-raised); }
+.term-bar .t { font-family: var(--font-mono); font-size: 11px; color: var(--color-text-muted); letter-spacing: .04em; }
+.term-body { padding: 18px 18px 20px; font-family: var(--font-mono); font-size: 13px; line-height: 1.7; white-space: pre-wrap; word-break: break-word; }
+.term-body .pr { color: var(--color-badge-source); }
+.term-body .cmd { color: var(--color-text); }
+.term-body .ok { color: var(--color-success); }
+.term-body .mut { color: var(--color-text-muted); }
+.term-body .warn { color: var(--color-warning); }
+
+/* Sections */
+section { padding: 60px 0; }
+.section-head { max-width: 60ch; }
+.section-head h2 { font-size: 32px; line-height: 1.15; letter-spacing: -0.01em; margin: 10px 0 0; font-weight: 700; }
+.section-head p { font-size: 17px; color: var(--color-text-secondary); line-height: 1.55; margin: 14px 0 0; }
+.divider { border: 0; border-top: 1px solid var(--color-border); margin: 0; }
+
+/* Quick value props (home) */
+.props { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 8px; }
+.prop { padding: 24px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); }
+.prop .pi { width: 36px; height: 36px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-md); background: var(--color-accent-muted); color: var(--color-success); }
+.prop h3 { font-size: 18px; margin: 14px 0 0; font-weight: 650; }
+.prop p { font-size: 14px; color: var(--color-text-secondary); line-height: 1.5; margin: 8px 0 0; }
+.prop a { display: inline-flex; align-items: center; gap: 6px; margin-top: 14px; font-size: 13px; color: var(--color-link); }
+
+/* Two surfaces */
+.surfaces { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 40px; }
+.surface-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-xl); padding: 28px; }
+.surface-card .ic { width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-md); background: var(--color-surface-elevated); border: 1px solid var(--color-border); color: var(--color-text-secondary); }
+.surface-card h3 { font-size: 21px; margin: 16px 0 0; font-weight: 650; }
+.surface-card p { font-size: 15px; color: var(--color-text-secondary); line-height: 1.55; margin: 10px 0 0; }
+.surface-card ul { list-style: none; margin: 16px 0 0; padding: 0; display: grid; gap: 8px; }
+.surface-card li { display: flex; gap: 9px; font-size: 14px; color: var(--color-text-secondary); }
+.surface-card li svg { width: 16px; height: 16px; color: var(--color-success); flex-shrink: 0; margin-top: 2px; }
+
+/* SDA strip */
+.sda { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: stretch; gap: 14px; margin-top: 36px; }
+.sda-step { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: 22px; }
+.sda-step .k { font-family: var(--font-mono); font-size: 12px; text-transform: uppercase; letter-spacing: .12em; font-weight: 700; }
+.sda-step h4 { font-size: 17px; margin: 8px 0 0; font-weight: 650; }
+.sda-step p { font-size: 14px; color: var(--color-text-muted); margin: 6px 0 0; line-height: 1.5; }
+.sda-arrow { align-self: center; color: var(--color-border-strong); font-size: 22px; }
+
+/* Component types */
+.types { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 36px; }
+.type-item { display: flex; align-items: flex-start; gap: 12px; padding: 16px; border: 1px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); }
+.type-item p { margin: 0; font-size: 13px; color: var(--color-text-muted); line-height: 1.45; }
+
+/* Assurance grid */
+.features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 40px; }
+.feature { padding: 22px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); }
+.feature .fi { width: 34px; height: 34px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-md); background: var(--color-accent-muted); color: var(--color-success); }
+.feature h4 { font-size: 16px; margin: 14px 0 0; font-weight: 650; }
+.feature p { font-size: 14px; color: var(--color-text-secondary); line-height: 1.5; margin: 8px 0 0; }
+
+/* Trust tiers */
+.tiers { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 36px; }
+.tier { padding: 22px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); }
+.tier .tlabel { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-text-muted); }
+.tier h4 { font-size: 17px; margin: 8px 0 0; font-weight: 650; }
+.tier p { font-size: 14px; color: var(--color-text-secondary); line-height: 1.5; margin: 8px 0 0; }
+.tier .trust { display: inline-block; margin-top: 12px; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: var(--radius-sm); }
+
+/* Use cases */
+.cases { margin-top: 36px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); overflow: hidden; }
+.case-row { display: grid; grid-template-columns: 1.2fr 1fr 1.4fr 1.2fr; gap: 16px; padding: 16px 20px; border-bottom: 1px solid var(--color-border); align-items: baseline; }
+.case-row:last-child { border-bottom: 0; }
+.case-row.head { background: var(--color-surface-elevated); }
+.case-row.head span { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-text-muted); }
+.case-row .dom { font-weight: 650; font-size: 15px; }
+.case-row .c { font-size: 14px; color: var(--color-text-secondary); }
+
+/* Code block */
+.codewrap { display: grid; grid-template-columns: 0.8fr 1.2fr; gap: 40px; align-items: center; margin-top: 8px; }
+pre.code { background: var(--color-surface-nav); border: 1px solid var(--color-border-strong); border-radius: var(--radius-lg); padding: 22px; font-family: var(--font-mono); font-size: 13px; line-height: 1.65; color: var(--color-text-secondary); overflow: auto; }
+pre.code .key { color: var(--color-badge-aggregation); }
+pre.code .str { color: var(--color-badge-source); }
+pre.code .cm { color: var(--color-text-muted); }
+
+/* Steps (get started) */
+.steps { display: grid; gap: 14px; margin-top: 36px; }
+.step { display: grid; grid-template-columns: 36px 1fr; gap: 16px; align-items: start; padding: 20px; border: 1px solid var(--color-border); border-radius: var(--radius-lg); background: var(--color-surface); }
+.step .num { width: 36px; height: 36px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-pill); background: var(--color-accent-muted); color: var(--color-success); font-family: var(--font-mono); font-weight: 700; }
+.step h4 { margin: 4px 0 0; font-size: 17px; font-weight: 650; }
+.step p { margin: 6px 0 0; font-size: 14px; color: var(--color-text-secondary); line-height: 1.5; }
+.step pre { margin: 12px 0 0; padding: 12px 14px; background: var(--color-surface-nav); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: 12.5px; color: var(--color-text-secondary); overflow: auto; }
+.step pre .pr { color: var(--color-badge-source); }
+
+/* CTA band */
+.ctaband { text-align: center; padding: 76px 0; background: var(--color-surface-nav); border-top: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); }
+.ctaband h2 { font-size: 36px; margin: 14px 0 0; font-weight: 700; letter-spacing: -0.01em; }
+.ctaband p { font-size: 17px; color: var(--color-text-secondary); margin: 14px auto 0; max-width: 52ch; }
+
+/* Footer */
+footer { padding: 44px 0; }
+.foot { display: flex; justify-content: space-between; align-items: center; gap: 20px; flex-wrap: wrap; }
+.foot .links { display: flex; gap: 20px; }
+.foot .links a { font-size: 13px; color: var(--color-text-muted); }
+.foot .links a:hover { color: var(--color-text); }
+.foot .copy { font-size: 13px; color: var(--color-text-muted); }
+
+.btn-lg { min-height: 48px; padding: 0 22px; font-size: 16px; border-radius: var(--radius-md); }
+
+@media (max-width: 900px) {
+  .hero-grid, .codewrap { grid-template-columns: 1fr; }
+  .surfaces, .types, .features, .props, .tiers { grid-template-columns: 1fr; }
+  .sda { grid-template-columns: 1fr; }
+  .sda-arrow { display: none; }
+  .hero h1 { font-size: 40px; }
+  .page-head h1 { font-size: 34px; }
+  .nav-links { display: none; }
+  .case-row { grid-template-columns: 1fr 1fr; }
+}

--- a/website/site.js
+++ b/website/site.js
@@ -1,0 +1,14 @@
+// site.js — shared marketing-site behaviour: render icons + theme toggle.
+(function () {
+  if (window.lucide) window.lucide.createIcons();
+  var t = document.getElementById("theme-toggle");
+  if (t) {
+    t.addEventListener("click", function () {
+      var root = document.documentElement;
+      var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+      root.setAttribute("data-theme", next);
+      t.innerHTML = '<i data-lucide="' + (next === "dark" ? "moon" : "sun") + '"></i>';
+      if (window.lucide) window.lucide.createIcons();
+    });
+  }
+})();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,15 @@
+/* =============================================================================
+   ELSPETH Design System — Global styles entry point.
+   Consumers link THIS file only. It is a manifest of @import lines; every
+   token, font, and shared primitive in the system is reachable from here.
+   ============================================================================= */
+
+/* Foundation: fonts → color tokens → type tokens → layout tokens. */
+@import "./tokens/fonts.css";
+@import "./tokens/colors.css";
+@import "./tokens/typography.css";
+@import "./tokens/layout.css";
+
+/* Base reset + shared primitive classes (buttons, badges, inputs, cards…). */
+@import "./tokens/base.css";
+@import "./tokens/primitives.css";

--- a/website/tokens/base.css
+++ b/website/tokens/base.css
@@ -1,0 +1,70 @@
+/* base.css — Global reset, document defaults, scrollbar, focus-visible, sr-only.
+   Mirrors the product's base layer. */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+kbd,
+samp,
+.mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+}
+
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Scrollbar ─────────────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: var(--color-scrollbar-track); }
+::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar-thumb);
+  border-radius: var(--radius-sm);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--color-scrollbar-thumb-hover); }
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+}
+
+/* ── Focus-visible — keyboard navigation ───────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+:focus:not(:focus-visible) { outline: none; }
+
+/* ── Screen-reader-only utility ────────────────────────────────────────────── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/website/tokens/colors.css
+++ b/website/tokens/colors.css
@@ -1,0 +1,220 @@
+/* colors.css — ELSPETH colour tokens.
+   Primary: :root (dark theme defaults) and [data-theme="light"] overrides.
+   Both blocks are TOP-LEVEL selectors.
+
+   The palette is built on the DTA / AGDS three-family role model:
+     • Workspace family  — Pacific teal   (active editing surfaces)
+     • Navigation family — Foundation navy (header / chrome)
+     • Inspection family — warm neutral    (right rail, paper modals)
+   so a screen reads as paper-on-desk against teal/navy columns rather than
+   one flat slab of colour. */
+
+:root {
+  /* ── Backgrounds — Workspace family (Pacific teal) ───────────────────────── */
+  --color-bg:                #0f2d35;
+  --color-surface:           #122f37;
+  --color-surface-elevated:  #1a3d47;
+  --color-surface-hover:     rgba(255, 255, 255, 0.04);
+  --color-surface-raised:    #1a3d47;
+  --color-surface-input:     #0f2d35;
+
+  /* ── Backgrounds — Navigation family (Foundation navy) ───────────────────── */
+  --color-surface-nav:        #0a1d2e;
+  --color-surface-nav-raised: #13283a;
+
+  /* ── Backgrounds — Inspection family (warm neutral paper) ────────────────── */
+  --color-surface-inspector: #2a2826;
+  --color-surface-paper:     #332f2c;
+
+  /* ── Text ────────────────────────────────────────────────────────────────── */
+  --color-text:              #dff0ee;
+  --color-text-secondary:    #a8d0d0;
+  --color-text-muted:        #7a9a9a;
+  --color-text-inverse:      #ffffff;
+
+  /* ── Borders — teal-tinted ───────────────────────────────────────────────── */
+  --color-border:            rgba(143, 200, 200, 0.12);
+  --color-border-strong:     rgba(143, 200, 200, 0.25);
+
+  /* ── Interactive / accent ────────────────────────────────────────────────── */
+  --color-accent:            #1a7a52;
+  --color-accent-muted:      rgba(20, 176, 174, 0.18);
+  --color-focus-ring:        #ffffff;
+  --color-btn-primary-bg:        #16664a;
+  --color-btn-primary-bg-hover:  #1a5840;
+  --color-btn-danger-bg:         #b23835;
+  --color-btn-danger-bg-hover:   #912f2d;
+  --color-link:              #61daff;
+  --color-highlight:         rgba(26, 122, 82, 0.14);
+  --color-selected-ring:     rgba(26, 122, 82, 0.55);
+
+  /* ── Semantic colours ────────────────────────────────────────────────────── */
+  --color-success:           #14b0ae;
+  --color-error:             #e85653;
+  --color-warning:           #e38444;
+  --color-info:              #61daff;
+  --color-state-positive:    #14b0ae;
+
+  --color-success-bg:        rgba(20, 176, 174, 0.12);
+  --color-success-border:    rgba(20, 176, 174, 0.30);
+  --color-error-bg:          rgba(232, 86, 83, 0.12);
+  --color-error-border:      rgba(232, 86, 83, 0.30);
+  --color-warning-bg:        rgba(227, 132, 68, 0.14);
+  --color-warning-border:    rgba(227, 132, 68, 0.30);
+  --color-info-bg:           rgba(97, 218, 255, 0.10);
+  --color-info-border:       rgba(97, 218, 255, 0.25);
+
+  /* ── Chat bubbles ────────────────────────────────────────────────────────── */
+  --color-bubble-user:             rgba(40, 130, 100, 0.14);
+  --color-bubble-user-border:      rgba(40, 130, 100, 0.35);
+  --color-bubble-assistant:        rgba(255, 255, 255, 0.05);
+  --color-bubble-assistant-border: rgba(255, 255, 255, 0.18);
+  --color-bubble-system:           rgba(255, 255, 255, 0.03);
+
+  /* ── Component-type badges — functional colour coding for the 6 primitives ── */
+  --color-badge-source:      #4db89a;   /* SENSE  — aqua-green */
+  --color-badge-transform:   #e8a030;   /* DECIDE — amber */
+  --color-badge-gate:        #c390f9;   /* DECIDE — purple */
+  --color-badge-sink:        #e07040;   /* ACT    — orange-red */
+  --color-badge-aggregation: #61daff;   /* DECIDE — cyan */
+  --color-badge-coalesce:    #18c2c0;   /* join   — cyan-teal */
+
+  --color-badge-source-bg:      #184244;
+  --color-badge-transform-bg:   #303e34;
+  --color-badge-gate-bg:        #2a3c52;
+  --color-badge-sink-bg:        #2e3737;
+  --color-badge-aggregation-bg: #1b4753;
+  --color-badge-coalesce-bg:    #10434a;
+
+  --color-badge-source-border:      rgba(77, 184, 154, 0.3);
+  --color-badge-transform-border:   rgba(232, 160, 48, 0.3);
+  --color-badge-gate-border:        rgba(195, 144, 249, 0.3);
+  --color-badge-sink-border:        rgba(224, 112, 64, 0.3);
+  --color-badge-aggregation-border: rgba(97, 218, 255, 0.3);
+  --color-badge-coalesce-border:    rgba(24, 194, 192, 0.3);
+
+  /* ── Per-node validation indicator borders ───────────────────────────────── */
+  --color-node-valid:     #14b0ae;
+  --color-node-warning:   #e38444;
+  --color-node-invalid:   #e85653;
+  --color-node-unchecked: var(--color-border-strong);
+
+  /* ── Run status badges ───────────────────────────────────────────────────── */
+  --color-status-pending:    #7a9a9a;
+  --color-status-running:    #61daff;
+  --color-status-completed:  #14b0ae;
+  --color-status-failed:     #e85653;
+  --color-status-cancelled:  #e38444;
+  --color-status-empty:      #888888;
+
+  /* ── Scrollbar — teal-tinted ─────────────────────────────────────────────── */
+  --color-scrollbar-track:       var(--color-bg);
+  --color-scrollbar-thumb:       rgba(143, 200, 200, 0.15);
+  --color-scrollbar-thumb-hover: rgba(143, 200, 200, 0.28);
+
+  /* ── React Flow canvas dot grid ──────────────────────────────────────────── */
+  --color-canvas-grid: rgba(170, 220, 220, 0.28);
+
+  /* ── Dimming ─────────────────────────────────────────────────────────────── */
+  --opacity-dimmed: 0.35; /* @kind other */
+}
+
+/* ---------------------------------------------------------------------------
+   Light Theme — applied via data-theme="light" (set by the useTheme hook).
+   --------------------------------------------------------------------------- */
+[data-theme="light"] {
+  /* Workspace family — light teal */
+  --color-bg:                #f4f8f9;
+  --color-surface:           #ffffff;
+  --color-surface-elevated:  #ffffff;
+  --color-surface-hover:     rgba(15, 45, 53, 0.06);
+  --color-surface-raised:    #eaf2f3;
+  --color-surface-input:     #ffffff;
+
+  /* Navigation family — pale navy */
+  --color-surface-nav:        #e8edf3;
+  --color-surface-nav-raised: #dbe3ec;
+
+  /* Inspection family — warm cream */
+  --color-surface-inspector: #faf7f3;
+  --color-surface-paper:     #f0eae3;
+
+  --color-text:              #0f2d35;
+  --color-text-secondary:    #3a5a64;
+  --color-text-muted:        #426069;
+  --color-text-inverse:      #ffffff;
+
+  --color-border:            rgba(15, 45, 53, 0.12);
+  --color-border-strong:     rgba(15, 45, 53, 0.25);
+
+  --color-accent:            #156048;
+  --color-accent-muted:      rgba(21, 96, 72, 0.12);
+  --color-focus-ring:        #0f2d35;
+  --color-btn-primary-bg:        #1a7a5a;
+  --color-btn-primary-bg-hover:  #156048;
+  --color-btn-danger-bg:         #b23835;
+  --color-btn-danger-bg-hover:   #912f2d;
+  --color-link:              #176d8a;
+  --color-highlight:         rgba(21, 96, 72, 0.12);
+  --color-selected-ring:     rgba(21, 96, 72, 0.45);
+
+  --color-success:           #0d8a88;
+  --color-error:             #c93b38;
+  --color-warning:           #b86830;
+  --color-info:              #176d8a;
+  --color-state-positive:    #056e6c;
+
+  --color-success-bg:        rgba(20, 160, 158, 0.10);
+  --color-success-border:    rgba(20, 160, 158, 0.35);
+  --color-error-bg:          rgba(210, 70, 67, 0.10);
+  --color-error-border:      rgba(210, 70, 67, 0.35);
+  --color-warning-bg:        rgba(200, 115, 55, 0.12);
+  --color-warning-border:    rgba(200, 115, 55, 0.35);
+  --color-info-bg:           rgba(40, 150, 190, 0.10);
+  --color-info-border:       rgba(40, 150, 190, 0.30);
+
+  --color-bubble-user:             rgba(40, 130, 100, 0.10);
+  --color-bubble-user-border:      rgba(40, 130, 100, 0.30);
+  --color-bubble-assistant:        rgba(15, 45, 53, 0.05);
+  --color-bubble-assistant-border: rgba(15, 45, 53, 0.15);
+  --color-bubble-system:           rgba(15, 45, 53, 0.03);
+
+  --color-badge-source:      #257963;
+  --color-badge-transform:   #926414;
+  --color-badge-gate:        #8356b6;
+  --color-badge-sink:        #ad502d;
+  --color-badge-aggregation: #207595;
+  --color-badge-coalesce:    #0e8090;
+
+  --color-badge-source-bg:      #dcebe9;
+  --color-badge-transform-bg:   #ece9de;
+  --color-badge-gate-bg:        #e7e5f2;
+  --color-badge-sink-bg:        #ede4e1;
+  --color-badge-aggregation-bg: #dcecf1;
+  --color-badge-coalesce-bg:    #d8eaec;
+
+  --color-badge-source-border:      rgba(42, 138, 112, 0.35);
+  --color-badge-transform-border:   rgba(176, 120, 24, 0.35);
+  --color-badge-gate-border:        rgba(138, 90, 192, 0.35);
+  --color-badge-sink-border:        rgba(184, 85, 48, 0.35);
+  --color-badge-aggregation-border: rgba(40, 144, 184, 0.35);
+  --color-badge-coalesce-border:    rgba(14, 128, 144, 0.35);
+
+  --color-node-valid:     #0d8a88;
+  --color-node-warning:   #b86830;
+  --color-node-invalid:   #c93b38;
+  --color-node-unchecked: var(--color-border-strong);
+
+  --color-status-pending:    #5a7a84;
+  --color-status-running:    #2890b8;
+  --color-status-completed:  #0d8a88;
+  --color-status-failed:     #c93b38;
+  --color-status-cancelled:  #b86830;
+  --color-status-empty:      #4d6a73;
+
+  --color-scrollbar-track:       var(--color-bg);
+  --color-scrollbar-thumb:       rgba(15, 45, 53, 0.18);
+  --color-scrollbar-thumb-hover: rgba(15, 45, 53, 0.30);
+
+  --color-canvas-grid: rgba(15, 45, 53, 0.20);
+}

--- a/website/tokens/fonts.css
+++ b/website/tokens/fonts.css
@@ -1,0 +1,6 @@
+/* fonts.css — Webfonts for ELSPETH.
+   The product ships Inter (body/UI, the DTA AGDS Foundation typeface) and
+   JetBrains Mono (audit/forensic register: wordmark, code, YAML, hashes).
+   Both are loaded from Google Fonts, exactly as the real app's index.html does.
+   The @import MUST be the first statement in this file. */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap");

--- a/website/tokens/layout.css
+++ b/website/tokens/layout.css
@@ -1,0 +1,48 @@
+/* layout.css — Spacing, radius, control sizing, transitions, z-index. */
+
+:root {
+  /* ── Spacing scale (2 → 32) ──────────────────────────────────────────────── */
+  --space-2xs: 2px;
+  --space-xs:  4px;
+  --space-sm:  8px;
+  --space-md:  12px;
+  --space-lg:  16px;
+  --space-xl:  24px;
+  --space-2xl: 32px;
+
+  /* ── Radius ──────────────────────────────────────────────────────────────── */
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   8px;
+  --radius-xl:   12px;
+  --radius-pill: 9999px;
+
+  /* ── Control heights ─────────────────────────────────────────────────────── */
+  /* --size-control is the WCAG 2.5.5 (AAA) 44×44 touch floor for canvas-area
+     primary actions. --size-control-compact is the chrome-row size used by
+     header buttons and dense toolbars (WCAG 2.5.8 AA, ≥24×24). */
+  --size-control:         44px;
+  --size-control-compact: 36px;
+
+  /* ── Side-rail / inspector sizing ────────────────────────────────────────── */
+  --inspector-default-width: 320px;
+  --inspector-min-width:     240px;
+
+  /* ── Transitions ─────────────────────────────────────────────────────────── */
+  --transition-fast:   100ms ease; /* @kind other */
+  --transition-normal: 150ms ease; /* @kind other */
+  --transition-slow:   250ms ease; /* @kind other */
+
+  /* ── Z-index layers ──────────────────────────────────────────────────────── */
+  --z-panel-controls:   10; /* @kind other */
+  --z-catalog-backdrop: 38; /* @kind other */
+  --z-catalog:          40; /* @kind other */
+  --z-popover:          50; /* @kind other */
+  --z-overlay-backdrop: 99; /* @kind other */
+  --z-overlay:         100; /* @kind other */
+  --z-dialog-backdrop: 200; /* @kind other */
+  --z-dialog:          201; /* @kind other */
+  --z-palette-backdrop: 300; /* @kind other */
+  --z-palette:         301; /* @kind other */
+  --z-skip-link:      1000; /* @kind other */
+}

--- a/website/tokens/primitives.css
+++ b/website/tokens/primitives.css
@@ -1,0 +1,305 @@
+/* primitives.css — Shared primitive classes used across the system and by the
+   foundation specimen cards. These mirror the product's shared.css so a card
+   that only links styles.css still renders ELSPETH-correct buttons, badges,
+   inputs, banners and tabs. React components reference the same class names. */
+
+/* ===========================================================================
+   Buttons
+   =========================================================================== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-lg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  min-height: var(--size-control);
+  cursor: pointer;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+  white-space: nowrap;
+}
+.btn:hover:not(:disabled):not([aria-disabled="true"]) {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-strong);
+}
+.btn:disabled,
+.btn[aria-disabled="true"] {
+  background-color: var(--color-bg);
+  color: var(--color-text-muted);
+  border-color: var(--color-border-strong);
+  cursor: not-allowed;
+}
+
+/* Compact variant for chrome-row controls (header, dense toolbars). */
+.btn-compact {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-2xs) var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  min-height: var(--size-control-compact);
+  cursor: pointer;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+  white-space: nowrap;
+}
+.btn-compact:hover:not(:disabled):not([aria-disabled="true"]) {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-strong);
+}
+
+.btn-primary {
+  background-color: var(--color-btn-primary-bg);
+  border-color: var(--color-btn-primary-bg);
+  color: var(--color-text-inverse);
+}
+.btn-primary:hover:not(:disabled) {
+  background-color: var(--color-btn-primary-bg-hover);
+  border-color: var(--color-btn-primary-bg-hover);
+}
+
+.btn-danger {
+  background-color: var(--color-btn-danger-bg);
+  border-color: var(--color-btn-danger-bg);
+  color: var(--color-text-inverse);
+}
+.btn-danger:hover:not(:disabled) {
+  background-color: var(--color-btn-danger-bg-hover);
+  border-color: var(--color-btn-danger-bg-hover);
+}
+
+.btn-ghost {
+  background-color: transparent;
+  border-color: transparent;
+}
+.btn-ghost:hover:not(:disabled) {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border);
+}
+
+.btn-small { font-size: var(--font-size-xs); padding: var(--space-2xs) var(--space-sm); }
+
+/* ===========================================================================
+   Component-type badges (the 6 pipeline primitives)
+   =========================================================================== */
+.type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+.type-badge-source {
+  background-color: var(--color-badge-source-bg);
+  color: var(--color-badge-source);
+  border: 1px solid var(--color-badge-source-border);
+}
+.type-badge-transform {
+  background-color: var(--color-badge-transform-bg);
+  color: var(--color-badge-transform);
+  border: 1px solid var(--color-badge-transform-border);
+}
+.type-badge-gate {
+  background-color: var(--color-badge-gate-bg);
+  color: var(--color-badge-gate);
+  border: 1px solid var(--color-badge-gate-border);
+}
+.type-badge-sink {
+  background-color: var(--color-badge-sink-bg);
+  color: var(--color-badge-sink);
+  border: 1px solid var(--color-badge-sink-border);
+}
+.type-badge-aggregation {
+  background-color: var(--color-badge-aggregation-bg);
+  color: var(--color-badge-aggregation);
+  border: 1px solid var(--color-badge-aggregation-border);
+}
+.type-badge-coalesce {
+  background-color: var(--color-badge-coalesce-bg);
+  color: var(--color-badge-coalesce);
+  border: 1px solid var(--color-badge-coalesce-border);
+}
+
+/* ===========================================================================
+   Status badges (run lifecycle)
+   =========================================================================== */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.status-badge-pending   { background-color: rgba(122, 154, 154, 0.15); color: var(--color-status-pending); }
+.status-badge-running   { background-color: rgba(97, 218, 255, 0.15);  color: var(--color-status-running); }
+.status-badge-completed { background-color: rgba(20, 176, 174, 0.15);  color: var(--color-status-completed); }
+.status-badge-failed    { background-color: rgba(232, 86, 83, 0.15);   color: var(--color-status-failed); }
+.status-badge-cancelled { background-color: rgba(227, 132, 68, 0.15);  color: var(--color-status-cancelled); }
+.status-badge-empty     { background-color: rgba(128, 128, 128, 0.15); color: var(--color-status-empty); }
+
+/* ===========================================================================
+   Inputs
+   =========================================================================== */
+.input,
+.textarea,
+.select {
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: 1.4;
+}
+.input::placeholder,
+.textarea::placeholder { color: var(--color-text-muted); }
+.input:focus-visible,
+.textarea:focus-visible,
+.select:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.textarea { resize: vertical; }
+.input-mono { font-family: var(--font-mono); font-size: var(--font-size-sm); }
+
+.field-label {
+  display: block;
+  margin-bottom: var(--space-xs);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-text);
+}
+.field-hint {
+  margin-top: var(--space-xs);
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-muted);
+}
+
+/* ===========================================================================
+   Cards
+   =========================================================================== */
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+}
+.card-paper {
+  background-color: var(--color-surface-paper);
+  border-color: var(--color-border);
+}
+
+/* ===========================================================================
+   Tabs
+   =========================================================================== */
+.tab-strip {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.tab-strip-tab {
+  padding: var(--space-sm) var(--space-lg);
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+.tab-strip-tab:hover { color: var(--color-text); }
+.tab-strip-tab-active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
+}
+
+/* ===========================================================================
+   Alert / validation banners
+   =========================================================================== */
+.alert-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: 10px 14px;
+  background-color: var(--color-error-bg);
+  color: var(--color-error);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+}
+.alert-banner--info {
+  background-color: var(--color-info-bg);
+  color: var(--color-info);
+  border-color: var(--color-info-border);
+}
+.alert-banner--warning {
+  background-color: var(--color-warning-bg);
+  color: var(--color-warning);
+  border-color: var(--color-warning-border);
+}
+.alert-banner--success {
+  background-color: var(--color-success-bg);
+  color: var(--color-success);
+  border-color: var(--color-success-border);
+}
+
+.validation-banner {
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+}
+.validation-banner-pass {
+  background-color: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  color: var(--color-success);
+}
+.validation-banner-fail {
+  background-color: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error);
+}
+
+/* ===========================================================================
+   Spinner (loading)
+   =========================================================================== */
+@keyframes ds-spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-text-muted);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ds-spin 0.6s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; border-top-color: var(--color-text-muted); opacity: 0.6; }
+}

--- a/website/tokens/typography.css
+++ b/website/tokens/typography.css
@@ -1,0 +1,36 @@
+/* typography.css — Type tokens.
+   Inter for body/UI; JetBrains Mono for the audit/forensic register
+   (wordmark, code, YAML, hashes, type badges). */
+
+:root {
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code",
+    "Source Code Pro", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+
+  /* ── Font sizes ─ a deliberately fine scale tuned for a dense operator UI ── */
+  --font-size-3xs:  10px;   /* tab counts, ribbon micro-text, required badge */
+  --font-size-2xs:  11px;   /* chrome hints, breadcrumbs */
+  --font-size-xs:   12px;
+  --font-size-sm:   13px;
+  --font-size-md:   15px;
+  --font-size-base: 16px;
+  --font-size-lg:   18px;
+  --font-size-xl:   22px;   /* empty-state heroes, loud headings */
+  --font-size-2xl:  32px;   /* display headings */
+
+  /* ── Line heights ────────────────────────────────────────────────────────── */
+  --line-height-tight:   1.3;
+  --line-height-snug:    1.35;   /* chat bubble body */
+  --line-height-normal:  1.5;
+  --line-height-relaxed: 1.7;
+
+  /* ── Weights ─────────────────────────────────────────────────────────────── */
+  --font-weight-regular:  400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+
+  /* ── Brand wordmark tracking — JetBrains Mono, uppercase ─────────────────── */
+  --tracking-wordmark: 0.18em;
+}

--- a/website/use-cases.html
+++ b/website/use-cases.html
@@ -1,0 +1,168 @@
+<!-- @dsCard group="Website" viewport="1280x720" name="Site — Use cases" subtitle="Same framework, different plugins" -->
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Use cases — ELSPETH</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="site.css" />
+<script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="index.html">ELSPETH</a>
+      <nav class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="authoring.html">Authoring</a>
+        <a href="assurance.html">Assurance</a>
+        <a href="use-cases.html" class="active">Use cases</a>
+        <a href="get-started.html">Get started</a>
+      </nav>
+    </div>
+    <div class="nav-right">
+      <button class="iconbtn" id="theme-toggle" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
+      <a class="btn-compact" href="#" style="gap:8px"><i data-lucide="github" style="width:15px;height:15px"></i> GitHub</a>
+      <a class="btn-compact btn-primary" href="get-started.html" style="background:var(--color-btn-primary-bg);border-color:var(--color-btn-primary-bg);color:#fff">Get started</a>
+    </div>
+  </div>
+</header>
+
+<div class="page-head dotgrid">
+  <div class="wrap">
+    <span class="eyebrow">Same framework, different plugins</span>
+    <h1>Built for high-stakes, accountable processing.</h1>
+    <p>Wherever a decision needs to be explainable to an auditor, ELSPETH maps the work onto Sense → Decide → Act and keeps a full audit trail behind it.</p>
+  </div>
+</div>
+
+<section>
+  <div class="wrap">
+    <div class="cases" style="margin-top:8px">
+      <div class="case-row head">
+        <span>Domain</span><span>Sense</span><span>Decide</span><span>Act</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Tender evaluation</span>
+        <span class="c">CSV of submissions</span>
+        <span class="c">LLM classification + safety gates</span>
+        <span class="c">Results CSV, abuse review queue</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Document QA</span>
+        <span class="c">PDF / text blobs</span>
+        <span class="c">Extraction, rubric checks, summaries</span>
+        <span class="c">Annotated outputs, exception queue</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Content moderation</span>
+        <span class="c">User submissions</span>
+        <span class="c">Safety classifier</span>
+        <span class="c">Published, human review, rejected</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Financial compliance</span>
+        <span class="c">Transaction feed</span>
+        <span class="c">Rules engine + ML fraud detection</span>
+        <span class="c">Approved, flagged, blocked</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Weather monitoring</span>
+        <span class="c">Sensor API feed</span>
+        <span class="c">Threshold + ML anomaly detection</span>
+        <span class="c">Routine log, warning, emergency alert</span>
+      </div>
+      <div class="case-row">
+        <span class="dom">Satellite operations</span>
+        <span class="c">Telemetry stream</span>
+        <span class="c">Anomaly classifier</span>
+        <span class="c">Routine log, investigation ticket</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<hr class="divider" />
+
+<section class="dotgrid">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="eyebrow">When to reach for it</span>
+      <h2>A good fit when "why did it do that?" matters.</h2>
+    </div>
+    <div class="props" style="margin-top:36px">
+      <div class="prop">
+        <span class="pi"><i data-lucide="gavel"></i></span>
+        <h3>Explainable to auditors</h3>
+        <p>Decisions with regulatory or compliance requirements, or legal accountability for the outcome.</p>
+      </div>
+      <div class="prop">
+        <span class="pi"><i data-lucide="users"></i></span>
+        <h3>Mixed automated + human review</h3>
+        <p>Workflows that route some rows to people and need an evidentiary record of which went where, and why.</p>
+      </div>
+      <div class="prop">
+        <span class="pi"><i data-lucide="scale"></i></span>
+        <h3>High-stakes processing</h3>
+        <p>Where the wrong output causes operational, legal, safety, financial, or security harm.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<hr class="divider" />
+
+<section>
+  <div class="wrap">
+    <div class="section-head">
+      <span class="eyebrow">Honest about fit</span>
+      <h2>When to reach for something else.</h2>
+      <p>The audit machinery that makes ELSPETH defensible is overhead you don't want for throughput-first work. If you don't need the trail, a leaner tool will serve you better.</p>
+    </div>
+    <div class="cases" style="margin-top:36px">
+      <div class="case-row head" style="grid-template-columns:1fr 1fr 2fr">
+        <span>If you need…</span><span>Consider instead</span><span>Why</span>
+      </div>
+      <div class="case-row" style="grid-template-columns:1fr 1fr 2fr">
+        <span class="dom">High-throughput ETL</span>
+        <span class="c"><code>Spark</code> · <code>dbt</code></span>
+        <span class="c">Bulk transformation at scale, where per-row lineage and audit evidence aren't the point.</span>
+      </div>
+      <div class="case-row" style="grid-template-columns:1fr 1fr 2fr">
+        <span class="dom">Sub-second streaming</span>
+        <span class="c"><code>Flink</code> · <code>Kafka Streams</code></span>
+        <span class="c">Low-latency event processing. ELSPETH's orchestrator is deterministic and single-writer by design.</span>
+      </div>
+      <div class="case-row" style="grid-template-columns:1fr 1fr 2fr">
+        <span class="dom">Simple scripts, no audit</span>
+        <span class="c">Plain Python</span>
+        <span class="c">One-off or low-stakes work where a reviewable trail would be ceremony, not value.</span>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px;font-size:14px;max-width:60ch">ELSPETH trades raw throughput for evidence. That's the right trade only when "why did it do that?" has to have an answer.</p>
+    <div class="cta-row" style="margin-top:32px">
+      <a class="btn btn-primary" href="get-started.html">Start a pipeline</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand">ELSPETH</span>
+    <div class="links">
+      <a href="index.html">Home</a>
+      <a href="authoring.html">Authoring</a>
+      <a href="assurance.html">Assurance</a>
+      <a href="get-started.html">Get started</a>
+      <a href="#">GitHub</a>
+    </div>
+    <span class="copy">MIT licensed · Built for decisions that must be defensible.</span>
+  </div>
+</footer>
+
+<script src="site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

Publishes the standalone ELSPETH marketing website (`website/`) to `main` so it can be served via GitHub Pages.

- 5 static pages: index (Home), authoring, assurance, use-cases, get-started
- Vendored design tokens (`website/tokens/`) — a static mirror of the frontend's canonical `src/elspeth/web/frontend/src/styles/tokens.css`
- No build step; Lucide icons load from the unpkg CDN
- All asset / inter-page links are **relative** (Pages-subpath safe)

Extracted verbatim from `release/0.7.0` (where it landed in the design-system merge `d56197fde`). **Web pages only — no backend, composer, or CI code.**

## Why to main

This lands the site on `main` as a standalone, reviewable unit decoupled from the rest of the 0.7.0 release, so the public site can go onto GitHub Pages independently.

## Out of scope (follow-up, continues on `release/0.7.0`)

- The Pages deploy mechanism (workflow / repo settings).
- Hosting the tutorial's synthetic `web_scrape` pages here (`website/tutorial-site/project-N.html`) and pointing `WebSettings.tutorial_sample_base_url` at the public Pages URL — the fix for the tutorial's loopback-origin SSRF-allowlist collision (the tutorial composes but won't execute on a localhost-served dev box because the server-injected loopback CIDR allowlist is rejected by the execution preflight that correctly blocks user-authored private allowlists). Hosting the pages publicly makes `resolve_tutorial_allowed_hosts` return `public_only` for every origin, dissolving the collision without touching the SSRF boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)