### PR TITLE
ci(pages): auto-deploy website/ to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,51 @@
+name: Deploy website to GitHub Pages
+
+# Publishes the static `website/` tree to GitHub Pages on every push to main
+# that touches it. Replaces the hand-maintained `gh-pages` branch: the first
+# run flips the Pages source from "deploy from branch" to "GitHub Actions" via
+# configure-pages `enablement`, then serves the `website/` directory at the
+# site root (so /tutorial-site/project-N.html resolves as before).
+#
+# Runs on a GitHub-hosted runner on purpose: a public static-site deploy needs
+# no repository secrets, so it stays off the trusted self-hosted pool.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/pages.yaml'
+  workflow_dispatch:
+
+# Least privilege: read the tree, mint the Pages OIDC token, write the deploy.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never run two Pages deploys at once; let an in-flight deploy finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy website/ to Pages
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v4
+      - name: Configure Pages (enable + select GitHub Actions source)
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+        with:
+          enablement: true
+      - name: Upload website/ as the Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: website
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4


### PR DESCRIPTION
## What

Replaces the hand-maintained `gh-pages` branch with a GitHub Actions Pages deploy. On push to `main` touching `website/` (or this workflow), it uploads the `website/` tree as the Pages artifact and deploys it — serving `website/` at the site root, so `…/tutorial-site/project-N.html` resolves exactly as today.

## Why

Pages is currently `build_type: legacy` (deploy from a `gh-pages` branch) with **no workflow** — the `gh-pages` branch is published by hand, so the live public site silently drifts from `main:website/` until someone remembers to republish. This automates it.

## Cutover (zero manual steps)

`actions/configure-pages` runs with `enablement: true`, which flips the Pages source **legacy → GitHub Actions** on the first run. So **merging this PR is the whole cutover** — the first post-merge run (this workflow's own path is in the `paths` filter) deploys the current `website/` via Actions and retires the `gh-pages` flow. No live-state change happens until merge; the site keeps serving its last build throughout.

**Fallback** (only if the auto-flip doesn't take): `gh api -X PUT repos/johnm-dta/elspeth/pages -f build_type=workflow` then re-run the workflow.

## Choices

- **`runs-on: ubuntu-24.04`** (GitHub-hosted): a public static deploy needs no repo secrets, so it deliberately stays **off** the trusted self-hosted pool (cf. the open runner-isolation P1).
- **Actions SHA-pinned** to match the repo's supply-chain convention (dependabot's `github-actions` group will bump them).
- **Least-privilege permissions** (`contents: read`, `pages: write`, `id-token: write`) + `concurrency: pages`.

After merge, the `gh-pages` branch becomes inert and can be deleted at your discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)