### PR TITLE
fix: cap web blob_fetch timeout and body size for web-authored pipelines

### DIFF
--- a/src/elspeth/web/execution/validation.py
+++ b/src/elspeth/web/execution/validation.py
@@ -140,6 +140,8 @@ _CHECK_SCHEMA = RUNTIME_CHECK_SCHEMA_COMPATIBILITY
 assert RUNTIME_GRAPH_VALIDATION_CHECKS == (_CHECK_PLUGINS, _CHECK_GRAPH, _CHECK_SCHEMA)
 
 _WEB_FETCH_TRANSFORMS = frozenset({"blob_fetch", "web_scrape"})
+_WEB_BLOB_FETCH_MAX_TIMEOUT_SECONDS = 30
+_WEB_BLOB_FETCH_MAX_BODY_BYTES = 10 * 1024 * 1024
 
 
 def _execution_ready() -> ValidationReadiness:
@@ -1025,33 +1027,65 @@ def validate_pipeline(
         http_options = node.options["http"] if "http" in node.options else None
         if not isinstance(http_options, Mapping):
             continue
-        if "allowed_hosts" not in http_options:
+        if "allowed_hosts" in http_options:
+            allowed_hosts = http_options["allowed_hosts"]
+            if allowed_hosts == "allow_private":
+                message = (
+                    f"{node.plugin}.http.allowed_hosts='allow_private' is not permitted in web execution. "
+                    "Web-authored pipelines may only use public SSRF policy; private-network fetching requires "
+                    "an operator-owned runtime outside the web composer."
+                )
+            elif isinstance(allowed_hosts, Sequence) and not isinstance(allowed_hosts, str):
+                message = (
+                    f"{node.plugin}.http.allowed_hosts CIDR allowlists are not permitted in web execution. "
+                    "Web-authored pipelines may only use allowed_hosts='public_only'; private-network fetching "
+                    "requires an operator-owned runtime outside the web composer."
+                )
+            else:
+                message = None
+            if message is not None:
+                error_code = (
+                    "web_scrape_private_network_not_allowed" if node.plugin == "web_scrape" else "web_fetch_private_network_not_allowed"
+                )
+                web_fetch_network_errors.append(
+                    ValidationError(
+                        component_id=node.id,
+                        component_type="transform",
+                        message=message,
+                        suggestion=f"Set {node.plugin}.http.allowed_hosts to 'public_only' or remove the option.",
+                        error_code=error_code,
+                    )
+                )
+        if node.plugin != "blob_fetch":
             continue
-        allowed_hosts = http_options["allowed_hosts"]
-        if allowed_hosts == "allow_private":
-            message = (
-                f"{node.plugin}.http.allowed_hosts='allow_private' is not permitted in web execution. "
-                "Web-authored pipelines may only use public SSRF policy; private-network fetching requires "
-                "an operator-owned runtime outside the web composer."
+        timeout = http_options.get("timeout")
+        if isinstance(timeout, int) and not isinstance(timeout, bool) and timeout > _WEB_BLOB_FETCH_MAX_TIMEOUT_SECONDS:
+            web_fetch_network_errors.append(
+                ValidationError(
+                    component_id=node.id,
+                    component_type="transform",
+                    message=(
+                        f"blob_fetch.http.timeout={timeout} exceeds the web execution limit of "
+                        f"{_WEB_BLOB_FETCH_MAX_TIMEOUT_SECONDS} seconds."
+                    ),
+                    suggestion=f"Set blob_fetch.http.timeout to {_WEB_BLOB_FETCH_MAX_TIMEOUT_SECONDS} or less.",
+                    error_code="web_fetch_resource_limit_exceeded",
+                )
             )
-        elif isinstance(allowed_hosts, Sequence) and not isinstance(allowed_hosts, str):
-            message = (
-                f"{node.plugin}.http.allowed_hosts CIDR allowlists are not permitted in web execution. "
-                "Web-authored pipelines may only use allowed_hosts='public_only'; private-network fetching "
-                "requires an operator-owned runtime outside the web composer."
+        max_body_bytes = http_options.get("max_body_bytes")
+        if isinstance(max_body_bytes, int) and not isinstance(max_body_bytes, bool) and max_body_bytes > _WEB_BLOB_FETCH_MAX_BODY_BYTES:
+            web_fetch_network_errors.append(
+                ValidationError(
+                    component_id=node.id,
+                    component_type="transform",
+                    message=(
+                        f"blob_fetch.http.max_body_bytes={max_body_bytes} exceeds the web execution limit of "
+                        f"{_WEB_BLOB_FETCH_MAX_BODY_BYTES} bytes."
+                    ),
+                    suggestion=f"Set blob_fetch.http.max_body_bytes to {_WEB_BLOB_FETCH_MAX_BODY_BYTES} or less.",
+                    error_code="web_fetch_resource_limit_exceeded",
+                )
             )
-        else:
-            continue
-        error_code = "web_scrape_private_network_not_allowed" if node.plugin == "web_scrape" else "web_fetch_private_network_not_allowed"
-        web_fetch_network_errors.append(
-            ValidationError(
-                component_id=node.id,
-                component_type="transform",
-                message=message,
-                suggestion=f"Set {node.plugin}.http.allowed_hosts to 'public_only' or remove the option.",
-                error_code=error_code,
-            )
-        )
 
     if web_fetch_network_errors:
         affected_nodes = tuple(error.component_id for error in web_fetch_network_errors if error.component_id is not None)

--- a/tests/unit/web/execution/test_validation.py
+++ b/tests/unit/web/execution/test_validation.py
@@ -670,6 +670,57 @@ class TestValidatePipelineWebFetchNetworkPolicy:
         assert "allow_private" in result.errors[0].message
         mock_yaml_gen.generate_yaml.assert_not_called()
 
+    def test_blob_fetch_large_resource_limits_rejected_before_yaml_generation(self) -> None:
+        options = self._blob_fetch_options()
+        http = cast(dict[str, object], options["http"])
+        http["timeout"] = 86400
+        http["max_body_bytes"] = 1024 * 1024 * 1024 * 1024
+        state = _make_state(
+            nodes=(
+                _make_node(
+                    plugin="blob_fetch",
+                    options=options,
+                ),
+            ),
+            outputs=(_make_output(name="results"),),
+        )
+        settings = _make_settings()
+        mock_yaml_gen = MagicMock(spec=YamlGenerator)
+        mock_yaml_gen.generate_yaml.return_value = "source:\n  plugin: csv_source\n  options: {}\n"
+
+        with patch("elspeth.web.execution.validation.load_settings_from_yaml_string") as mock_load:
+            mock_load.side_effect = ValueError("settings stop")
+            result = validate_pipeline(state, settings, mock_yaml_gen)
+
+        assert result.is_valid is False
+        assert _check(result, "web_scrape_network_policy").passed is False
+        assert {error.error_code for error in result.errors} == {"web_fetch_resource_limit_exceeded"}
+        assert any("blob_fetch.http.timeout=86400" in error.message for error in result.errors)
+        assert any("blob_fetch.http.max_body_bytes" in error.message for error in result.errors)
+        mock_yaml_gen.generate_yaml.assert_not_called()
+
+    def test_blob_fetch_default_resource_limits_allowed_to_reach_yaml_generation(self) -> None:
+        state = _make_state(
+            nodes=(
+                _make_node(
+                    plugin="blob_fetch",
+                    options=self._blob_fetch_options(),
+                ),
+            ),
+            outputs=(_make_output(name="results"),),
+        )
+        settings = _make_settings()
+        mock_yaml_gen = MagicMock(spec=YamlGenerator)
+        mock_yaml_gen.generate_yaml.return_value = "source:\n  plugin: csv_source\n  options: {}\n"
+
+        with patch("elspeth.web.execution.validation.load_settings_from_yaml_string") as mock_load:
+            mock_load.side_effect = ValueError("settings stop")
+            result = validate_pipeline(state, settings, mock_yaml_gen)
+
+        assert result.is_valid is False
+        assert _check(result, "web_scrape_network_policy").passed is True
+        mock_yaml_gen.generate_yaml.assert_called_once()
+
     def test_web_scrape_explicit_cidr_allowlist_rejected_before_yaml_generation(self) -> None:
         state = _make_state(
             nodes=(


### PR DESCRIPTION
### Motivation

- The `blob_fetch` transform accepted user-controlled `timeout` and `max_body_bytes` with only `gt=0` constraints, allowing web-authored pipelines to request very large downloads or long waits that could exhaust worker time, memory, or payload storage.
- Web-side validation only blocked private-network SSRF settings and did not impose resource caps for `blob_fetch`, leaving a runtime DoS vector for authenticated users.

### Description

- Add web-side caps `_WEB_BLOB_FETCH_MAX_TIMEOUT_SECONDS = 30` and `_WEB_BLOB_FETCH_MAX_BODY_BYTES = 10 * 1024 * 1024` to `src/elspeth/web/execution/validation.py` and enforce them during pipeline validation for `blob_fetch` nodes.
- Extend `validate_pipeline()` to report `ValidationError` entries with `error_code="web_fetch_resource_limit_exceeded"` when `blob_fetch.http.timeout` or `blob_fetch.http.max_body_bytes` exceed the web limits, while preserving existing SSRF `allowed_hosts` checks.
- Add two regression tests in `tests/unit/web/execution/test_validation.py` to assert that oversized `blob_fetch` resource limits are rejected before YAML generation and that default limits continue to pass the web fetch policy gate.

### Testing

- Ran formatter and lint checks: `python -m ruff format` (reformatted two files) and `python -m ruff check` — checks passed.
- Performed static compilation sanity: `python -m compileall -q` on the modified files — succeeded.
- Executed the targeted validation test class with `pytest` but the run was blocked by a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500303a4d48323a7c2f4f29da2e47e)