### PR TITLE
fix(export): reject stale audit node provenance

### DIFF
--- a/src/elspeth/engine/orchestrator/export.py
+++ b/src/elspeth/engine/orchestrator/export.py
@@ -221,6 +221,8 @@ def export_landscape(
     from elspeth.contracts import NodeType
     from elspeth.contracts.errors import AuditIntegrityError
     from elspeth.contracts.schema import SchemaConfig
+    from elspeth.core.canonical import canonical_json, stable_hash
+    from elspeth.core.config import sanitize_node_config_for_audit
 
     # Snapshot first: export audit rows can never recurse into their own bytes.
     factory = RecorderFactory(db, payload_store=payload_store)
@@ -229,8 +231,9 @@ def export_landscape(
     # publication response finds the row a prior attempt registered. Reuse it
     # so the retry reaches SinkEffectCoordinator reconciliation of the durable
     # effect instead of crashing on the nodes composite primary key. Fail
-    # closed if the registered identity is not the audit-export sink node this
-    # attempt would register.
+    # closed if the registered provenance is not exactly what this attempt
+    # would register. A partial identity match would let a changed retry run
+    # under stale audit attribution.
     existing_node = factory.data_flow.get_node(sink.node_id, run_id)
     if existing_node is None:
         factory.data_flow.register_node(
@@ -244,12 +247,27 @@ def export_landscape(
             determinism=Determinism.IO_WRITE,
             source_file_hash=sink.source_file_hash,
         )
-    elif existing_node.node_type is not NodeType.SINK or existing_node.plugin_name != sink.name:
-        raise AuditIntegrityError(
-            f"audit export node {sink.node_id!r} for run {run_id!r} is already registered "
-            f"with divergent identity ({existing_node.node_type.value!r}/{existing_node.plugin_name!r}); "
-            f"refusing to reuse it for export sink {sink.name!r}"
-        )
+    else:
+        audit_safe_config = sanitize_node_config_for_audit(dict(sink.config), plugin_name=sink.name)
+        expected_provenance = {
+            "plugin_name": sink.name,
+            "node_type": NodeType.SINK,
+            "plugin_version": sink.plugin_version,
+            "determinism": Determinism.IO_WRITE,
+            "config_hash": stable_hash(audit_safe_config),
+            "config_json": canonical_json(audit_safe_config),
+            "source_file_hash": sink.source_file_hash,
+            "schema_hash": None,
+            "sequence_in_pipeline": None,
+            "schema_mode": "observed",
+            "schema_fields": None,
+        }
+        divergent_fields = [field for field, expected in expected_provenance.items() if getattr(existing_node, field) != expected]
+        if divergent_fields:
+            raise AuditIntegrityError(
+                f"audit export node {sink.node_id!r} for run {run_id!r} is already registered "
+                f"with divergent provenance fields {divergent_fields!r}; refusing to reuse it for export sink {sink.name!r}"
+            )
     try:
         execute_audit_export_effect(
             factory=factory,

--- a/tests/unit/engine/orchestrator/test_export.py
+++ b/tests/unit/engine/orchestrator/test_export.py
@@ -26,11 +26,12 @@ from uuid import UUID
 import pytest
 from pydantic import ValidationError
 
-from elspeth.contracts import CallType
+from elspeth.contracts import CallType, Determinism, NodeType
 from elspeth.contracts.audit_export import AuditExportContentStoreResolver
 from elspeth.contracts.errors import AuditIntegrityError
 from elspeth.contracts.hashing import stable_hash
 from elspeth.contracts.plugin_context import PluginContext
+from elspeth.contracts.schema import SchemaConfig
 from elspeth.contracts.sink_effects import SINK_EFFECT_PROTOCOL_VERSION, AuditExportFormat, SinkEffectInputKind
 from elspeth.core.landscape.factory import RecorderFactory as _RealRecorderFactory
 from elspeth.engine.orchestrator.export import (
@@ -1355,6 +1356,57 @@ class TestExportNodeRegistrationIdempotence:
                 ),
                 patch("elspeth.engine.orchestrator.audit_export_effects.execute_audit_export_effect") as execute,
                 pytest.raises(AuditIntegrityError, match="export:output"),
+            ):
+                export_landscape(db, run_id, settings, sink_factory)
+
+            execute.assert_not_called()
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize(
+        ("registered_overrides", "retry_overrides", "divergent_field"),
+        [
+            ({"config": {"path": "/old"}}, {"config": {"path": "/new"}}, "config_hash"),
+            ({"plugin_version": "old"}, {"plugin_version": "new"}, "plugin_version"),
+            (
+                {"source_file_hash": "sha256:" + "a" * 16},
+                {"source_file_hash": "sha256:" + "b" * 16},
+                "source_file_hash",
+            ),
+        ],
+    )
+    def test_export_refuses_to_reuse_node_with_stale_provenance(
+        self,
+        registered_overrides: dict[str, Any],
+        retry_overrides: dict[str, Any],
+        divergent_field: str,
+    ) -> None:
+        db, real_factory, run_id = self._real_db_setup()
+        try:
+            valid_source_hash = "sha256:" + "0" * 16
+            registered_sink, _ = _make_sink_and_factory(**{"source_file_hash": valid_source_hash, **registered_overrides})
+            real_factory.data_flow.register_node(
+                run_id=run_id,
+                node_id="export:output",
+                plugin_name=registered_sink.name,
+                node_type=NodeType.SINK,
+                plugin_version=registered_sink.plugin_version,
+                config=dict(registered_sink.config),
+                schema_config=SchemaConfig.from_dict({"mode": "observed"}),
+                determinism=Determinism.IO_WRITE,
+                source_file_hash=registered_sink.source_file_hash,
+            )
+            settings = _make_settings()
+            _retry_sink, sink_factory = _make_sink_and_factory(**{"source_file_hash": valid_source_hash, **retry_overrides})
+
+            with (
+                patch("elspeth.core.landscape.factory.RecorderFactory", _RealRecorderFactory),
+                patch(
+                    "elspeth.engine.orchestrator.audit_export_effects.prepare_audit_export_snapshot",
+                    return_value=object(),
+                ),
+                patch("elspeth.engine.orchestrator.audit_export_effects.execute_audit_export_effect") as execute,
+                pytest.raises(AuditIntegrityError, match=divergent_field),
             ):
                 export_landscape(db, run_id, settings, sink_factory)
 


### PR DESCRIPTION
### Motivation

- Make idempotent export-node reuse safe by preventing retry executions from proceeding under stale/preserved node provenance that can misattribute audit exports.
- The previous idempotence path only compared `node_type` and `plugin_name`, which allowed retries with changed `config`, `plugin_version`, or `source_file_hash` to publish under old provenance.

### Description

- In `export_landscape` (`src/elspeth/engine/orchestrator/export.py`) compute the audit-safe config, `config_hash` and `config_json` using `sanitize_node_config_for_audit`, `stable_hash`, and `canonical_json`, and assemble the full expected provenance for the deterministic `export:<sink>` node.
- Compare the persisted `existing_node` fields (including `plugin_version`, `determinism`, `config_hash`, `config_json`, `source_file_hash`, and schema metadata) to the expected provenance and raise `AuditIntegrityError` if any immutable provenance field diverges instead of silently reusing the row.
- Preserve the fresh-registration path and the intended idempotent behavior for truly identical retries while failing closed when provenance differs.
- Add a parametrized regression test in `tests/unit/engine/orchestrator/test_export.py` that exercises divergent `config`, `plugin_version`, and `source_file_hash` cases and verifies the sink effect is not executed when provenance is stale.

### Testing

- Ran `ruff check src/elspeth/engine/orchestrator/export.py tests/unit/engine/orchestrator/test_export.py` and `ruff format --check` and both passed.
- Ran `python -m compileall -q src/elspeth/engine/orchestrator/export.py tests/unit/engine/orchestrator/test_export.py` and it completed without syntax errors.
- Ran `git diff --check` and repository formatting checks (no problems found).
- Attempted to run `pytest` for the modified unit tests, but execution was blocked by the environment being unable to download a test dependency from PyPI (so the new tests could not be executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fd847c8323abd511a1ee0487c7)