### PR TITLE
fix(evals): remove hardcoded staging credentials

### DIFF
--- a/evals/2026-05-03-composer/README.md
+++ b/evals/2026-05-03-composer/README.md
@@ -116,8 +116,9 @@ rerun-mode pass against staging using those IDs.
 These files were captured from a live evaluation run against the staging deploy at `https://elspeth.foundryside.dev` on 2026-05-03 (HEAD `f3137ae8`).
 
 **Redacted before commit**:
-- `jwt*.txt` files in every scenario directory — the original short-lived `dta_user` JWTs are replaced with placeholder text. Tokens were already expired (1-hour TTL) but credential-shaped strings shouldn't land in git regardless.
+- `jwt*.txt` files in every scenario directory — the original short-lived JWTs are replaced with placeholder text. Tokens were already expired (1-hour TTL) but credential-shaped strings shouldn't land in git regardless.
 - `login.json`, `login2.json` — wrapped access/refresh tokens, replaced with `{"redacted": ...}` placeholders.
+- Reusable local-auth passwords are not committed. Harnesses require `ELSPETH_EVAL_USER` / `ELSPETH_EVAL_PASS` from the operator environment or an untracked env file.
 
 **Not redacted (and intentionally preserved for audit-trail integrity)**:
 - Session IDs, blob IDs, run IDs — these are non-sensitive identifiers traceable through the staging audit DB.

