### PR TITLE
Fix stale runtime-VAL evidence between runs

### DIFF
--- a/src/elspeth/core/landscape/run_lifecycle_repository.py
+++ b/src/elspeth/core/landscape/run_lifecycle_repository.py
@@ -11,7 +11,6 @@ import re
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from functools import cache
 from typing import TYPE_CHECKING, Any, Final
 
 from sqlalchemy import select
@@ -178,22 +177,10 @@ def _validate_openrouter_catalog_snapshot(*, sha256: str, source: str) -> None:
         raise AuditIntegrityError(f"openrouter_catalog_source must be one of {sorted(_OPENROUTER_CATALOG_SOURCES)!r}, got {source!r}")
 
 
-@cache
-def _cached_frozen_runtime_val_manifest_json() -> str:
-    """Serialize the process's frozen runtime-VAL registries once.
-
-    Building the manifest hashes source, bytecode, and transitive helper
-    dependencies. Those inputs cannot change after the registries are frozen
-    in a production worker, so recomputing them for every run adds latency
-    without adding evidence. The uncached builder remains authoritative for
-    direct drift probes that deliberately mutate code objects.
-    """
-    return canonical_json(build_runtime_val_manifest())
-
-
 def _frozen_runtime_val_manifest_json() -> str:
+    """Serialize the runtime-VAL state in force at the start of this run."""
     _assert_runtime_val_registries_frozen()
-    return _cached_frozen_runtime_val_manifest_json()
+    return canonical_json(build_runtime_val_manifest())
 
 
 class RunLifecycleRepository:

--- a/tests/unit/core/landscape/test_run_lifecycle_repository.py
+++ b/tests/unit/core/landscape/test_run_lifecycle_repository.py
@@ -17,6 +17,7 @@ import json
 import pytest
 from sqlalchemy import select, update
 
+import elspeth.core.landscape.run_lifecycle_repository as run_lifecycle_repository_module
 from elspeth.contracts import (
     Determinism,
     ExportStatus,
@@ -394,6 +395,26 @@ class TestBeginRunRuntimeValManifest:
         manifest_json = row[0]
         assert manifest_json is not None, "runtime_val_manifest_json is NULL"
         return json.loads(manifest_json)
+
+    def test_begin_run_rebuilds_manifest_for_each_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Run-start evidence must reflect implementation drift between runs."""
+        build_count = 0
+
+        def build_manifest() -> dict[str, object]:
+            nonlocal build_count
+            build_count += 1
+            return {"implementation_generation": build_count}
+
+        monkeypatch.setattr(run_lifecycle_repository_module, "build_runtime_val_manifest", build_manifest)
+        db = make_landscape_db()
+        repo = RunLifecycleRepository(db, DatabaseOps(db), RunLoader())
+
+        repo.begin_run(config={}, canonical_version="v1", run_id="manifest-before-drift")
+        repo.begin_run(config={}, canonical_version="v1", run_id="manifest-after-drift")
+
+        assert self._fetch_manifest(db, "manifest-before-drift") == {"implementation_generation": 1}
+        assert self._fetch_manifest(db, "manifest-after-drift") == {"implementation_generation": 2}
+        assert build_count == 2
 
     def test_manifest_records_declaration_contract_registry(self) -> None:
         """Registered DeclarationContract instances appear in the manifest."""


### PR DESCRIPTION
### Motivation
- A process-global cached serialization of the frozen runtime-VAL manifest allowed begin_run to record stale implementation hashes when in-process code changed after the first manifest build, weakening run-start audit evidence integrity.
- The goal is to ensure each run records a manifest that reflects the registries and implementation state frozen at that run's start so drift is detectable.

### Description
- Remove the process-global memoized manifest and have `_frozen_runtime_val_manifest_json()` call `canonical_json(build_runtime_val_manifest())` so the manifest is recomputed for each run start. 
- Delete the `@cache`-backed wrapper and its memoized builder to avoid returning cached JSON across runs. 
- Add a regression test `test_begin_run_rebuilds_manifest_for_each_run` that monkeypatches `build_runtime_val_manifest` and asserts two consecutive `begin_run()` calls persist independently rebuilt manifests.

### Testing
- Ran `ruff check` and `ruff format --check` on the modified files and they passed. 
- Ran `git diff --check` to validate whitespace/formatting issues and it passed. 
- Attempted to run the unit test file with `pytest` but the test run could not be executed because `hypothesis` was not available in the environment and dependency installation was blocked by the environment's network tunnel (dependency download for `parso` failed), so the new regression test was not executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4ccd2f48323b3907189794eb0b3)