### PR TITLE
fix(landscape): validate failsink primary links

### DIFF
--- a/src/elspeth/core/landscape/execution/sink_effect_reservation.py
+++ b/src/elspeth/core/landscape/execution/sink_effect_reservation.py
@@ -25,6 +25,7 @@ from elspeth.contracts.sink_effects import (
     SinkEffectInputKind,
     SinkEffectMember,
     SinkEffectReservationRequest,
+    SinkEffectRole,
     SinkEffectState,
 )
 from elspeth.core.landscape._helpers import now
@@ -423,6 +424,7 @@ class SinkEffectReservation:
             return SinkEffectReservationResult(finalized, opened, None)
 
         identity = _pipeline_identity(request, unbound)
+        self._validate_primary_links(conn, request, identity)
         sequence: int | None = None
         predecessor: str | None = None
         if request.replacing_target:
@@ -465,6 +467,40 @@ class SinkEffectReservation:
             if result.rowcount != 1:
                 raise ValueError("sink effect stream tail changed during reservation")
         return SinkEffectReservationResult(finalized, opened, effect)
+
+    @staticmethod
+    def _validate_primary_links(
+        conn: Connection,
+        request: SinkEffectReservationRequest,
+        identity: _EffectIdentity,
+    ) -> None:
+        """Require every failsink member to name its own same-run primary effect."""
+        if request.role is SinkEffectRole.PRIMARY:
+            return
+
+        primary_effect_ids = {str(member.primary_effect_id) for member in identity.members}
+        if identity.effect_id in primary_effect_ids:
+            raise ValueError("failsink effect cannot refer to itself as its primary effect")
+        primary_rows = conn.execute(
+            select(sink_effects_table.c.effect_id).where(
+                sink_effects_table.c.effect_id.in_(tuple(sorted(primary_effect_ids))),
+                sink_effects_table.c.run_id == request.run_id,
+                sink_effects_table.c.role == SinkEffectRole.PRIMARY.value,
+            )
+        ).fetchall()
+        if {str(row.effect_id) for row in primary_rows} != primary_effect_ids:
+            raise ValueError("failsink effects require same-run primary effects")
+
+        linked_members = conn.execute(
+            select(sink_effect_members_table.c.effect_id, sink_effect_members_table.c.token_id).where(
+                sink_effect_members_table.c.effect_id.in_(tuple(sorted(primary_effect_ids))),
+                sink_effect_members_table.c.run_id == request.run_id,
+                sink_effect_members_table.c.role == SinkEffectRole.PRIMARY.value,
+            )
+        ).fetchall()
+        primary_members = {(str(row.effect_id), str(row.token_id)) for row in linked_members}
+        if any((str(member.primary_effect_id), member.token_id) not in primary_members for member in identity.members):
+            raise ValueError("failsink members require a primary effect for the same token")
 
     def _reserve_export(self, request: SinkEffectReservationRequest) -> SinkEffectReservationResult:
         assert request.audit_export_snapshot_id is not None

--- a/tests/unit/core/landscape/test_sink_effect_reservation.py
+++ b/tests/unit/core/landscape/test_sink_effect_reservation.py
@@ -132,6 +132,31 @@ def test_pipeline_reservation_is_idempotent_under_reverse_arrival(db_factory: tu
         assert conn.scalar(select(func.count()).select_from(operations_table)) == 1
 
 
+def test_failsink_reservation_rejects_cross_run_primary_link_before_mutation(
+    db_factory: tuple[LandscapeDB, RecorderFactory],
+) -> None:
+    db, factory = db_factory
+    first_run_id, first_sink_id, first_members = _pipeline_members(factory, count=1)
+    primary = factory.execution.sink_effects.reserve(_pipeline_request(first_run_id, first_sink_id, first_members)).new_effect
+    assert primary is not None
+
+    second_run_id, second_sink_id, second_members = _pipeline_members(factory, count=1)
+    request = _pipeline_request(second_run_id, second_sink_id, second_members)
+    failsink_request = replace(
+        request,
+        role=SinkEffectRole.FAILSINK,
+        members=tuple(replace(member, primary_effect_id=primary.effect_id) for member in second_members),
+        primary_effect_id=primary.effect_id,
+    )
+
+    with pytest.raises(ValueError, match="same-run primary effects"):
+        factory.execution.sink_effects.reserve(failsink_request)
+
+    with db.read_only_connection() as conn:
+        assert conn.scalar(select(func.count()).select_from(sink_effects_table)) == 1
+        assert conn.scalar(select(func.count()).select_from(sink_effect_members_table)) == 1
+
+
 @pytest.mark.parametrize("terminal_status", (NodeStateStatus.COMPLETED, NodeStateStatus.FAILED))
 def test_pipeline_reservation_refuses_non_open_latest_sink_state_before_mutation(
     db_factory: tuple[LandscapeDB, RecorderFactory],


### PR DESCRIPTION
### Motivation

- Prevent FAILSINK reservations from accepting arbitrary `primary_effect_id` values that can create self-referential or cross-run primary links and break audit/provenance integrity.

### Description

- Add a pre-insert validation method `_validate_primary_links` that runs during pipeline reservations and rejects self-referential primary IDs, ensures each referenced effect exists and is a `PRIMARY` for the same `run_id`, and confirms each failsink member points to a primary member for the same token. 
- Invoke `_validate_primary_links` before inserting a new pipeline `sink_effect` so invalid links are rejected before any durable mutation.
- Add a regression test `test_failsink_reservation_rejects_cross_run_primary_link_before_mutation` that asserts cross-run primary links are rejected before additional sink rows are persisted.
- Add the missing import for `SinkEffectRole` required by the new validations.

### Testing

- ✅ `uv run ruff check src/elspeth/core/landscape/execution/sink_effect_reservation.py tests/unit/core/landscape/test_sink_effect_reservation.py` succeeded.
- ✅ `python -m compileall -q src/elspeth/core/landscape/execution/sink_effect_reservation.py tests/unit/core/landscape/test_sink_effect_reservation.py` succeeded.
- ✅ `git diff --check` succeeded.
- ⚠️ `uv run pytest tests/unit/core/landscape/test_sink_effect_reservation.py -q` could not complete because the test environment lacked the `hypothesis` package and the package index was unreachable, so unit test execution was not completed here.
- ⚠️ `uv run mypy src/elspeth/core/landscape/execution/sink_effect_reservation.py` could not be fully validated in this environment due to missing plugins/dependencies during type-checking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d2e6add0832393c61507f4eac5f0)