### PR TITLE
fix(chroma): revalidate HTTP targets before runtime connection

### DIFF
--- a/src/elspeth/plugins/sinks/chroma_sink.py
+++ b/src/elspeth/plugins/sinks/chroma_sink.py
@@ -51,6 +51,7 @@ from elspeth.core.canonical import canonical_json
 from elspeth.plugins.infrastructure.base import BaseSink
 from elspeth.plugins.infrastructure.clients.retrieval.connection import (
     ChromaConnectionConfig,
+    _validate_chroma_http_target,
 )
 from elspeth.plugins.infrastructure.config_base import DataPluginConfig
 from elspeth.plugins.infrastructure.schema_factory import create_schema_from_config
@@ -271,6 +272,7 @@ class ChromaSink(BaseSink):
                 raise FrameworkBugError(
                     "ChromaSinkConfig.host is None in 'client' mode — ChromaConnectionConfig validation should have rejected this"
                 )
+            _validate_chroma_http_target(self._config.host, self._config.port, ssl=self._config.ssl)
             self._client = chromadb.HttpClient(
                 host=self._config.host,
                 port=self._config.port,

--- a/tests/unit/plugins/sinks/test_chroma_sink.py
+++ b/tests/unit/plugins/sinks/test_chroma_sink.py
@@ -182,6 +182,35 @@ class TestChromaSinkOnStart:
             with pytest.raises(RuntimeError, match="Connection refused"):
                 sink.on_start(ctx)
 
+    def test_client_on_start_revalidates_ssrf_target_after_preflight_construction(self) -> None:
+        from elspeth.plugins.infrastructure.preflight import plugin_preflight_mode
+
+        config = {
+            "collection": "test-collection",
+            "mode": "client",
+            "host": "169.254.169.254",
+            "port": 8000,
+            "ssl": True,
+            "field_mapping": {
+                "document_field": "text",
+                "id_field": "doc_id",
+                "metadata_fields": [],
+            },
+            "schema": {
+                "mode": "fixed",
+                "fields": ["doc_id: str", "text: str"],
+            },
+        }
+        with plugin_preflight_mode(True):
+            sink = inject_write_failure(ChromaSink(config))
+        ctx = _make_lifecycle_ctx()
+
+        with patch("elspeth.plugins.sinks.chroma_sink.chromadb") as mock_chromadb:
+            with pytest.raises(ValueError, match=r"(?i)ssrf"):
+                sink.on_start(ctx)
+
+            mock_chromadb.HttpClient.assert_not_called()
+
 
 class TestChromaSinkFlush:
     def test_flush_is_noop(self) -> None:


### PR DESCRIPTION
### Motivation
- The web execution path instantiated plugins under `preflight_mode=True`, which deferred SSRF/DNS validation during plugin construction and allowed a `chroma_sink` built in preflight to open real HTTP connections in `on_start()` without re-running the SSRF checks.
- This change prevents an authenticated operator policy from being able to bypass the SSRF block by relying on preflight-only validation.

### Description
- Import and call the shared `_validate_chroma_http_target` validator in `ChromaSink.on_start()` immediately before creating `chromadb.HttpClient(...)` to enforce the SSRF policy at real runtime.
- Add a unit test `test_client_on_start_revalidates_ssrf_target_after_preflight_construction` that constructs a `ChromaSink` under `plugin_preflight_mode(True)` and asserts that an internal/metadata IP is rejected during `on_start()` and that `HttpClient` is not called.
- Keep existing behavior for `mode=='persistent'` and only apply the revalidation for `client` mode before network client construction.

### Testing
- Ran formatter and static checks: `uv run ruff format ...` and `uv run ruff check ...`, both completed successfully.
- Attempted to run the targeted unit tests with `pytest` but execution was blocked by a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`), so the new regression test was not executed end-to-end in this environment.
- Attempted environment sync (`uv sync --extra dev`) but it failed due to a network/tunnel error fetching dependencies, preventing a full test run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6153c77d308323918357ba8b4c6eef)