### PR TITLE
fix(export): reject forged audit verification carriers

### DIFF
--- a/src/elspeth/core/landscape/execution/audit_export_snapshots.py
+++ b/src/elspeth/core/landscape/execution/audit_export_snapshots.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass, fields
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Final, cast
+from weakref import WeakSet
 
 from sqlalchemy import and_, or_, select
 from sqlalchemy.engine import Connection
@@ -343,7 +344,7 @@ class AuditExportSnapshotRegistration:
 _VERIFICATION_PROOF: Final = object()
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False, weakref_slot=True)
 class VerifiedAuditExportCandidate:
     """Proof-carrying candidate produced only by ``verify_candidate``.
 
@@ -409,6 +410,7 @@ class AuditExportSnapshotRepository:
     def __init__(self) -> None:
         self._snapshot_loader = _AuditExportSnapshotRowLoader()
         self._chunk_loader = AuditExportSnapshotChunkLoader()
+        self._verified_candidates: WeakSet[VerifiedAuditExportCandidate] = WeakSet()
 
     @staticmethod
     def winner_from_candidate(candidate: AuditExportSnapshotCandidate) -> AuditExportSnapshotWinner:
@@ -532,7 +534,9 @@ class AuditExportSnapshotRepository:
             signed_manifest_verifier=signed_manifest_verifier,
             record_signature_verifier=record_signature_verifier,
         )
-        return VerifiedAuditExportCandidate(candidate=candidate, _proof=_VERIFICATION_PROOF)
+        verified = VerifiedAuditExportCandidate(candidate=candidate, _proof=_VERIFICATION_PROOF)
+        self._verified_candidates.add(verified)
+        return verified
 
     def register_candidate(
         self,
@@ -566,7 +570,7 @@ class AuditExportSnapshotRepository:
         verified: VerifiedAuditExportCandidate,
     ) -> AuditExportSnapshotRegistration:
         """Short write/CAS registration of a verification-proven candidate."""
-        if type(verified) is not VerifiedAuditExportCandidate:
+        if type(verified) is not VerifiedAuditExportCandidate or verified not in self._verified_candidates:
             raise TypeError("verified must be exact VerifiedAuditExportCandidate from verify_candidate")
         candidate = verified.candidate
         key = AuditExportSnapshotRegistryKey.from_snapshot(candidate.snapshot)

--- a/tests/unit/core/landscape/test_audit_export_snapshots.py
+++ b/tests/unit/core/landscape/test_audit_export_snapshots.py
@@ -458,6 +458,37 @@ def test_register_verified_candidate_registers_without_content_store_reads() -> 
         db.close()
 
 
+def test_register_verified_candidate_rejects_replaced_carrier() -> None:
+    db = LandscapeDB.in_memory()
+    store = _MemoryContentStore()
+    resolver = AuditExportContentStoreResolver()
+    resolver.register(store)
+    repository = _repository()
+    try:
+        _insert_terminal_run(db)
+        verified = repository.verify_candidate(
+            _candidate(store),
+            content_store_resolver=resolver,
+            limits=AuditExportSnapshotReadLimits(),
+            signed_manifest_verifier=lambda _content, _descriptor: None,
+        )
+        forged_candidate = _forge_chunk_seal(store, verified.candidate)
+        forged_carriers = (
+            replace(verified, candidate=forged_candidate),
+            VerifiedAuditExportCandidate(candidate=forged_candidate, _proof=verified._proof),
+        )
+
+        for forged in forged_carriers:
+            with pytest.raises(TypeError, match="from verify_candidate"), db.engine.begin() as connection:
+                repository.register_verified_candidate(connection, forged)
+
+        with db.engine.connect() as connection:
+            assert connection.scalar(select(func.count()).select_from(audit_export_snapshots_table)) == 0
+            assert connection.scalar(select(func.count()).select_from(audit_export_snapshot_chunks_table)) == 0
+    finally:
+        db.close()
+
+
 def test_registration_rejects_forged_graph_before_registry_insert() -> None:
     db = LandscapeDB.in_memory()
     store = _MemoryContentStore()


### PR DESCRIPTION
### Motivation

- The two-step audit-export registration API introduced a forgeable proof carrier (`VerifiedAuditExportCandidate`) that callers could reconstruct or copy to bypass expensive graph/signature verification, allowing unverified snapshot rows to be persisted. 
- `register_verified_candidate()` previously checked only the carrier type and therefore accepted forged carriers, undermining audit integrity.

### Description

- Bind verified carriers to the `AuditExportSnapshotRepository` instance that performed verification by tracking exact carrier identities in a `WeakSet` on the repository. 
- Make `VerifiedAuditExportCandidate` weakref-capable (`weakref_slot=True`) and non-equality-based (`eq=False`) so only identity membership is meaningful for acceptance checks. 
- `verify_candidate()` now registers the exact returned `VerifiedAuditExportCandidate` instance in the repository-local weak set, and `register_verified_candidate()` rejects carriers not present in that set. 
- Add a unit test that covers both `dataclasses.replace()` and direct-carrier-reconstruction forgery paths and asserts that forged carriers are rejected and no snapshot or chunk rows are persisted.

### Testing

- ✅ `python -m compileall -q src/elspeth/core/landscape/execution/audit_export_snapshots.py tests/unit/core/landscape/test_audit_export_snapshots.py` (compilation succeeded). 
- ✅ `git diff --check` (no whitespace or patch-format issues). 
- ⚠️ `uv run pytest -q tests/unit/core/landscape/test_audit_export_snapshots.py` (running unit tests was blocked by missing development dependency downloads from PyPI in the environment, so full test execution could not complete here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fd48d48323b519be2f3c710f71)