### PR TITLE
ci: keep pull request jobs off trusted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ env:
 permissions:
   contents: read
 
-# Public-repository guardrail: self-hosted runners execute arbitrary workflow
-# code on our infrastructure, so fork PRs stay on GitHub-hosted runners.
-# Trusted pushes and same-repository PRs use the nyx runner.
+# Public-repository guardrail: pull_request workflows execute code from
+# unmerged branches, so all PRs stay on GitHub-hosted runners.
+# Trusted push workflows use the nyx runner.
 #
 # GitHub's runs-on expression accepts either a runner label string or a JSON
 # array of labels. Keep this expression identical across jobs so the aggregate
@@ -40,7 +40,7 @@ permissions:
 # default workspace. Every checkout below uses a per-run, per-job path so stale
 # workspace siblings cannot break actions/checkout before project commands run.
 #
-#   ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+#   ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
 
 jobs:
   # ===========================================================================
@@ -48,7 +48,7 @@ jobs:
   # ===========================================================================
   static-analysis:
     name: Static analysis
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     container:
       image: python:3.13-bookworm
     env:
@@ -153,8 +153,8 @@ jobs:
       - name: Run trust-tier elspeth-lints rule
         working-directory: ${{ env.CI_CHECKOUT_PATH }}
         env:
-          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY }}
-          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'shape-only-when-key-missing' || 'required' }}
+          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ github.event_name != 'pull_request' && secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY || '' }}
+          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && 'shape-only-when-key-missing' || 'required' }}
         run: |
           PYTHONPATH=elspeth-lints/src uv run python -m elspeth_lints.core.cli check \
             --rules trust_tier.tier_model \
@@ -163,8 +163,8 @@ jobs:
       - name: Run trust-boundary honesty-gate elspeth-lints rules
         working-directory: ${{ env.CI_CHECKOUT_PATH }}
         env:
-          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY }}
-          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'shape-only-when-key-missing' || 'required' }}
+          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ github.event_name != 'pull_request' && secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY || '' }}
+          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && 'shape-only-when-key-missing' || 'required' }}
         run: |
           PYTHONPATH=elspeth-lints/src uv run python -m elspeth_lints.core.cli check \
             --rules trust_boundary.tests,trust_boundary.scope,trust_boundary.tier \
@@ -279,8 +279,8 @@ jobs:
         if: always()
         working-directory: ${{ env.CI_CHECKOUT_PATH }}
         env:
-          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY }}
-          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'shape-only-when-key-missing' || 'required' }}
+          ELSPETH_JUDGE_METADATA_HMAC_KEY: ${{ github.event_name != 'pull_request' && secrets.ELSPETH_JUDGE_METADATA_HMAC_KEY || '' }}
+          ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE: ${{ github.event_name == 'pull_request' && 'shape-only-when-key-missing' || 'required' }}
         run: |
           set +e
           PYTHONPATH=elspeth-lints/src uv run python -m elspeth_lints.core.cli check \
@@ -320,7 +320,7 @@ jobs:
   # ===========================================================================
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     container:
       image: python:${{ matrix.python-version }}-bookworm
     env:
@@ -408,7 +408,7 @@ jobs:
   # ===========================================================================
   integration:
     name: Integration Tests
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     container:
       image: python:3.13-bookworm
     needs: [test]
@@ -467,7 +467,7 @@ jobs:
   # (the Phase 1C plan calls this out at line 127-131).
   test-postgres-testcontainer:
     name: Test (Postgres testcontainer)
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     needs: [static-analysis]
     env:
       CI_CHECKOUT_PATH: ci-${{ github.run_id }}-${{ github.run_attempt }}-test-postgres-testcontainer
@@ -534,7 +534,7 @@ jobs:
   # ===========================================================================
   supply-chain-audit:
     name: Dependency and License Audit
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     container:
       image: python:3.13-bookworm
     needs: [static-analysis]
@@ -617,7 +617,7 @@ jobs:
   # browser journey blocks merge instead of being waved through.
   e2e-frontend:
     name: Frontend E2E (Playwright)
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     env:
       CI_CHECKOUT_PATH: ci-${{ github.run_id }}-${{ github.run_attempt }}-e2e-frontend
     steps:
@@ -714,7 +714,7 @@ jobs:
   # blocks merge.
   frontend-unit:
     name: Frontend unit (vitest + typecheck)
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     env:
       CI_CHECKOUT_PATH: ci-${{ github.run_id }}-${{ github.run_attempt }}-frontend-unit
     steps:
@@ -749,7 +749,7 @@ jobs:
   # ===========================================================================
   ci-success:
     name: CI Success
-    runs-on: ${{ fromJSON((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
+    runs-on: ${{ fromJSON((github.event_name != 'pull_request') && '["self-hosted","Linux","X64","nyx-ci","trusted"]' || '"ubuntu-24.04"') }}
     needs:
       - static-analysis
       - test


### PR DESCRIPTION
### Motivation
- The CI routing allowed same-repository `pull_request` runs to execute on the persistent self-hosted `nyx-ci/trusted` runner pool, exposing the runner and release credentials to unmerged branch code and creating a privilege-boundary vulnerability. 
- The intent is to preserve trusted self-hosted routing for trusted pushes and release workflows while ensuring all `pull_request` runs execute on GitHub-hosted runners to eliminate PR-controlled host-level execution and secrets exposure.

### Description
- Updated `.github/workflows/ci.yaml` to simplify the dynamic `runs-on` expressions so that `pull_request` events always use the GitHub-hosted `ubuntu-24.04` runner and non-PR events continue to route to `['self-hosted','Linux','X64','nyx-ci','trusted']` (keeps push/release lanes on self-hosted).  
- Withheld the judge metadata HMAC key from PR jobs by setting `ELSPETH_JUDGE_METADATA_HMAC_KEY` only when `github.event_name != 'pull_request'`, and set PR verification to shape-only mode via `ELSPETH_JUDGE_METADATA_SIGNATURE_VERIFY_MODE` for PR runs to avoid exposing signing material to unmerged branch code.  
- Adjusted the workflow header comment to reflect the corrected guardrail semantics and left `build-push.yaml`/other release workflows’ `runs-on` (self-hosted) unchanged so release jobs retain their intended environment.  
- Committed the change as `ci: keep pull request jobs off trusted runners` and opened a PR with the same title.

### Testing
- Parsed the workflow YAMLs with `python`/`yaml.safe_load()` for `.github/workflows/ci.yaml`, `.github/workflows/build-push.yaml`, and `.github/workflows/mutation-testing.yaml` which succeeded.  
- Ran a repository-local policy check script that verified there are 8 dynamic `runs-on` job expressions, that each now uses the `fromJSON((github.event_name != 'pull_request') ...)` routing (so PR -> `ubuntu-24.04`, push -> `nyx-ci/trusted`), and that the three HMAC guards / verification-mode guards are present, all of which passed.  
- Ran `git diff --check` and committed the change; both checks succeeded.  
- Attempted to run `actionlint` to lint the workflows but the sandbox/network blocked installation and direct release download (Go proxy and GitHub release downloads returned `403`), so `actionlint` was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cdf914888323940cd303f91a681d)