### PR TITLE
fix(web): bind run artifact downloads to session-owned bytes

### DIFF
--- a/src/elspeth/web/execution/preview.py
+++ b/src/elspeth/web/execution/preview.py
@@ -82,22 +82,16 @@ def _select_content_type(suffix: str) -> PreviewContentType:
     return "text"
 
 
-def build_artifact_preview(
-    fs_path: Path,
+def _build_artifact_preview_from_head(
+    head_bytes: bytes,
     *,
+    total_size_bytes: int,
     artifact_id: str,
-    byte_cap: int = _DEFAULT_BYTE_CAP,
-    row_cap: int = _DEFAULT_ROW_CAP,
+    display_path: Path,
+    byte_cap: int,
+    row_cap: int,
 ) -> RunOutputArtifactPreview:
-    """Build a bounded preview for ``fs_path``.
-
-    Caller is responsible for verifying ``fs_path`` is in the sink
-    allowlist and exists. This function reads at most ``byte_cap`` bytes
-    and, for tabular content types, additionally caps at ``row_cap`` rows.
-    """
-    total_size_bytes = fs_path.stat().st_size
-    with fs_path.open("rb") as f:
-        head_bytes = f.read(byte_cap)
+    """Build the preview model from already-captured head bytes."""
     bytes_read = len(head_bytes)
     truncated_by_bytes = bytes_read < total_size_bytes
 
@@ -112,7 +106,7 @@ def build_artifact_preview(
             row_count_preview=None,
         )
 
-    content_type = _select_content_type(fs_path.suffix)
+    content_type = _select_content_type(display_path.suffix)
     is_tabular = content_type in {"csv", "jsonl"}
 
     if is_tabular:
@@ -143,4 +137,55 @@ def build_artifact_preview(
         truncated=truncated,
         total_size_bytes=total_size_bytes,
         row_count_preview=row_count_preview,
+    )
+
+
+def build_artifact_preview_from_bytes(
+    content: bytes,
+    *,
+    artifact_id: str,
+    display_path: Path,
+    byte_cap: int = _DEFAULT_BYTE_CAP,
+    row_cap: int = _DEFAULT_ROW_CAP,
+) -> RunOutputArtifactPreview:
+    """Build a bounded preview from already-authorized artifact bytes.
+
+    ``display_path`` supplies only the suffix used for renderer selection;
+    the bytes are the caller-captured content. This lets authorization
+    code verify an artifact hash once and preview exactly those bytes,
+    rather than reopening a mutable filesystem path after verification.
+    """
+    return _build_artifact_preview_from_head(
+        content[:byte_cap],
+        total_size_bytes=len(content),
+        artifact_id=artifact_id,
+        display_path=display_path,
+        byte_cap=byte_cap,
+        row_cap=row_cap,
+    )
+
+
+def build_artifact_preview(
+    fs_path: Path,
+    *,
+    artifact_id: str,
+    byte_cap: int = _DEFAULT_BYTE_CAP,
+    row_cap: int = _DEFAULT_ROW_CAP,
+) -> RunOutputArtifactPreview:
+    """Build a bounded preview for ``fs_path``.
+
+    Caller is responsible for verifying ``fs_path`` is in the sink
+    allowlist and exists. This function reads at most ``byte_cap`` bytes
+    and, for tabular content types, additionally caps at ``row_cap`` rows.
+    """
+    total_size_bytes = fs_path.stat().st_size
+    with fs_path.open("rb") as f:
+        head_bytes = f.read(byte_cap)
+    return _build_artifact_preview_from_head(
+        head_bytes,
+        total_size_bytes=total_size_bytes,
+        artifact_id=artifact_id,
+        display_path=fs_path,
+        byte_cap=byte_cap,
+        row_cap=row_cap,
     )

--- a/src/elspeth/web/execution/routes.py
+++ b/src/elspeth/web/execution/routes.py
@@ -15,14 +15,18 @@ run's parent session.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, cast
+from urllib.parse import quote
 from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse
+from fastapi.responses import Response
 from pydantic import ValidationError
 
 from elspeth.web.async_workers import run_sync_in_worker
@@ -47,7 +51,7 @@ from elspeth.web.execution.outputs import (
     load_run_outputs_for_settings,
     path_or_uri_to_filesystem_path,
 )
-from elspeth.web.execution.preview import build_artifact_preview
+from elspeth.web.execution.preview import build_artifact_preview_from_bytes
 from elspeth.web.execution.progress import ProgressBroadcaster
 from elspeth.web.execution.protocol import ExecutionService, StateAccessError
 from elspeth.web.execution.schemas import (
@@ -62,13 +66,13 @@ from elspeth.web.execution.schemas import (
     RunDiagnosticsWorkingView,
     RunEvent,
     RunEventType,
+    RunOutputArtifact,
     RunOutputArtifactPreview,
     RunOutputsResponse,
     RunResultsResponse,
     RunStatusResponse,
     ValidationResult,
 )
-from elspeth.web.paths import allowed_sink_directories
 from elspeth.web.sessions.ownership import verify_session_ownership
 from elspeth.web.sessions.protocol import (
     OPERATOR_COMPLETION_RUN_STATUS_VALUES,
@@ -100,12 +104,8 @@ async def _get_session_service(request: Request) -> SessionServiceProtocol:
 # Run-ownership verification remains here — only execution/ runs care.
 
 
-async def _verify_run_ownership(run_id: UUID, user: UserIdentity, request: Request) -> None:
-    """Verify the run exists and belongs to the current user's session.
-
-    Looks up the run's parent session and checks ownership.
-    Returns 404 (not 403) to avoid leaking run existence (IDOR).
-    """
+async def _get_owned_run_record(run_id: UUID, user: UserIdentity, request: Request) -> RunRecord:
+    """Return the run row after IDOR-safe ownership verification."""
     session_service: SessionServiceProtocol = request.app.state.session_service
     settings: WebSettings = request.app.state.settings
     try:
@@ -120,6 +120,89 @@ async def _verify_run_ownership(run_id: UUID, user: UserIdentity, request: Reque
 
     if session.user_id != user.user_id or session.auth_provider_type != settings.auth_provider:
         raise HTTPException(status_code=404, detail="Run not found")
+    return run
+
+
+async def _verify_run_ownership(run_id: UUID, user: UserIdentity, request: Request) -> None:
+    """Verify the run exists and belongs to the current user's session.
+
+    Looks up the run's parent session and checks ownership.
+    Returns 404 (not 403) to avoid leaking run existence (IDOR).
+    """
+    await _get_owned_run_record(run_id, user, request)
+
+
+def _artifact_path_owned_by_session(resolved: Path, *, data_dir: str, session_id: UUID) -> bool:
+    """Return True iff a filesystem artifact lives in this session's namespace.
+
+    The sink allowlist is intentionally global for write compatibility, but
+    readback is an authorization boundary. Downloads/previews therefore require
+    a session-owned namespace under ``data_dir/outputs/{session_id}`` or
+    ``data_dir/blobs/{session_id}``; a global ``data_dir/outputs/shared.jsonl``
+    path is only a mutable filesystem location, not proof that the current
+    bytes belong to the caller's run.
+    """
+    base = Path(data_dir).resolve()
+    session_key = str(session_id)
+    session_roots = (base / "outputs" / session_key, base / "blobs" / session_key)
+    return any(resolved.is_relative_to(root) for root in session_roots)
+
+
+def _artifact_path_unauthorized_http(path_or_uri: str) -> HTTPException:
+    return HTTPException(
+        status_code=403,
+        detail={
+            "error_type": "output_path_outside_allowlist",
+            "path_or_uri": path_or_uri,
+        },
+    )
+
+
+def _artifact_not_available_http(path_or_uri: str) -> HTTPException:
+    return HTTPException(
+        status_code=410,
+        detail={
+            "error_type": "artifact_purged_or_moved",
+            "path_or_uri": path_or_uri,
+        },
+    )
+
+
+def _artifact_content_changed_http(artifact_id: str, path_or_uri: str) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={
+            "error_type": "artifact_content_changed",
+            "artifact_id": artifact_id,
+            "path_or_uri": path_or_uri,
+        },
+    )
+
+
+def _read_verified_artifact_bytes(resolved: Path, artifact: RunOutputArtifact) -> bytes:
+    """Read bytes and verify they still match the audit artifact descriptor."""
+    try:
+        content = resolved.read_bytes()
+    except (FileNotFoundError, NotADirectoryError):
+        raise _artifact_not_available_http(artifact.path_or_uri) from None
+    except IsADirectoryError:
+        raise _artifact_not_available_http(artifact.path_or_uri) from None
+
+    actual_hash = hashlib.sha256(content).hexdigest()
+    if len(content) != artifact.size_bytes or not hmac.compare_digest(actual_hash, artifact.content_hash):
+        raise _artifact_content_changed_http(artifact.artifact_id, artifact.path_or_uri)
+    return content
+
+
+def _artifact_is_download_authorized(artifact: RunOutputArtifact, *, data_dir: str, session_id: UUID) -> bool:
+    fs_path = path_or_uri_to_filesystem_path(artifact.path_or_uri)
+    if artifact.artifact_type != "file" or fs_path is None:
+        return False
+    try:
+        resolved = fs_path.resolve()
+    except OSError:
+        return False
+    return resolved.exists() and _artifact_path_owned_by_session(resolved, data_dir=data_dir, session_id=session_id)
 
 
 def _run_not_found_http() -> HTTPException:
@@ -946,7 +1029,7 @@ def create_execution_router() -> APIRouter:
         endpoint is the audit-evidence retrieval surface — every artefact
         the run wrote, with ``content_hash`` and ``exists_now``.
         """
-        await _verify_run_ownership(run_id, user, request)
+        owned_run = await _get_owned_run_record(run_id, user, request)
         try:
             status = await _load_run_status_with_accounting(run_id, app=request.app, service=service)
         except _RunStatusNotFoundError:
@@ -956,7 +1039,7 @@ def create_execution_router() -> APIRouter:
 
         landscape_run_id = status.landscape_run_id or status.run_id
         try:
-            return await run_sync_in_worker(
+            manifest = await run_sync_in_worker(
                 load_run_outputs_for_settings,
                 request.app.state.settings,
                 run_id=status.run_id,
@@ -972,6 +1055,20 @@ def create_execution_router() -> APIRouter:
                 },
             ) from exc
 
+        artifacts = [
+            artifact.model_copy(
+                update={
+                    "downloadable": _artifact_is_download_authorized(
+                        artifact,
+                        data_dir=str(request.app.state.settings.data_dir),
+                        session_id=owned_run.session_id,
+                    )
+                }
+            )
+            for artifact in manifest.artifacts
+        ]
+        return manifest.model_copy(update={"artifacts": artifacts})
+
     @router.get("/api/runs/{run_id}/outputs/{artifact_id}/content")
     async def get_run_output_content(
         run_id: UUID,
@@ -982,20 +1079,23 @@ def create_execution_router() -> APIRouter:
     ) -> Any:
         """Stream the bytes of one artefact written by a run.
 
-        Path-allowlist guard: refuses any artefact whose ``path_or_uri``
-        resolves outside ``allowed_sink_directories(data_dir)`` (the
-        canonical ``data_dir/{outputs,blobs}`` set). This is
-        defence-in-depth — the path was already allowlisted at write
-        time, but the audit row is read-mutable in principle and the
-        read-side guard MUST NOT trust it.
+        Readback guard: refuses filesystem artefacts outside this run's
+        session-owned namespace under ``data_dir/outputs/{session_id}``
+        or ``data_dir/blobs/{session_id}``, then verifies the current
+        bytes against the audit row's ``size_bytes`` and
+        ``content_hash`` before returning the captured bytes. The global
+        sink allowlist is a write-boundary guard only; it is not proof
+        that a mutable path's current bytes belong to this run.
 
         Returns:
-        * 200 with file bytes when path is in-allowlist and exists.
-        * 403 when path is outside allowlist.
+        * 200 with file bytes when path is session-owned, exists, and
+          still matches the audit descriptor.
+        * 403 when path is outside the session-owned read namespace.
         * 404 when artefact is not in the run's manifest.
-        * 410 when path was in-allowlist but file no longer exists.
+        * 409 when current bytes differ from the audited artefact bytes.
+        * 410 when path was session-owned but file no longer exists.
         """
-        await _verify_run_ownership(run_id, user, request)
+        owned_run = await _get_owned_run_record(run_id, user, request)
         try:
             status = await _load_run_status_with_accounting(run_id, app=request.app, service=service)
         except _RunStatusNotFoundError:
@@ -1046,34 +1146,18 @@ def create_execution_router() -> APIRouter:
         try:
             resolved = fs_path.resolve()
         except OSError:
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error_type": "output_path_outside_allowlist",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            ) from None
+            raise _artifact_path_unauthorized_http(artifact.path_or_uri) from None
         data_dir = request.app.state.settings.data_dir
-        allowed = allowed_sink_directories(data_dir)
-        if not any(resolved.is_relative_to(base) for base in allowed):
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error_type": "output_path_outside_allowlist",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            )
+        if not _artifact_path_owned_by_session(resolved, data_dir=str(data_dir), session_id=owned_run.session_id):
+            raise _artifact_path_unauthorized_http(artifact.path_or_uri)
 
-        if not resolved.exists():
-            raise HTTPException(
-                status_code=410,
-                detail={
-                    "error_type": "artifact_purged_or_moved",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            )
-
-        return FileResponse(resolved, filename=resolved.name)
+        content = await run_sync_in_worker(_read_verified_artifact_bytes, resolved, artifact)
+        filename = quote(resolved.name)
+        return Response(
+            content=content,
+            media_type="application/octet-stream",
+            headers={"Content-Disposition": f"attachment; filename*=UTF-8''{filename}"},
+        )
 
     @router.get(
         "/api/runs/{run_id}/outputs/{artifact_id}/preview",
@@ -1091,19 +1175,21 @@ def create_execution_router() -> APIRouter:
         Companion to ``/content``: where ``/content`` streams the full
         file, ``/preview`` reads at most 256 KiB or 100 rows so the
         operator UI can render an inline preview without a full
-        download. Same path-allowlist guard, same ownership check —
-        the only behavioural difference is bounded read.
+        download. Same session-owned path guard, same audited-byte
+        verification, same ownership check — the only behavioural
+        difference is bounded rendering.
 
         Returns:
         * 200 with ``RunOutputArtifactPreview`` on success.
-        * 403 when path is outside allowlist.
+        * 403 when path is outside the session-owned read namespace.
         * 404 when artefact is not in the run's manifest.
-        * 410 when path was in-allowlist but file no longer exists
+        * 409 when current bytes differ from the audited artefact bytes.
+        * 410 when path was session-owned but file no longer exists
           (frontend treats this as the "no longer available on disk"
           state, mirroring the manifest's ``exists_now=False``).
         * 415 when the artefact is non-file (object-store URI).
         """
-        await _verify_run_ownership(run_id, user, request)
+        owned_run = await _get_owned_run_record(run_id, user, request)
         try:
             status = await _load_run_status_with_accounting(run_id, app=request.app, service=service)
         except _RunStatusNotFoundError:
@@ -1151,40 +1237,16 @@ def create_execution_router() -> APIRouter:
         try:
             resolved = fs_path.resolve()
         except OSError:
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error_type": "output_path_outside_allowlist",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            ) from None
+            raise _artifact_path_unauthorized_http(artifact.path_or_uri) from None
         data_dir = request.app.state.settings.data_dir
-        allowed = allowed_sink_directories(data_dir)
-        if not any(resolved.is_relative_to(base) for base in allowed):
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error_type": "output_path_outside_allowlist",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            )
+        if not _artifact_path_owned_by_session(resolved, data_dir=str(data_dir), session_id=owned_run.session_id):
+            raise _artifact_path_unauthorized_http(artifact.path_or_uri)
 
-        if not resolved.exists():
-            # Manifest/preview race: file existed at manifest-load time
-            # but is gone now (purged, retention, manual delete). Match
-            # the /content endpoint's vocabulary — frontend handles either.
-            raise HTTPException(
-                status_code=410,
-                detail={
-                    "error_type": "artifact_purged_or_moved",
-                    "path_or_uri": artifact.path_or_uri,
-                },
-            )
-
-        return await run_sync_in_worker(
-            build_artifact_preview,
-            resolved,
+        content = await run_sync_in_worker(_read_verified_artifact_bytes, resolved, artifact)
+        return build_artifact_preview_from_bytes(
+            content,
             artifact_id=artifact_id,
+            display_path=resolved,
         )
 
     return router

--- a/src/elspeth/web/execution/schemas.py
+++ b/src/elspeth/web/execution/schemas.py
@@ -639,11 +639,11 @@ class RunOutputArtifact(_StrictResponse):
     re-fetch flows. Returned by ``/api/runs/{rid}/outputs``.
 
     ``downloadable`` is a server-computed convenience: true iff the
-    ``/outputs/{artifact_id}/content`` endpoint would actually serve
-    bytes for this row. False when the artifact is not file-backed,
-    when the file is gone, or when the path resolves outside the
-    sink-allowlist. Lets the UI suppress download buttons that would
-    otherwise 4xx on click.
+    artifact is file-backed and currently resolves to an existing file in
+    the caller's session-owned read namespace. The content/preview
+    endpoints still verify ``content_hash`` and ``size_bytes`` at read
+    time, so a mutable path that changed after audit may return 409 even
+    when this UI hint was true.
     """
 
     artifact_id: str

--- a/tests/unit/web/execution/test_outputs_routes.py
+++ b/tests/unit/web/execution/test_outputs_routes.py
@@ -5,13 +5,14 @@ mocks on app.state.* and dependency_overrides for the auth middleware.
 
 The manifest endpoint is the authoritative full-list of every sink-write
 artefact produced by a run (distinct from the diagnostics endpoint's
-20-artifact preview). The content endpoint streams the bytes of one
-artefact, gated by a path-allowlist guard that enforces
-``allowed_sink_directories(data_dir)``.
+20-artifact preview). The content and preview endpoints read bytes only
+from session-owned artifact namespaces and verify audited size/hash
+before serving mutable filesystem content.
 """
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,7 +22,6 @@ from uuid import UUID, uuid4
 
 import pytest
 from fastapi import FastAPI
-from fastapi.responses import FileResponse
 from httpx import ASGITransport, AsyncClient
 from starlette.routing import Route
 
@@ -46,6 +46,7 @@ def _route_endpoint(app: FastAPI, name: str) -> Callable[..., Awaitable[Any]]:
 def _create_test_app(
     execution_service: MagicMock | None = None,
     settings: MagicMock | None = None,
+    session_id: UUID | None = None,
 ) -> FastAPI:
     from elspeth.web.auth.middleware import get_current_user
     from elspeth.web.execution.routes import create_execution_router
@@ -60,7 +61,7 @@ def _create_test_app(
     mock_session.user_id = _TEST_USER_ID
     mock_session.auth_provider_type = "local"
     mock_session_service.get_session = AsyncMock(return_value=mock_session)
-    mock_run = MagicMock(session_id=uuid4())
+    mock_run = MagicMock(session_id=session_id or uuid4())
     mock_run.landscape_run_id = None
     mock_session_service.get_run = AsyncMock(return_value=mock_run)
     app.state.session_service = mock_session_service
@@ -90,6 +91,10 @@ def _running_status(run_id: UUID) -> RunStatusResponse:
         error=None,
         landscape_run_id=None,
     )
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
 
 
 # ── Manifest endpoint tests ─────────────────────────────────────────
@@ -188,10 +193,12 @@ class TestRunOutputContentEndpoint:
     @pytest.mark.asyncio
     async def test_streams_file_bytes_when_inside_sink_allowlist(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "results.jsonl"
-        sink_file.write_bytes(b'{"interaction_id":"INT-1001"}\n')
+        content = b'{"interaction_id":"INT-1001"}\n'
+        sink_file.write_bytes(content)
 
         svc = MagicMock()
         svc.get_status = AsyncMock(return_value=_running_status(run_id))
@@ -206,8 +213,8 @@ class TestRunOutputContentEndpoint:
                         sink_node_id="results",
                         artifact_type="file",
                         path_or_uri=f"file://{sink_file}",
-                        content_hash="a" * 64,
-                        size_bytes=sink_file.stat().st_size,
+                        content_hash=_sha256(content),
+                        size_bytes=len(content),
                         created_at=datetime.now(UTC),
                         exists_now=True,
                         downloadable=True,
@@ -225,21 +232,115 @@ class TestRunOutputContentEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
-        endpoint = _route_endpoint(app, "get_run_output_content")
-        request = MagicMock()
-        request.app = app
-        response = await endpoint(
-            run_id=run_id,
-            artifact_id="art-1",
-            request=request,
-            user=UserIdentity(user_id=_TEST_USER_ID, username="testuser"),
-            service=svc,
-        )
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/runs/{run_id}/outputs/art-1/content")
 
-        assert isinstance(response, FileResponse)
-        assert response.path == sink_file
-        assert sink_file.read_bytes() == b'{"interaction_id":"INT-1001"}\n'
+        assert response.status_code == 200
+        assert response.content == content
+        assert response.headers["content-disposition"] == "attachment; filename*=UTF-8''results.jsonl"
+
+    @pytest.mark.asyncio
+    async def test_403_when_path_is_global_sink_path_not_session_owned(self, monkeypatch, tmp_path) -> None:
+        run_id = uuid4()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs"
+        outputs_dir.mkdir()
+        shared_file = outputs_dir / "shared.jsonl"
+        content = b'{"tenant":"victim","secret":"SSN-123-45-6789"}\n'
+        shared_file.write_bytes(content)
+
+        svc = MagicMock()
+        svc.get_status = AsyncMock(return_value=_running_status(run_id))
+
+        def fake_load(*args: object, **kwargs: object) -> RunOutputsResponse:
+            return RunOutputsResponse(
+                run_id=str(run_id),
+                landscape_run_id=str(run_id),
+                artifacts=[
+                    RunOutputArtifact(
+                        artifact_id="art-shared",
+                        sink_node_id="results",
+                        artifact_type="file",
+                        path_or_uri=str(shared_file),
+                        content_hash=_sha256(content),
+                        size_bytes=len(content),
+                        created_at=datetime.now(UTC),
+                        exists_now=True,
+                        downloadable=True,
+                    )
+                ],
+            )
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr("elspeth.web.execution.routes.load_run_outputs_for_settings", fake_load)
+        monkeypatch.setattr("elspeth.web.execution.routes.run_sync_in_worker", fake_to_thread)
+
+        settings = MagicMock()
+        settings.auth_provider = "local"
+        settings.data_dir = str(tmp_path)
+
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/runs/{run_id}/outputs/art-shared/content")
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["error_type"] == "output_path_outside_allowlist"
+        assert b"SSN-123-45-6789" not in response.content
+
+    @pytest.mark.asyncio
+    async def test_409_when_artifact_bytes_changed_since_audit_row(self, monkeypatch, tmp_path) -> None:
+        run_id = uuid4()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
+        sink_file = outputs_dir / "results.jsonl"
+        original = b'{"tenant":"attacker"}\n'
+        victim = b'{"tenant":"victim","secret":"SSN-123-45-6789"}\n'
+        sink_file.write_bytes(original)
+
+        svc = MagicMock()
+        svc.get_status = AsyncMock(return_value=_running_status(run_id))
+
+        def fake_load(*args: object, **kwargs: object) -> RunOutputsResponse:
+            sink_file.write_bytes(victim)
+            return RunOutputsResponse(
+                run_id=str(run_id),
+                landscape_run_id=str(run_id),
+                artifacts=[
+                    RunOutputArtifact(
+                        artifact_id="art-1",
+                        sink_node_id="results",
+                        artifact_type="file",
+                        path_or_uri=str(sink_file),
+                        content_hash=_sha256(original),
+                        size_bytes=len(original),
+                        created_at=datetime.now(UTC),
+                        exists_now=True,
+                        downloadable=True,
+                    )
+                ],
+            )
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr("elspeth.web.execution.routes.load_run_outputs_for_settings", fake_load)
+        monkeypatch.setattr("elspeth.web.execution.routes.run_sync_in_worker", fake_to_thread)
+
+        settings = MagicMock()
+        settings.auth_provider = "local"
+        settings.data_dir = str(tmp_path)
+
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/runs/{run_id}/outputs/art-1/content")
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["error_type"] == "artifact_content_changed"
+        assert b"SSN-123-45-6789" not in response.content
 
     @pytest.mark.asyncio
     async def test_403_when_path_outside_sink_allowlist(self, monkeypatch, tmp_path) -> None:
@@ -324,8 +425,9 @@ class TestRunOutputContentEndpoint:
     @pytest.mark.asyncio
     async def test_410_when_artifact_path_no_longer_exists(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "results.jsonl"
         sink_file.write_bytes(b"will-purge\n")
         sink_file.unlink()  # File was purged after the run
@@ -362,7 +464,7 @@ class TestRunOutputContentEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(f"/api/runs/{run_id}/outputs/art-purged/content")
 
@@ -384,7 +486,7 @@ def _file_artifact_in_outputs(
         sink_node_id=sink_node_id,
         artifact_type="file",
         path_or_uri=f"file://{sink_file}",
-        content_hash="a" * 64,
+        content_hash=_sha256(sink_file.read_bytes()),
         size_bytes=sink_file.stat().st_size,
         created_at=datetime.now(UTC),
         exists_now=True,
@@ -418,8 +520,9 @@ class TestRunOutputPreviewEndpoint:
     @pytest.mark.asyncio
     async def test_returns_csv_preview_for_small_file(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "results.csv"
         sink_file.write_text("col1,col2\n1,2\n3,4\n")
 
@@ -431,7 +534,7 @@ class TestRunOutputPreviewEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(f"/api/runs/{run_id}/outputs/art-1/preview")
 
@@ -446,8 +549,9 @@ class TestRunOutputPreviewEndpoint:
     @pytest.mark.asyncio
     async def test_text_file_under_cap_returns_full_content(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "log.txt"
         sink_file.write_text("hello world\n")
 
@@ -459,7 +563,7 @@ class TestRunOutputPreviewEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(f"/api/runs/{run_id}/outputs/art-1/preview")
 
@@ -472,8 +576,9 @@ class TestRunOutputPreviewEndpoint:
     @pytest.mark.asyncio
     async def test_binary_file_returns_binary_content_type(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "blob.bin"
         sink_file.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 200)
 
@@ -485,7 +590,7 @@ class TestRunOutputPreviewEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(f"/api/runs/{run_id}/outputs/art-1/preview")
 
@@ -549,8 +654,9 @@ class TestRunOutputPreviewEndpoint:
     @pytest.mark.asyncio
     async def test_410_when_file_purged_between_manifest_and_preview(self, monkeypatch, tmp_path) -> None:
         run_id = uuid4()
-        outputs_dir = tmp_path / "outputs"
-        outputs_dir.mkdir()
+        session_id = uuid4()
+        outputs_dir = tmp_path / "outputs" / str(session_id)
+        outputs_dir.mkdir(parents=True)
         sink_file = outputs_dir / "gone.csv"
         sink_file.write_text("data\n")
         sink_file.unlink()
@@ -574,7 +680,7 @@ class TestRunOutputPreviewEndpoint:
         settings.auth_provider = "local"
         settings.data_dir = str(tmp_path)
 
-        app = _create_test_app(execution_service=svc, settings=settings)
+        app = _create_test_app(execution_service=svc, settings=settings, session_id=session_id)
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(f"/api/runs/{run_id}/outputs/art-purged/preview")
 


### PR DESCRIPTION
### Motivation
- The content streaming and preview endpoints exposed a cross-tenant read primitive by trusting a global sink allowlist and serving the current filesystem path bytes for an artifact row. 
- The intent is to enforce a strict read-time authorization and integrity boundary so an artifact row cannot be used to download bytes that were written later by another session or tenant.

### Description
- Require the run-owned session namespace for readback by checking that resolved filesystem paths live under `data_dir/outputs/{session_id}` or `data_dir/blobs/{session_id}` before serving content or previews. 
- Verify the current file bytes against the audited `size_bytes` and `content_hash` and return a `409 artifact_content_changed` when the on-disk bytes no longer match the recorded artifact descriptor. 
- Serve verified bytes via a safe `Response` with a UTF-8 filename disposition header instead of directly returning `FileResponse` for potentially mutable shared paths. 
- Refactor preview rendering so the preview code can build a bounded preview from an already-verified byte buffer (`build_artifact_preview_from_bytes`) rather than reopening the mutable path after authorization, and update the `downloadable` documentation to reflect the session-scoped hint semantics.

### Testing
- Ran static and formatting checks: `python -m ruff check` on the changed files succeeded. 
- Verified syntactic validity with `python -m compileall -q` on the modified modules and `git diff --check` with no issues. 
- Attempted to run unit tests with `pytest` but the run was blocked locally because `hypothesis`/test deps are not available in the sandbox environment. 
- Attempted dev-dependency sync and tier-linting (`uv sync --extra dev`, `elspeth_lints trust_tier.tier_model`) but both were blocked by network/download or missing-package constraints in the execution environment (PyPI download failure for a dev wheel, and `pydantic` missing for the linter runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227e66c6608323acac1a4609f37a00)