--- a/evals/2026-05-03-composer/hardmode/README.md
+++ b/evals/2026-05-03-composer/hardmode/README.md
@@ -154,7 +154,7 @@ This run produced real on-disk output at `data/outputs/q3_{fraud_security_flags,
 Three bash scripts that drive the harness. Each is independently runnable:
 
 ### `harness.sh <scenario_id>`
-Bootstrap. Reads `scenarios/<scenario_id>_*.json`, logs in fresh, creates a composer session, uploads the CSV blob if the scenario has one. Writes `session.json`, `sid.txt`, `jwt.txt`, `blob.json` (if applicable) into `results/<scenario_id>/`. Does not send any messages.
+Bootstrap. Reads `scenarios/<scenario_id>_*.json`, logs in fresh using `ELSPETH_EVAL_USER` / `ELSPETH_EVAL_PASS` from the operator environment or an untracked env file, creates a composer session, uploads the CSV blob if the scenario has one. Writes `session.json`, `sid.txt`, `jwt.txt`, `blob.json` (if applicable) into `results/<scenario_id>/`. Does not send any messages.
 
 ### `post_message.sh <scenario_id> <turn_index> <user_message_file>`
 Per-turn driver. Captures state-before, posts the user message to `/messages`, captures composer response, captures state-after, captures `/composer-progress` events, computes per-turn metrics. Writes `msg.t{N}.{req,resp,curl_meta}`, `state.{before,after}.t{N}.json`, `progress.t{N}.json`, `metrics.t{N}.json`.

--- a/evals/2026-05-03-composer/hardmode/harness.sh
+++ b/evals/2026-05-03-composer/hardmode/harness.sh
@@ -22,48 +22,39 @@
 
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SID_FILE=""
-JWT_FILE=""
+EVALS_SCRIPT_DIR="$ROOT"
+# shellcheck source=../../lib/common.sh
+source "$ROOT/../../lib/common.sh"
 
 scenario_id="${1:-}"
-if [[ -z "$scenario_id" ]]; then echo "usage: $0 <scenario_id>"; exit 1; fi
+if [[ -z "$scenario_id" ]]; then evals_die 64 "usage: $0 <scenario_id>"; fi
 
-scen=$ROOT/scenarios/${scenario_id}_*.json
-scen=$(ls $scen 2>/dev/null | head -1)
-if [[ -z "$scen" ]]; then echo "scenario not found: $scenario_id"; exit 1; fi
+evals_require_tools
+: "${ELSPETH_EVAL_BASE_URL:=https://elspeth.foundryside.dev}"
+evals_load_env --require-creds
 
-out=$ROOT/results/$scenario_id
-mkdir -p $out
-cp "$scen" $out/scenario.json
+scen=$(evals_resolve_scenario "$ROOT/scenarios" "$scenario_id")
+
+out="$ROOT/results/$scenario_id"
+mkdir -p "$out"
+cp "$scen" "$out/scenario.json"
+export EVALS_OUT_DIR="$out"
+export EVALS_JWT_FILE="$out/jwt.txt"
 
 # --- step 1: login fresh ---
-curl -fsS -X POST https://elspeth.foundryside.dev/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"username":"dta_user","password":"dta_pass"}' \
-  | jq -r '.access_token' > $out/jwt.txt
-J=$(cat $out/jwt.txt)
-[[ -n "$J" ]] || { echo "login failed"; exit 2; }
+evals_login
 
 # --- step 2: create session ---
-title=$(jq -r '.task_summary' $out/scenario.json)
-curl -fsS -X POST https://elspeth.foundryside.dev/api/sessions \
-  -H "Authorization: Bearer $J" -H 'Content-Type: application/json' \
-  -d "$(jq -n --arg t "hardmode/$scenario_id $title" '{title:$t}')" \
-  -o $out/session.json
-sid=$(jq -r '.id' $out/session.json)
-echo "$sid" > $out/sid.txt
+title=$(jq -r '.task_summary' "$out/scenario.json")
+sid=$(evals_create_session "hardmode/$scenario_id $title")
 
 # --- step 3: upload blob if scenario has one ---
-csv_filename=$(jq -r '.csv_filename // empty' $out/scenario.json)
+csv_filename=$(jq -r '.csv_filename // empty' "$out/scenario.json")
 if [[ -n "$csv_filename" ]]; then
-  jq -n \
-    --arg fn "$csv_filename" \
-    --rawfile body <(jq -r '.csv_content' $out/scenario.json) \
-    '{filename:$fn, mime_type:"text/csv", content:$body}' \
-    > $out/blob.req.json
-  curl -fsS -X POST "https://elspeth.foundryside.dev/api/sessions/$sid/blobs/inline" \
-    -H "Authorization: Bearer $J" -H 'Content-Type: application/json' \
-    --data @$out/blob.req.json -o $out/blob.json
+  csv_content_file=$(mktemp)
+  trap 'rm -f "$csv_content_file"' EXIT
+  jq -r '.csv_content' "$out/scenario.json" > "$csv_content_file"
+  evals_upload_blob "$sid" "$csv_filename" "text/csv" "$csv_content_file"
 fi
 
 echo "Scaffold ready: $out (sid=$sid)"

--- a/src/elspeth/web/frontend/playwright.staging.config.ts
+++ b/src/elspeth/web/frontend/playwright.staging.config.ts
@@ -14,7 +14,7 @@
 //
 // Invocation:
 //   STAGING_BASE_URL=https://elspeth.foundryside.dev \
-//   STAGING_USERNAME=dta_user STAGING_PASSWORD=dta_pass \
+//   STAGING_USERNAME=<staging-user> STAGING_PASSWORD=<staging-password> \
 //   PLAYWRIGHT_BACKEND_BASE_URL=https://elspeth.foundryside.dev \
 //   npx playwright test --config=playwright.staging.config.ts composer-preferences
 


### PR DESCRIPTION
### Motivation
- Close a secret-leak: the hard-mode eval harness contained a committed username/password payload that could be reused against the staging service, so the harness must not contain reusable credentials in the tree. 
- Require operator-supplied credentials and reuse the shared eval helpers so runs still produce the same outputs without embedding secrets in source files.

### Description
- Replace inline login in `evals/2026-05-03-composer/hardmode/harness.sh` with the shared eval helpers by sourcing `evals/lib/common.sh` and using `evals_login`, `evals_create_session`, and `evals_upload_blob`, and require `ELSPETH_EVAL_USER` / `ELSPETH_EVAL_PASS` via `evals_load_env --require-creds` while preserving `ELSPETH_EVAL_BASE_URL` default. 
- Stop writing a committed `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226ed8764c8323855f5b1f9b3f15d2)