### PR TITLE
fix(composer): synchronize authoring-aids memo to prevent race

### DIFF
--- a/src/elspeth/web/composer/planner_authoring_aids.py
+++ b/src/elspeth/web/composer/planner_authoring_aids.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
+from threading import Lock
 from typing import Any, Final
 
 from elspeth.contracts.plugin_capabilities import PluginCapability
@@ -734,6 +735,7 @@ def fork_coalesce_exemplar_args(
 # caller can poison the cached payload.
 _AIDS_MEMO: dict[str, dict[str, Any]] = {}
 _AIDS_MEMO_MAX: Final[int] = 8
+_AIDS_MEMO_LOCK = Lock()
 
 
 def build_planner_authoring_aids(catalog: PolicyCatalogView) -> dict[str, Any]:
@@ -744,12 +746,19 @@ def build_planner_authoring_aids(catalog: PolicyCatalogView) -> dict[str, Any]:
     policy-hidden are omitted rather than rendered with invented names.
     """
     key = catalog.snapshot.snapshot_hash
-    cached = _AIDS_MEMO.get(key)
+    with _AIDS_MEMO_LOCK:
+        cached = _AIDS_MEMO.get(key)
     if cached is None:
-        cached = _build_planner_authoring_aids(catalog)
-        if len(_AIDS_MEMO) >= _AIDS_MEMO_MAX:
-            _AIDS_MEMO.pop(next(iter(_AIDS_MEMO)))
-        _AIDS_MEMO[key] = cached
+        built = _build_planner_authoring_aids(catalog)
+        with _AIDS_MEMO_LOCK:
+            # Another worker may have populated this snapshot while the
+            # catalog sweep ran. Prefer that value and mutate/evict only while
+            # holding the cache lock.
+            cached = _AIDS_MEMO.get(key)
+            if cached is None:
+                if len(_AIDS_MEMO) >= _AIDS_MEMO_MAX:
+                    _AIDS_MEMO.pop(next(iter(_AIDS_MEMO)))
+                _AIDS_MEMO[key] = cached = built
     return deepcopy(cached)
 
 

--- a/tests/unit/web/composer/test_planner_authoring_aids.py
+++ b/tests/unit/web/composer/test_planner_authoring_aids.py
@@ -15,13 +15,16 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
+import pytest
 from sqlalchemy import insert
 from sqlalchemy.pool import StaticPool
 
 from elspeth.web.catalog.policy_view import PolicyCatalogView
+from elspeth.web.composer import planner_authoring_aids
 from elspeth.web.composer.planner_authoring_aids import (
     PLACEHOLDER_BLOB_ID,
     build_planner_authoring_aids,
@@ -47,6 +50,37 @@ def _trained_view() -> tuple[PolicyCatalogView, PluginAvailabilitySnapshot]:
     catalog = create_catalog_service()
     snapshot = PluginAvailabilitySnapshot.for_trained_operator(catalog)
     return PolicyCatalogView.for_trained_operator(catalog, snapshot), snapshot
+
+
+def test_authoring_aids_memo_access_is_locked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every cache operation is serialized across planner worker threads."""
+
+    class LockCheckedMemo(dict[str, dict[str, Any]]):
+        def _assert_locked(self) -> None:
+            assert planner_authoring_aids._AIDS_MEMO_LOCK.locked()
+
+        def get(self, key: str, default: Any = None) -> Any:
+            self._assert_locked()
+            return super().get(key, default)
+
+        def __len__(self) -> int:
+            self._assert_locked()
+            return super().__len__()
+
+        def __setitem__(self, key: str, value: dict[str, Any]) -> None:
+            self._assert_locked()
+            super().__setitem__(key, value)
+
+    memo = LockCheckedMemo()
+    monkeypatch.setattr(planner_authoring_aids, "_AIDS_MEMO", memo)
+    monkeypatch.setattr(planner_authoring_aids, "_build_planner_authoring_aids", lambda catalog: {"key": "value"})
+    catalog: Any = SimpleNamespace(snapshot=SimpleNamespace(snapshot_hash="snapshot"))
+
+    first = planner_authoring_aids.build_planner_authoring_aids(catalog)
+    second = planner_authoring_aids.build_planner_authoring_aids(catalog)
+
+    assert first == second == {"key": "value"}
+    assert first is not second
 
 
 def _profile_view(tmp_path: Path) -> tuple[PolicyCatalogView, PluginAvailabilitySnapshot]:


### PR DESCRIPTION
### Motivation

- The process-global authoring-aids memo (`_AIDS_MEMO`) was mutated from planner worker threads without synchronization, allowing concurrent cold builds to race during eviction and raise `StopIteration`/`KeyError` and surface as planner failures.

### Description

- Add a `threading.Lock` as `_AIDS_MEMO_LOCK` and serialize cache reads and mutations using `with _AIDS_MEMO_LOCK:` to prevent concurrent eviction/insert races. 
- Keep the expensive catalog-built payload construction off-lock (`_build_planner_authoring_aids`) and perform a locked second `get` before inserting to prefer any value populated by another worker. 
- Eviction (`_AIDS_MEMO.pop(next(iter(_AIDS_MEMO)))`) and insertion are performed only while holding the lock. 
- Add `test_authoring_aids_memo_access_is_locked` to `tests/unit/web/composer/test_planner_authoring_aids.py` which monkeypatches the cache and builder to assert that `get`, `__len__`, and `__setitem__` are called while the memo lock is held.

### Testing

- Ran `ruff check` and `ruff format --check` against the modified files and they passed. 
- Ran `pytest -q tests/unit/web/composer/test_planner_authoring_aids.py` and the updated unit test passed. 
- Attempting a broader dev test invocation (`uv run --extra dev pytest`) failed due to external dependency download issues (`pytest-xdist`) and the full test run in the base environment reported a missing `hypothesis` dependency, so full-suite runs were blocked by test-environment dependency availability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c2ae97b083238c1af2681cefa3f1)