### PR TITLE
fix(composer): reject unhashable structural plugin probes

### DIFF
--- a/src/elspeth/web/composer/tools/_common.py
+++ b/src/elspeth/web/composer/tools/_common.py
@@ -1314,7 +1314,7 @@ def _validate_plugin_name(
     name: str,
 ) -> PluginPolicyViolation | None:
     """Validate a new plugin selection against one request policy view."""
-    if plugin_type == "transform" and name in _STRUCTURAL_NODE_TYPE_GUIDANCE:
+    if isinstance(name, str) and plugin_type == "transform" and name in _STRUCTURAL_NODE_TYPE_GUIDANCE:
         return PluginPolicyViolation(
             error_code=PluginUnavailableReason.NOT_INSTALLED,
             message=_STRUCTURAL_NODE_TYPE_GUIDANCE[name],

--- a/tests/unit/web/composer/test_tools.py
+++ b/tests/unit/web/composer/test_tools.py
@@ -14110,6 +14110,21 @@ class TestStructuralNodeTypeProbedAsPlugin:
         for fragment in expected_fragments:
             assert fragment in message, f"teaching message for {name!r} must mention {fragment!r}: {message}"
 
+    @pytest.mark.parametrize("name", [[], {}])
+    def test_get_plugin_schema_rejects_unhashable_name(self, name: object) -> None:
+        policy_catalog, snapshot = self._trained_pair()
+
+        result = execute_tool(
+            "get_plugin_schema",
+            {"plugin_type": "transform", "name": name},
+            _empty_state(),
+            policy_catalog,
+            plugin_snapshot=snapshot,
+        )
+
+        assert result.success is False
+        assert result.data["error_code"] == "not_installed"
+
 
 class TestExplainGateRouteLabels:
     def test_explains_gate_route_labels_mismatch(self) -> None:


### PR DESCRIPTION
### Motivation

- The structural node-type guidance check performed `name in _STRUCTURAL_NODE_TYPE_GUIDANCE` before ensuring `name` is a string, which allows unhashable JSON values (e.g. `[]`, `{}`) to raise `TypeError` in direct/MCP dispatch paths. 

### Description

- Guard the structural node-type lookup with `isinstance(name, str)` so non-string/unhashable `name` values do not trigger an unhandled `TypeError` and instead flow through the normal validation path. 
- Add a regression test `test_get_plugin_schema_rejects_unhashable_name` that exercises `get_plugin_schema` with `name` set to `[]` and `{}` via direct tool dispatch, asserting a structured `not_installed` failure. 
- Modified files: `src/elspeth/web/composer/tools/_common.py` and `tests/unit/web/composer/test_tools.py`.

### Testing

- Ran `ruff check` and `ruff format --check` on the modified files and both checks passed. 
- Verified Python compilation with `python -m compileall -q` for the modified modules and it succeeded. 
- Attempted to run the focused test selection with `pytest` (`uv run --extra dev pytest -q tests/unit/web/composer/test_tools.py -k 'StructuralNodeTypeProbedAsPlugin'`) but the environment could not download the `pytest-asyncio` dependency so the full pytest run was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fdd7048323844fc1f2f4ec5364)