### PR TITLE
feat(website): add tutorial synthetic-scrape demo pages for GitHub Pages

### DIFF
--- a/website/tutorial-site/README.md
+++ b/website/tutorial-site/README.md
@@ -1,0 +1,14 @@
+# Tutorial synthetic scrape pages
+
+Three self-contained synthetic "government project brief" pages used by the
+first-run guided tutorial's `web_scrape` demo: the tutorial fetches them at
+`{base}/tutorial-site/project-N.html` and has an LLM write a short summary of
+each.
+
+These **mirror** the application copies in
+`src/elspeth/web/frontend/public/tutorial-site/` (which the deployed app serves
+at its own origin). They are published here on the public GitHub Pages site so
+the tutorial can also run end-to-end from a loopback dev origin — set
+`ELSPETH_WEB__TUTORIAL_SAMPLE_BASE_URL=https://johnm-dta.github.io/elspeth`
+(see the top-level README, "Web Composer" notes). Re-copy here if the app copies
+change.

--- a/website/tutorial-site/project-1.html
+++ b/website/tutorial-site/project-1.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Helios — Brief (SYNTHETIC)</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; color: #1a1a2e; }
+      .banner { background: #c0392b; color: #fff; text-align: center; padding: 8px; font-weight: 700; }
+      .hero { background: linear-gradient(120deg, #1a1a2e, #16213e); color: #fff; padding: 48px 32px; }
+      .hero h1 { margin: 0; font-size: 2.4rem; }
+      main { max-width: 880px; margin: 0 auto; padding: 24px 32px; }
+      table { border-collapse: collapse; width: 100%; margin: 16px 0 32px; }
+      th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; }
+      th { background: #16213e; color: #fff; }
+      caption { text-align: left; font-weight: 700; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <div class="banner">SYNTHETIC TEST DATA ONLY — DO NOT USE</div>
+    <header class="hero"><h1>Project Helios</h1><p>Public-records digitisation programme — project brief.</p></header>
+    <main>
+      <table>
+        <caption>Risk register</caption>
+        <tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr>
+        <tr><td>Legacy data corruption on ingest</td><td>Medium</td><td>High</td><td>Checksum every record against the source register</td></tr>
+        <tr><td>Vendor scanning delays</td><td>Low</td><td>Medium</td><td>Dual-source the scanning contract</td></tr>
+        <tr><td>Access-control misconfiguration</td><td>Low</td><td>Low</td><td>Quarterly IRAP-aligned review</td></tr>
+      </table>
+      <table>
+        <caption>Schedule</caption>
+        <tr><th>Milestone</th><th>Date</th><th>Status</th></tr>
+        <tr><td>Discovery complete</td><td>2026-02-15</td><td>Done</td></tr>
+        <tr><td>Pilot ingest</td><td>2026-05-30</td><td>In progress</td></tr>
+        <tr><td>Go-live</td><td>2026-09-30</td><td>Planned</td></tr>
+      </table>
+      <table>
+        <caption>Cost breakdown</caption>
+        <tr><th>Line item</th><th>Cost</th></tr>
+        <tr><td>Scanning &amp; OCR</td><td>$120,000</td></tr>
+        <tr><td>Platform engineering</td><td>$80,000</td></tr>
+        <tr><td>Assurance &amp; review</td><td>$25,000</td></tr>
+      </table>
+    </main>
+  </body>
+</html>

--- a/website/tutorial-site/project-2.html
+++ b/website/tutorial-site/project-2.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Borealis — Brief (SYNTHETIC)</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; color: #1a1a2e; }
+      .banner { background: #c0392b; color: #fff; text-align: center; padding: 8px; font-weight: 700; }
+      .hero { background: linear-gradient(120deg, #1a1a2e, #16213e); color: #fff; padding: 48px 32px; }
+      .hero h1 { margin: 0; font-size: 2.4rem; }
+      main { max-width: 880px; margin: 0 auto; padding: 24px 32px; }
+      table { border-collapse: collapse; width: 100%; margin: 16px 0 32px; }
+      th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; }
+      th { background: #16213e; color: #fff; }
+      caption { text-align: left; font-weight: 700; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <div class="banner">SYNTHETIC TEST DATA ONLY — DO NOT USE</div>
+    <header class="hero"><h1>Project Borealis</h1><p>Grants-administration modernisation — project brief.</p></header>
+    <main>
+      <table>
+        <caption>Risk register</caption>
+        <tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr>
+        <tr><td>Grant-rule misinterpretation</td><td>High</td><td>High</td><td>Codify rules with policy sign-off before build</td></tr>
+        <tr><td>Identity-provider outage</td><td>Medium</td><td>Medium</td><td>Cache assertions with a short grace window</td></tr>
+        <tr><td>Reporting lag</td><td>Low</td><td>Low</td><td>Nightly incremental aggregation</td></tr>
+      </table>
+      <table>
+        <caption>Schedule</caption>
+        <tr><th>Milestone</th><th>Date</th><th>Status</th></tr>
+        <tr><td>Rules workshop</td><td>2026-03-10</td><td>Done</td></tr>
+        <tr><td>Beta release</td><td>2026-06-20</td><td>In progress</td></tr>
+        <tr><td>Go-live</td><td>2026-11-15</td><td>Planned</td></tr>
+      </table>
+      <table>
+        <caption>Cost breakdown</caption>
+        <tr><th>Line item</th><th>Cost</th></tr>
+        <tr><td>Rules engine</td><td>$200,000</td></tr>
+        <tr><td>Identity integration</td><td>$60,000</td></tr>
+        <tr><td>Reporting</td><td>$40,000</td></tr>
+      </table>
+    </main>
+  </body>
+</html>

--- a/website/tutorial-site/project-3.html
+++ b/website/tutorial-site/project-3.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Meridian — Brief (SYNTHETIC)</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; color: #1a1a2e; }
+      .banner { background: #c0392b; color: #fff; text-align: center; padding: 8px; font-weight: 700; }
+      .hero { background: linear-gradient(120deg, #1a1a2e, #16213e); color: #fff; padding: 48px 32px; }
+      .hero h1 { margin: 0; font-size: 2.4rem; }
+      main { max-width: 880px; margin: 0 auto; padding: 24px 32px; }
+      table { border-collapse: collapse; width: 100%; margin: 16px 0 32px; }
+      th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; }
+      th { background: #16213e; color: #fff; }
+      caption { text-align: left; font-weight: 700; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <div class="banner">SYNTHETIC TEST DATA ONLY — DO NOT USE</div>
+    <header class="hero"><h1>Project Meridian</h1><p>Service-status telemetry platform — project brief.</p></header>
+    <main>
+      <table>
+        <caption>Risk register</caption>
+        <tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr>
+        <tr><td>Telemetry volume overrun</td><td>Medium</td><td>High</td><td>Tiered sampling with a hard storage ceiling</td></tr>
+        <tr><td>Dashboard adoption shortfall</td><td>Medium</td><td>Medium</td><td>Embed dashboards in existing ops tooling</td></tr>
+        <tr><td>Alert fatigue</td><td>Low</td><td>Low</td><td>Tune thresholds against a four-week baseline</td></tr>
+      </table>
+      <table>
+        <caption>Schedule</caption>
+        <tr><th>Milestone</th><th>Date</th><th>Status</th></tr>
+        <tr><td>Instrumentation</td><td>2026-01-20</td><td>Done</td></tr>
+        <tr><td>Pilot dashboards</td><td>2026-04-25</td><td>In progress</td></tr>
+        <tr><td>Go-live</td><td>2026-08-12</td><td>Planned</td></tr>
+      </table>
+      <table>
+        <caption>Cost breakdown</caption>
+        <tr><th>Line item</th><th>Cost</th></tr>
+        <tr><td>Ingestion pipeline</td><td>$90,000</td></tr>
+        <tr><td>Dashboarding</td><td>$55,000</td></tr>
+        <tr><td>On-call &amp; SRE</td><td>$30,000</td></tr>
+      </table>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds the three synthetic "government project brief" pages the first-run guided tutorial scrapes, under `website/tutorial-site/`:

- `project-1.html` — Project Borealis
- `project-2.html` — Project Helios
- `project-3.html` — Project Meridian
- `README.md` — provenance / mirror note

They are **byte-identical** to the canonical app copies in `src/elspeth/web/frontend/public/tutorial-site/`.

## Why

The tutorial fetches `{base}/tutorial-site/project-N.html`. On a public deployment `{base}` is the deployment's own origin (works). On a **loopback dev origin** the server-injected private allowlist is (correctly) rejected by the execution preflight, so the tutorial composes but won't run. Hosting the pages on the project's public GitHub Pages site lets a dev box point `ELSPETH_WEB__TUTORIAL_SAMPLE_BASE_URL=https://johnm-dta.github.io/elspeth` and scrape a **public** origin → `resolve_tutorial_allowed_hosts` returns `public_only`, no SSRF-boundary change.

The pages are already live on the `gh-pages` snapshot; this PR makes them **canonical in `main:website/`** (the source of truth the Pages site is built from), closing the source-of-truth gap so the marketing site + demo pages stay in one reviewed place.

**Web pages only — no backend/composer/CI code.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)