### PR TITLE
fix(sinks): avoid inheriting undeclared diverted outputs

### DIFF
--- a/src/elspeth/plugins/sinks/_local_file_effects.py
+++ b/src/elspeth/plugins/sinks/_local_file_effects.py
@@ -489,7 +489,7 @@ def prepare_local_effect(
     descriptor_size = staged.size_bytes
     if input_kind is SinkEffectInputKind.PIPELINE_MEMBERS and not accepted:
         descriptor_mode = SinkEffectDescriptorMode.NO_PUBLICATION
-        if predecessor.exists:
+        if predecessor.exists and predecessor_declared:
             if predecessor.content_hash is None or predecessor.size_bytes is None:
                 _remove_exact_staging(staging, staged)
                 raise LocalFilePreconditionError("existing no-publication predecessor has incomplete descriptor evidence")

--- a/tests/unit/plugins/sinks/test_local_file_sink_effects.py
+++ b/tests/unit/plugins/sinks/test_local_file_sink_effects.py
@@ -596,6 +596,38 @@ def test_no_publication_uses_exact_virtual_and_inherited_descriptors(tmp_path: P
     assert not _stage_path(inherited).exists()
 
 
+def test_no_publication_does_not_inherit_undeclared_existing_target(tmp_path: Path) -> None:
+    target = tmp_path / "shared-output.txt"
+    target.write_bytes(b"another run's bytes\n")
+    inspection = local_effects.inspect_local_effect(
+        target_path=target,
+        request=SinkEffectInspectionRequest(effect_id="a3" * 32, target="{}", predecessor_descriptor=None),
+    )
+
+    plan = local_effects.prepare_local_effect(
+        effect_id="a3" * 32,
+        input_kind=SinkEffectInputKind.PIPELINE_MEMBERS,
+        inspection=inspection,
+        chunks=(),
+        row_count=1,
+        accepted_ordinals=(),
+        diverted_ordinals=(0,),
+        encoding="utf-8",
+        format_name="text",
+        stream_sequence=0,
+    )
+
+    assert plan.descriptor_mode is SinkEffectDescriptorMode.NO_PUBLICATION
+    assert plan.safe_evidence["predecessor_exists"] is True
+    assert plan.safe_evidence["predecessor_declared"] is False
+    assert plan.safe_evidence["publication_kind"] == "virtual"
+    assert plan.expected_descriptor is not None
+    assert plan.expected_descriptor.content_hash == sha256(b"").hexdigest()
+    assert plan.expected_descriptor.size_bytes == 0
+    assert target.read_bytes() == b"another run's bytes\n"
+    assert not _stage_path(plan).exists()
+
+
 def test_effect_streaming_preserves_stateful_text_encodings(tmp_path: Path) -> None:
     csv_target = tmp_path / "utf16.csv"
     csv_sink = CSVSink({"path": str(csv_target), "schema": _SCHEMA, "encoding": "utf-16"})


### PR DESCRIPTION
### Motivation
- Prevent all-diverted local-file sink effects from claiming pre-existing files as inherited artifacts when no predecessor was declared, which allowed an attacker to import another user's bytes into their own run's artifact record.
- Require that a predecessor be explicitly declared/durable before treating an existing target as an `inherited` no-publication descriptor.

### Description
- Tighten the all-diverted branch in `prepare_local_effect` so it only treats an existing predecessor as `inherited` when `predecessor_declared` is true by changing the condition to `if predecessor.exists and predecessor_declared` in `src/elspeth/plugins/sinks/_local_file_effects.py`.
- Add a regression test `test_no_publication_does_not_inherit_undeclared_existing_target` to `tests/unit/plugins/sinks/test_local_file_sink_effects.py` that verifies an undeclared, pre-existing target yields a `virtual` no-publication descriptor and does not stage or claim the file.

### Testing
- Ran `ruff check src/elspeth/plugins/sinks/_local_file_effects.py tests/unit/plugins/sinks/test_local_file_sink_effects.py`, which passed without findings.
- Ran `python -m py_compile src/elspeth/plugins/sinks/_local_file_effects.py tests/unit/plugins/sinks/test_local_file_sink_effects.py`, which succeeded with no syntax errors.
- Attempted `pytest tests/unit/plugins/sinks/test_local_file_sink_effects.py -q`, but it was blocked by a missing `hypothesis` dev dependency in the execution environment and an attempted `pip install hypothesis` failed due to the package index returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61699d366883238cfb8bf546045e2e)