### PR TITLE
fix(gitignore): preserve credential exclusions in evals/composer-parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,24 @@ scratch/
 # so junk under the corpus stays ignored.
 !/evals/composer-parity/
 !/evals/composer-parity/**
+# Preserve the repository-wide credential safeguards after the broad corpus
+# exception above (the last matching gitignore rule wins).
+/evals/composer-parity/**/jwt.txt
+/evals/composer-parity/**/jwt-*.txt
+/evals/composer-parity/**/jwt_*.txt
+/evals/composer-parity/**/*.api_key
+/evals/composer-parity/**/*.access_token
+/evals/composer-parity/**/*.bearer_token
+/evals/composer-parity/**/login.json
+/evals/composer-parity/**/login_*.json
+/evals/composer-parity/**/*.pem
+/evals/composer-parity/**/*.p12
+/evals/composer-parity/**/*.pfx
+/evals/composer-parity/**/.env
+/evals/composer-parity/**/.env.*
+!/evals/composer-parity/**/.env.example
+!/evals/composer-parity/**/.env.template
+!/evals/composer-parity/**/.env.sample
 
 # Generated bug analysis docs (can be regenerated)
 docs/bugs/generated/


### PR DESCRIPTION
### Motivation
- A broad negation for `!/evals/composer-parity/**` appeared after repository-wide credential-shaped ignore rules, which caused credential-shaped files under that corpus to become trackable due to gitignore last-match semantics.
- Reapply the repository-wide filename-based safeguards inside the `evals/composer-parity` tree while keeping the intended corpus fixtures and README tracked.

### Description
- Updated `.gitignore` to re-add explicit ignore rules scoped to `evals/composer-parity` so credential-shaped filenames are refused inside the corpus directory.
- Added specific patterns for JWTs, login files, API/access/bearer tokens, certificate and key files, and environment files such as `evals/composer-parity/**/jwt.txt`, `**/jwt-*.txt`, `**/jwt_*.txt`, `**/*.api_key`, `**/*.access_token`, `**/*.bearer_token`, `**/login.json`, `**/login_*.json`, `**/*.pem`, `**/*.p12`, `**/*.pfx`, `**/.env`, and `**/.env.*`.
- Preserved the intentional exceptions for templated environment files by keeping `!/evals/composer-parity/**/.env.example`, `!/evals/composer-parity/**/.env.template`, and `!/evals/composer-parity/**/.env.sample` so sample files remain trackable and fixtures remain unaffected.

### Testing
- Ran `git check-ignore -q` on representative credential-shaped paths under `evals/composer-parity/fixtures/` and confirmed they are ignored (passed).
- Verified representative corpus files such as `evals/composer-parity/README.md`, `evals/composer-parity/fixtures/linear_transform.json`, `evals/composer-parity/fixtures/two_llm_colour.csv`, and `evals/composer-parity/fixtures/two_llm_colour_request.txt` remain trackable with `git check-ignore` (passed).
- Executed `git diff --check` and `git status --short --branch` to ensure no whitespace issues and a clean working tree (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fe07b48323abfd364ec237a81e)