### PR TITLE
fix(composer): reject mixed queue fields cleanly

### DIFF
--- a/src/elspeth/web/composer/yaml_importer.py
+++ b/src/elspeth/web/composer/yaml_importer.py
@@ -329,7 +329,7 @@ def _queues_from_runtime_mapping(section: object) -> list[NodeSpec]:
             raise RuntimeYamlImportError("queues keys must be non-empty strings")
         path = f"queues.{raw_name}"
         entry = _require_mapping(raw_entry, path)
-        unknown = sorted(set(entry) - {"description"})
+        unknown = sorted(set(entry) - {"description"}, key=lambda field: (type(field).__name__, repr(field)))
         if unknown:
             raise RuntimeYamlImportError(f"{path} contains unknown field(s): {unknown}")
         description = entry.get("description")

--- a/tests/unit/web/composer/test_yaml_importer.py
+++ b/tests/unit/web/composer/test_yaml_importer.py
@@ -588,6 +588,11 @@ def test_composition_state_from_runtime_yaml_rejects_unknown_queue_field() -> No
         composition_state_from_runtime_yaml("queues:\n  inbound:\n    priority: 5\n")
 
 
+def test_composition_state_from_runtime_yaml_rejects_mixed_type_unknown_queue_fields() -> None:
+    with pytest.raises(RuntimeYamlImportError, match=r"queues\.inbound contains unknown field\(s\): \[1, 'priority'\]"):
+        composition_state_from_runtime_yaml("queues:\n  inbound:\n    priority: 5\n    1: invalid\n")
+
+
 def test_composition_state_from_runtime_yaml_rejects_non_string_queue_description() -> None:
     with pytest.raises(RuntimeYamlImportError, match=r"queues\.inbound\.description must be a string"):
         composition_state_from_runtime_yaml("queues:\n  inbound:\n    description: 7\n")


### PR DESCRIPTION
### Motivation

- Prevent a `TypeError` when importing `queues:` YAML that contains mixed-type mapping keys (e.g. string and int) so malformed untrusted input is rejected with the expected `RuntimeYamlImportError` instead of triggering a 500.
- Keep the existing behavior for normal string-only unknown fields while making the unknown-field ordering deterministic across heterogeneous key types.

### Description

- Change the unknown-field sorting to a deterministic key function by replacing `unknown = sorted(set(entry) - {"description"})` with `unknown = sorted(set(entry) - {"description"}, key=lambda field: (type(field).__name__, repr(field)))` in `src/elspeth/web/composer/yaml_importer.py` so mixed-type keys do not raise `TypeError` during sorting.
- Add a regression test `test_composition_state_from_runtime_yaml_rejects_mixed_type_unknown_queue_fields` to `tests/unit/web/composer/test_yaml_importer.py` that asserts a mixed integer/string unknown key set is rejected with `RuntimeYamlImportError`.
- Preserve existing error messages and handling for string-only unknown fields and non-string descriptions.

### Testing

- Ran `ruff check src/elspeth/web/composer/yaml_importer.py tests/unit/web/composer/test_yaml_importer.py` which passed.
- Ran `ruff format --check src/elspeth/web/composer/yaml_importer.py tests/unit/web/composer/test_yaml_importer.py` which passed.
- Ran `python -m compileall -q src/elspeth/web/composer/yaml_importer.py tests/unit/web/composer/test_yaml_importer.py` which passed and `git diff --check` which showed no issues.
- Attempted to run `pytest -q tests/unit/web/composer/test_yaml_importer.py -k 'queue'` but test collection could not start due to missing dev dependency `hypothesis` and the environment being unable to install dev extras (network/package fetch limitation), so full pytest execution was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4cccb708323a7408579255991d6)