### PR TITLE
Cap sparse JSON contract inference

### DIFF
--- a/src/elspeth/contracts/contract_builder.py
+++ b/src/elspeth/contracts/contract_builder.py
@@ -16,6 +16,10 @@ from elspeth.contracts.schema_contract import FieldContract, SchemaContract
 from elspeth.contracts.type_normalization import UNSUPPORTED_CONTRACT_TYPE, normalize_type_for_contract
 
 
+class ContractFieldLimitExceeded(ValueError):
+    """Raised when sparse post-lock inference would exceed the contract field limit."""
+
+
 class ContractBuilder:
     """Manages contract state through first-row inference.
 
@@ -30,6 +34,14 @@ class ContractBuilder:
 
     Attributes:
         contract: Current contract state (may be locked or unlocked)
+    """
+
+    MAX_LOCKED_CONTRACT_FIELDS = 1024
+    """Maximum fields retained by post-lock sparse inference.
+
+    First-row inference keeps legacy behavior, but sparse fields that first
+    appear after the contract is locked are capped so compact JSON streams
+    cannot force unbounded contract growth or quadratic validation work.
     """
 
     def __init__(self, contract: SchemaContract) -> None:
@@ -166,7 +178,18 @@ class ContractBuilder:
         present in the first valid row. A valid emitted field still needs schema
         contract custody for audit/header restoration. The field's first
         observation locks its type exactly as first-row inference does.
+
+        Post-lock inference is bounded to prevent compact sparse inputs from
+        growing the contract without limit and making later validation scan an
+        attacker-controlled number of inferred fields.
         """
         if self._contract.mode == "FIXED":
             return self._contract
+
+        new_field_names = [normalized_name for normalized_name in row if self._contract.find_name(normalized_name) is None]
+        if len(self._contract.fields) + len(new_field_names) > self.MAX_LOCKED_CONTRACT_FIELDS:
+            raise ContractFieldLimitExceeded(
+                f"Sparse JSON field inference exceeded the maximum locked contract field count ({self.MAX_LOCKED_CONTRACT_FIELDS})"
+            )
+
         return self._infer_missing_fields(row, field_resolution)

--- a/src/elspeth/plugins/sources/json_source.py
+++ b/src/elspeth/plugins/sources/json_source.py
@@ -18,7 +18,7 @@ from pydantic import Field, ValidationError, field_validator, model_validator
 
 from elspeth.contracts import Determinism, PluginSchema, SourceRow
 from elspeth.contracts.contexts import SourceContext
-from elspeth.contracts.contract_builder import ContractBuilder
+from elspeth.contracts.contract_builder import ContractBuilder, ContractFieldLimitExceeded
 from elspeth.contracts.plugin_assistance import PluginAssistance
 from elspeth.contracts.schema_contract_factory import create_contract_from_config
 from elspeth.plugins.infrastructure.base import BaseSource
@@ -533,10 +533,20 @@ class JSONSource(BaseSource):
                 # audit recording.
                 if self._field_resolution is None:
                     raise ValueError("field_resolution must be established before sparse-field contract inference")
-                contract = self._contract_builder.process_sparse_fields(
-                    validated_row,
-                    self._field_resolution.resolution_mapping,
-                )
+                try:
+                    contract = self._contract_builder.process_sparse_fields(
+                        validated_row,
+                        self._field_resolution.resolution_mapping,
+                    )
+                except ContractFieldLimitExceeded as exc:
+                    quarantined = self._record_validation_failure(
+                        ctx=ctx,
+                        row=validated_row,
+                        error_msg=str(exc),
+                    )
+                    if quarantined is not None:
+                        yield quarantined
+                    return
                 self.set_schema_contract(contract)
 
             if contract.locked:

--- a/tests/unit/plugins/sources/test_json_source.py
+++ b/tests/unit/plugins/sources/test_json_source.py
@@ -1581,6 +1581,35 @@ class TestJSONSourceKeyNormalization:
         assert {field.normalized_name for field in second_contract.fields} == {"a", "b"}
         assert second_contract.get_field("b").original_name == "b"
 
+    def test_sparse_field_contract_growth_is_capped(self, tmp_path: Path, ctx: PluginContext, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Post-lock sparse inference is bounded to avoid unbounded contract growth."""
+        from elspeth.contracts.contract_builder import ContractBuilder
+        from elspeth.plugins.sources.json_source import JSONSource
+
+        monkeypatch.setattr(ContractBuilder, "MAX_LOCKED_CONTRACT_FIELDS", 2)
+
+        json_file = tmp_path / "data.json"
+        json_file.write_text(json.dumps([{"a": 1}, {"b": 2}, {"c": 3}]))
+
+        source = JSONSource(
+            {
+                "path": str(json_file),
+                "schema": {"mode": "observed"},
+                "on_validation_failure": "quarantine",
+            }
+        )
+
+        rows = list(source.load(ctx))
+
+        assert len(rows) == 3
+        assert [row.is_quarantined for row in rows] == [False, False, True]
+        assert rows[2].quarantine_error is not None
+        assert "maximum locked contract field count" in rows[2].quarantine_error
+
+        contract = source.get_schema_contract()
+        assert contract is not None
+        assert {field.normalized_name for field in contract.fields} == {"a", "b"}
+
     def test_first_row_quarantined_key_rebuild(self, tmp_path: Path, ctx: PluginContext) -> None:
         """When first row is quarantined and second row has different keys, resolution rebuilds.
 


### PR DESCRIPTION
### Motivation
- Prevent an authenticated resource-exhaustion path where OBSERVED/FLEXIBLE JSON sources could grow the schema contract unboundedly and induce O(n^2) validation cost by inferring a new field for every sparse row.

### Description
- Add a `ContractFieldLimitExceeded` exception and a `MAX_LOCKED_CONTRACT_FIELDS = 1024` cap to `ContractBuilder` to bound post-lock sparse-field inference and preserve legacy first-row behavior.
- Update `ContractBuilder.process_sparse_fields()` to pre-check how many new normalized fields a row would add and raise `ContractFieldLimitExceeded` if the cap would be exceeded.
- Catch `ContractFieldLimitExceeded` in `JSONSource._validate_and_yield()` and route the offending row through existing validation-failure handling so the row is quarantined or discarded according to `on_validation_failure` rather than expanding the contract.
- Add a regression test `test_sparse_field_contract_growth_is_capped` that monkeypatches `ContractBuilder.MAX_LOCKED_CONTRACT_FIELDS` to a low value and verifies that rows up to the cap succeed and the next unique sparse field is quarantined and that the persisted contract stays bounded.

### Testing
- `ruff check` on the modified files succeeded.
- Byte-compile via `PYTHONPATH=src .venv/bin/python -m py_compile` for the changed modules succeeded.
- An automated `PYTHONPATH=src` sanity script exercising `JSONSource` with a lowered `MAX_LOCKED_CONTRACT_FIELDS` cap verified the expected quarantining behavior (`sparse cap behavior ok`).
- Full `pytest` execution in this environment could not be completed because the test runner environment is missing `hypothesis` and the attempt to install dev extras failed due to external package download errors, and `wardline` was not available for static gating, so the full unit test run and wardline scan were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a412474c8323b1cb9824f699a617)