### PR TITLE
fix(azure-di): restrict credential endpoints

### DIFF
--- a/src/elspeth/plugins/transforms/azure/document_intelligence.py
+++ b/src/elspeth/plugins/transforms/azure/document_intelligence.py
@@ -84,6 +84,24 @@ _KNOWN_FEATURES: frozenset[str] = frozenset(
 
 _MODEL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._~-]{1,63}$")
 _PAGES_PATTERN = re.compile(r"^(\d+(-\d+)?)(,\s*(\d+(-\d+)?))*$")
+_AZURE_DOCUMENT_INTELLIGENCE_HOST_SUFFIXES: tuple[str, ...] = (
+    ".cognitiveservices.azure.com",
+    ".cognitiveservices.azure.us",
+    ".cognitiveservices.azure.cn",
+)
+
+
+def _validate_azure_document_intelligence_endpoint(value: str) -> str:
+    """Validate that a credential-bearing endpoint targets Azure Document Intelligence."""
+    from elspeth.plugins.infrastructure.url_validation import validate_credential_safe_https_url
+
+    endpoint = validate_credential_safe_https_url(value, field_name="endpoint")
+    parsed = urlparse(endpoint)
+    hostname = (parsed.hostname or "").casefold().rstrip(".")
+    if not any(hostname.endswith(suffix) and hostname.removesuffix(suffix) for suffix in _AZURE_DOCUMENT_INTELLIGENCE_HOST_SUFFIXES):
+        allowed = ", ".join(f"*{suffix}" for suffix in _AZURE_DOCUMENT_INTELLIGENCE_HOST_SUFFIXES)
+        raise ValueError(f"endpoint must be an Azure Document Intelligence resource endpoint ({allowed})")
+    return endpoint
 
 
 class ExtractFields(BaseModel):
@@ -109,7 +127,7 @@ class ExtractFields(BaseModel):
 class AzureDocumentIntelligenceConfig(TransformDataConfig):
     """Configuration for the azure_document_intelligence transform."""
 
-    endpoint: str = Field(..., description="Azure Document Intelligence endpoint URL (HTTPS).")
+    endpoint: str = Field(..., description="Azure Document Intelligence resource endpoint URL (HTTPS, Azure host only).")
     api_key: str = Field(..., repr=False, description="Document Intelligence API key (Ocp-Apim-Subscription-Key).")
     api_version: str = Field("2024-11-30", description="REST api-version (GA 2024-11-30 only in v1).")
     model_id: str = Field(..., description="Prebuilt or custom model id, e.g. prebuilt-layout, prebuilt-invoice.")
@@ -155,9 +173,7 @@ class AzureDocumentIntelligenceConfig(TransformDataConfig):
     @field_validator("endpoint")
     @classmethod
     def _validate_endpoint(cls, v: str) -> str:
-        from elspeth.plugins.infrastructure.url_validation import validate_credential_safe_https_url
-
-        return validate_credential_safe_https_url(v, field_name="endpoint")
+        return _validate_azure_document_intelligence_endpoint(v)
 
     @field_validator("api_key")
     @classmethod

--- a/tests/golden/web/catalog/knob_schema/transform__azure_document_intelligence.json
+++ b/tests/golden/web/catalog/knob_schema/transform__azure_document_intelligence.json
@@ -20,7 +20,7 @@
         "required": false
       },
       {
-        "description": "Azure Document Intelligence endpoint URL (HTTPS).",
+        "description": "Azure Document Intelligence resource endpoint URL (HTTPS, Azure host only).",
         "kind": "text",
         "label": "Endpoint",
         "name": "endpoint",

--- a/tests/unit/plugins/transforms/azure/test_document_intelligence.py
+++ b/tests/unit/plugins/transforms/azure/test_document_intelligence.py
@@ -58,6 +58,15 @@ def test_rejects_http_endpoint() -> None:
         _cfg(endpoint="http://di.cognitiveservices.azure.com")
 
 
+def test_rejects_non_azure_document_intelligence_endpoint() -> None:
+    with pytest.raises(PluginConfigError):
+        _cfg(endpoint="https://attacker.example")
+
+
+def test_accepts_sovereign_azure_document_intelligence_endpoint() -> None:
+    assert _cfg(endpoint="https://di.cognitiveservices.azure.us").endpoint == "https://di.cognitiveservices.azure.us"
+
+
 def test_rejects_empty_api_key() -> None:
     with pytest.raises(PluginConfigError):
         _cfg(api_key="   ")


### PR DESCRIPTION
### Motivation
- Prevent accidental exfiltration of operator/server-scoped Azure DI keys by blocking arbitrary HTTPS endpoints as credential-bearing targets.  The existing validator only enforced HTTPS and allowed user-controlled hosts.
- Keep existing audit and behavior (HTTPS + credential-safe checks) while narrowing allowed endpoints to genuine Azure Document Intelligence resources.

### Description
- Add `_AZURE_DOCUMENT_INTELLIGENCE_HOST_SUFFIXES` and implement `_validate_azure_document_intelligence_endpoint` which first calls `validate_credential_safe_https_url` and then enforces that the hostname ends with known Azure Cognitive Services suffixes (`.cognitiveservices.azure.com`, `.cognitiveservices.azure.us`, `.cognitiveservices.azure.cn`).
- Wire the stricter validator into the config via `AzureDocumentIntelligenceConfig._validate_endpoint` so endpoint validation now rejects non-Azure hosts.
- Update the endpoint knob description in `tests/golden/web/catalog/knob_schema/transform__azure_document_intelligence.json` to indicate the endpoint must be an Azure host.
- Add unit coverage in `tests/unit/plugins/transforms/azure/test_document_intelligence.py` to assert rejection of `https://attacker.example` and acceptance of sovereign Azure endpoints (`https://di.cognitiveservices.azure.us`).
- Files changed: `src/elspeth/plugins/transforms/azure/document_intelligence.py`, `tests/unit/plugins/transforms/azure/test_document_intelligence.py`, and `tests/golden/web/catalog/knob_schema/transform__azure_document_intelligence.json`.

### Testing
- Ran style/lint checks with `uv run ruff check` on the modified files and they passed.
- Ran `git diff --check` and it reported no issues.
- Attempted to run `uv run pytest tests/unit/plugins/transforms/azure/test_document_intelligence.py` but executing unit tests was blocked because dev test dependencies (`hypothesis`, `respx`, etc.) could not be installed due to network/PyPI download failures; therefore the new tests were added but not executed in this environment.
- Local/interactive validations (edit + `ruff`) and test additions are minimal and preserve existing behavior for Azure host endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fe5c105a08323a02b088c78831adb)