### PR TITLE
web: block aws_s3 sources from web-authored pipelines

### DIFF
--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -126,6 +126,7 @@ from elspeth.web.plugin_policy.profiles import OperatorProfileRegistry
 from elspeth.web.plugin_policy.validation import PolicyValidationStage, validate_plugin_policy
 from elspeth.web.provider_config_policy import (
     web_aws_s3_endpoint_url_policy_error,
+    web_aws_s3_source_policy_error,
     web_llm_base_url_policy_error,
     web_llm_retry_budget_policy_error,
     web_llm_tracing_policy_error,
@@ -1778,15 +1779,21 @@ def validate_pipeline(
     )
 
     for source_name, source in state.sources.items():
+        source_policy_error = web_aws_s3_source_policy_error(source.plugin)
         endpoint_policy_error = web_aws_s3_endpoint_url_policy_error(source.plugin, source.options)
-        if endpoint_policy_error is None:
+        policy_error = source_policy_error or endpoint_policy_error
+        if policy_error is None:
             continue
         source_component = "source" if source_name == "source" else f"source:{source_name}"
         checks.append(
             ValidationCheck(
                 name=_CHECK_AWS_S3_ENDPOINT_URL_POLICY,
                 passed=False,
-                detail=f"Source '{source_name}' sets aws_s3 endpoint_url in a web-authored pipeline",
+                detail=(
+                    f"Source '{source_name}' uses aws_s3 in a web-authored pipeline"
+                    if source_policy_error is not None
+                    else f"Source '{source_name}' sets aws_s3 endpoint_url in a web-authored pipeline"
+                ),
                 affected_nodes=(source_component,),
                 outcome_code=None,
             )
@@ -1799,14 +1806,26 @@ def validate_pipeline(
                 ValidationError(
                     component_id=source_component,
                     component_type="source",
-                    message=endpoint_policy_error,
-                    suggestion="Remove endpoint_url and use operator-controlled AWS configuration.",
-                    error_code="aws_s3_endpoint_url_not_allowed",
+                    message=policy_error,
+                    suggestion=(
+                        "Use an operator-controlled connector, allowlisted ingestion job, or batch/CLI runtime for S3 reads."
+                        if source_policy_error is not None
+                        else "Remove endpoint_url and use operator-controlled AWS configuration."
+                    ),
+                    error_code=(
+                        "aws_s3_source_not_allowed"
+                        if source_policy_error is not None
+                        else "aws_s3_endpoint_url_not_allowed"
+                    ),
                 )
             ],
             readiness=_blocked_readiness(
                 code=_CHECK_AWS_S3_ENDPOINT_URL_POLICY,
-                detail=f"source {source_component} sets aws_s3 endpoint_url in a web-authored pipeline",
+                detail=(
+                    f"source {source_component} uses aws_s3 in a web-authored pipeline"
+                    if source_policy_error is not None
+                    else f"source {source_component} sets aws_s3 endpoint_url in a web-authored pipeline"
+                ),
                 component_id=source_component,
                 component_type="source",
             ),

--- a/src/elspeth/web/provider_config_policy.py
+++ b/src/elspeth/web/provider_config_policy.py
@@ -40,6 +40,11 @@ LLM_RETRY_BUDGET_POLICY_ERROR: Final[str] = (
     "The LLM transform default is one hour, which can monopolize the web execution worker. "
     "Set max_capacity_retry_seconds to a small positive value or use pool_size > 1 for pooled retry handling."
 )
+AWS_S3_SOURCE_POLICY_ERROR: Final[str] = (
+    "Web-authored aws_s3 sources are disabled because they read with the server AWS "
+    "credential chain while bucket and key are author-controlled. Use an operator-controlled "
+    "connector, allowlisted ingestion job, or batch/CLI runtime for S3 reads."
+)
 AWS_S3_ENDPOINT_URL_POLICY_ERROR: Final[str] = (
     "Web-authored aws_s3 source and sink options may not set endpoint_url. "
     "Custom storage endpoints can redirect server-side requests to an author-chosen "
@@ -49,6 +54,24 @@ AWS_S3_ENDPOINT_URL_POLICY_ERROR: Final[str] = (
 _FALSE_LITERALS: Final[frozenset[str]] = frozenset({"", "0", "false", "f", "no", "n", "off"})
 _TRUE_LITERALS: Final[frozenset[str]] = frozenset({"1", "true", "t", "yes", "y", "on"})
 _INT_ADAPTER: Final[TypeAdapter[int]] = TypeAdapter(int)
+
+
+@trust_boundary(
+    tier=3,
+    source="web-authored aws_s3 source plugin (untrusted author-supplied selection)",
+    source_param="plugin",
+    suppresses=("R1", "R5"),
+    invariant=(
+        "non-aws_s3 source plugins are ignored; every aws_s3 source returns the static "
+        "policy error because S3 reads would use server credentials with author-chosen keys; never raises"
+    ),
+    non_raising=True,
+)
+def web_aws_s3_source_policy_error(plugin: str | None) -> str | None:
+    """Reject web-authored AWS S3 sources that would read with server AWS credentials."""
+    if plugin != "aws_s3":
+        return None
+    return AWS_S3_SOURCE_POLICY_ERROR
 
 
 @trust_boundary(

--- a/tests/unit/web/execution/test_validation.py
+++ b/tests/unit/web/execution/test_validation.py
@@ -60,7 +60,7 @@ from elspeth.web.plugin_policy.models import (
 )
 from elspeth.web.plugin_policy.profiles import OperatorProfileRegistry, RuntimeWebPluginConfig
 from elspeth.web.plugin_policy.validation import validate_plugin_policy
-from elspeth.web.provider_config_policy import AWS_S3_ENDPOINT_URL_POLICY_ERROR
+from elspeth.web.provider_config_policy import AWS_S3_ENDPOINT_URL_POLICY_ERROR, AWS_S3_SOURCE_POLICY_ERROR
 
 
 def _make_source(options: dict[str, Any] | None = None, plugin: str = "csv") -> SourceSpec:
@@ -1246,17 +1246,43 @@ class TestValidatePipelineAwsS3EndpointUrlPolicy:
         mock_load.assert_not_called()
         mock_instantiate.assert_not_called()
 
-    @pytest.mark.parametrize("component", ["source", "sink"])
     @pytest.mark.parametrize("endpoint_options", [{}, {"endpoint_url": None}])
-    def test_aws_s3_omitted_or_null_endpoint_url_passes_policy(
+    def test_aws_s3_source_is_blocked_even_without_endpoint_url(
         self,
-        component: str,
         endpoint_options: dict[str, object],
     ) -> None:
-        source_plugin = "aws_s3" if component == "source" else "csv"
-        source_options = endpoint_options if component == "source" else {}
-        output_plugin = "aws_s3" if component == "sink" else "csv"
-        output_options = endpoint_options if component == "sink" else {}
+        state = _make_state(
+            source_plugin="aws_s3",
+            source_options=endpoint_options,
+            outputs=(_make_output(name="results"),),
+        )
+        settings = _make_settings()
+        mock_yaml_gen = MagicMock(spec=YamlGenerator)
+        mock_yaml_gen.generate_yaml.return_value = "sources: {}\nsinks: {}\n"
+
+        with (
+            patch("elspeth.web.execution.validation.load_settings_from_yaml_string") as mock_load,
+            patch("elspeth.web.execution.validation.instantiate_runtime_plugins") as mock_instantiate,
+        ):
+            result = validate_pipeline_for_trained_operator(state, settings, mock_yaml_gen)
+
+        assert result.is_valid is False
+        assert _check(result, "aws_s3_endpoint_url_policy").passed is False
+        assert result.errors[0].message == AWS_S3_SOURCE_POLICY_ERROR
+        assert result.errors[0].error_code == "aws_s3_source_not_allowed"
+        assert result.errors[0].component_id == "source"
+        mock_load.assert_not_called()
+        mock_instantiate.assert_not_called()
+
+    @pytest.mark.parametrize("endpoint_options", [{}, {"endpoint_url": None}])
+    def test_aws_s3_sink_omitted_or_null_endpoint_url_passes_policy(
+        self,
+        endpoint_options: dict[str, object],
+    ) -> None:
+        source_plugin = "csv"
+        source_options = {}
+        output_plugin = "aws_s3"
+        output_options = endpoint_options
         state = _make_state(
             source_plugin=source_plugin,
             source_options=source_options,

--- a/tests/unit/web/test_provider_config_policy.py
+++ b/tests/unit/web/test_provider_config_policy.py
@@ -10,10 +10,25 @@ import pytest
 
 from elspeth.web.provider_config_policy import (
     AWS_S3_ENDPOINT_URL_POLICY_ERROR,
+    AWS_S3_SOURCE_POLICY_ERROR,
     LLM_TRACING_POLICY_ERROR,
     web_aws_s3_endpoint_url_policy_error,
+    web_aws_s3_source_policy_error,
     web_llm_tracing_policy_error,
 )
+
+
+class TestWebAwsS3SourcePolicy:
+    @pytest.mark.parametrize("plugin", ["csv", None, "json"])
+    def test_allows_non_aws_s3_sources(self, plugin: str | None) -> None:
+        assert web_aws_s3_source_policy_error(plugin) is None
+
+    def test_rejects_aws_s3_source_without_echoing_bucket_or_key(self) -> None:
+        error = web_aws_s3_source_policy_error("aws_s3")
+
+        assert error == AWS_S3_SOURCE_POLICY_ERROR
+        assert "prod-confidential-bucket" not in error
+        assert "payroll/ssn.csv" not in error
 
 
 class TestWebAwsS3EndpointUrlPolicy:


### PR DESCRIPTION
### Motivation
- Prevent a confused-deputy/data-exfiltration risk where a web author can specify arbitrary S3 `bucket`/`key` while the server uses its ambient AWS credentials to read protected objects. 

### Description
- Add a static web policy string `AWS_S3_SOURCE_POLICY_ERROR` and a helper `web_aws_s3_source_policy_error(plugin)` in `src/elspeth/web/provider_config_policy.py` that rejects web-authored `aws_s3` sources. 
- Invoke the new `web_aws_s3_source_policy_error` from the web execution validation path in `src/elspeth/web/execution/validation.py` and treat it as a blocking policy before settings loading or runtime plugin instantiation, returning a `aws_s3_source_not_allowed` error code and operator-directed suggestion. 
- Preserve the existing `endpoint_url` restriction and its behavior for sinks and for the specific endpoint override policy. 
- Add unit coverage: `tests/unit/web/test_provider_config_policy.py` gains `TestWebAwsS3SourcePolicy` and `tests/unit/web/execution/test_validation.py` adds a test asserting web `aws_s3` sources are blocked even when `endpoint_url` is omitted or null. 

### Testing
- Ran Python byte-compile on modified modules with `python -m py_compile src/elspeth/web/provider_config_policy.py src/elspeth/web/execution/validation.py tests/unit/web/test_provider_config_policy.py tests/unit/web/execution/test_validation.py`, which succeeded. 
- Attempted unit test run with `pytest tests/unit/web/test_provider_config_policy.py tests/unit/web/execution/test_validation.py -q`, which was blocked by a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`). 
- Attempted to sync dev extras with `uv sync --extra dev` to install test deps, which failed due to a network/proxy tunnel error while fetching a binary wheel (`psycopg2-binary`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a614fcc7eec832394d301cfe58fbaee)