### PR TITLE
fix(sinks): restore precomputed remote reconciliation contract

### DIFF
--- a/src/elspeth/plugins/sinks/_remote_object_effects.py
+++ b/src/elspeth/plugins/sinks/_remote_object_effects.py
@@ -629,8 +629,6 @@ def reconcile_remote_observation(
         return SinkEffectReconcileResult.applied(
             plan.expected_descriptor,
             evidence={"effect_id": plan.effect_id, "provider": evidence.provider, "reconciled": "exact_metadata"},
-            accepted_ordinals=evidence.accepted_ordinals,
-            diverted_ordinals=evidence.diverted_ordinals,
         )
     if not observation.exists and evidence.precondition == "if_none_match":
         return SinkEffectReconcileResult.not_applied(

--- a/tests/unit/plugins/sinks/test_remote_object_sink_effects.py
+++ b/tests/unit/plugins/sinks/test_remote_object_sink_effects.py
@@ -529,8 +529,8 @@ def test_azure_effect_diverts_fixed_schema_extra_and_publishes_good_rows() -> No
         schema={"mode": "fixed", "fields": ["id: int", "name: str"]},
     ).reconcile_effect(plan, _CTX)
     assert reconciled.kind is SinkEffectReconcileKind.APPLIED_WITH_EXACT_DESCRIPTOR
-    assert reconciled.accepted_ordinals == (0,)
-    assert reconciled.diverted_ordinals == (1,)
+    assert reconciled.accepted_ordinals is None
+    assert reconciled.diverted_ordinals is None
 
 
 def test_s3_csv_effect_applies_display_headers_before_serialization() -> None:


### PR DESCRIPTION
### Motivation
- The coordinator rejects any reconciliation that carries result-derived ordinal partitions for `PRECOMPUTED` plans, which can leave already-applied remote sink writes finalized externally but impossible to recover or finalize by the run.

### Description
- Stop returning `accepted_ordinals` and `diverted_ordinals` from `reconcile_remote_observation` for exact remote-object observations by removing those fields from the `SinkEffectReconcileResult.applied(...)` return in `src/elspeth/plugins/sinks/_remote_object_effects.py`.
- Update the Azure diversion regression test in `tests/unit/plugins/sinks/test_remote_object_sink_effects.py` to assert that reconciled ordinal fields are `None` instead of preserving them.

### Testing
- Compiled the modified files with `python -m compileall -q src/elspeth/plugins/sinks/_remote_object_effects.py tests/unit/plugins/sinks/test_remote_object_sink_effects.py` and the compilation succeeded.
- Ran `git diff --check` which reported no issues.
- Attempted to run the unit test suite with `pytest` but execution could not proceed in this environment because test dependencies (`pytest`, `hypothesis`) are not installed, so full test runs were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c3fd71d883239a459fb739590bd4)