### PR TITLE
Fix traceback secret scrubbing across frame-like lines

### DIFF
--- a/src/elspeth/contracts/errors.py
+++ b/src/elspeth/contracts/errors.py
@@ -61,16 +61,18 @@ def _scrub_traceback_for_audit(traceback_text: str) -> str:
             if scrub_text_for_audit(tail_text) != tail_text:
                 redacted_indexes.update(range(tail_start, run_stop))
 
-    for run_start, run_stop in nonstructural_runs:
-        for start in range(run_start, run_stop):
-            window_stop = min(run_stop, start + _TRACEBACK_SECRET_WINDOW_SIZE)
-            for stop in range(start + 2, window_stop + 1):
-                window_indexes = range(start, stop)
-                if any(index in redacted_indexes for index in window_indexes):
-                    continue
-                window_text = _join_line_parts(line_parts[start:stop])
-                if scrub_text_for_audit(window_text) != window_text:
-                    redacted_indexes.update(window_indexes)
+    # Scan bounded windows across every line boundary. Exception text is
+    # attacker-controlled and may itself look like traceback structure, so a
+    # structural classification must not create a secret-scrubbing boundary.
+    for window_size in range(2, _TRACEBACK_SECRET_WINDOW_SIZE + 1):
+        for start in range(len(line_parts) - window_size + 1):
+            stop = start + window_size
+            window_indexes = range(start, stop)
+            if any(index in redacted_indexes for index in window_indexes):
+                continue
+            window_text = _join_line_parts(line_parts[start:stop])
+            if scrub_text_for_audit(window_text) != window_text:
+                redacted_indexes.update(window_indexes)
 
     return "".join(
         f"{scrubbed_content_by_index[index] if index not in redacted_indexes else _REDACTED_SECRET}{line_ending}"

--- a/tests/unit/contracts/test_errors.py
+++ b/tests/unit/contracts/test_errors.py
@@ -177,6 +177,33 @@ class TestExecutionError:
         assert "opaque-token" not in error.traceback
         assert "opaque-token" not in str(error.to_dict())
 
+    def test_execution_error_traceback_scrubs_secret_split_by_fake_frame(self) -> None:
+        """Attacker-controlled frame-like message lines cannot evade scrubbing."""
+        from elspeth.contracts import ExecutionError
+
+        traceback = (
+            'Traceback (most recent call last):\n'
+            '  File "worker.py", line 10, in run\n'
+            'RuntimeError: Authorization:\n'
+            'File "Bearer opaque-token"\n'
+        )
+
+        error = ExecutionError(
+            exception="boom",
+            exception_type="RuntimeError",
+            traceback=traceback,
+        )
+
+        assert error.traceback == (
+            'Traceback (most recent call last):\n'
+            '  File "worker.py", line 10, in run\n'
+            '<redacted-secret>\n'
+            '<redacted-secret>\n'
+        )
+        assert "Authorization" not in error.traceback
+        assert "opaque-token" not in error.traceback
+        assert "opaque-token" not in str(error.to_dict())
+
     def test_execution_error_traceback_scrubs_secret_continuation_after_redacted_message_line(self) -> None:
         """Continuation lines after a redacted exception message tail are redacted."""
         from elspeth.contracts import ExecutionError


### PR DESCRIPTION
### Motivation
- The traceback scrubber previously excluded lines classified as traceback structure from multi-line secret detection, allowing attacker-controlled exception text that mimics frames (e.g., lines starting with `File "`) to split and evade redaction.
- The goal is to ensure secrets split across message and frame-like lines are still detected and redacted while preserving legitimate frame diagnostics when possible.

### Description
- Replace the windowed multi-line scanning restricted to `nonstructural_runs` with a bounded-window scan across every line boundary so structural classification cannot create a scrubbing boundary, implemented in `src/elspeth/contracts/errors.py` in `_scrub_traceback_for_audit`.
- Iterate by `window_size` first and then by `start` to evaluate smaller windows before larger ones, so only the minimal implicated lines are redacted and safe frames are preserved.
- Keep the existing per-line single-line redaction and exception-tail handling, and combine those results with the new bounded-window detection to compute `redacted_indexes`.
- Add a regression test `test_execution_error_traceback_scrubs_secret_split_by_fake_frame` in `tests/unit/contracts/test_errors.py` that verifies an `Authorization:` message whose value appears on a fake `File "..."` line is fully redacted in the persisted `ExecutionError.traceback` and audit payload.

### Testing
- Ran a targeted proof-of-concept check with `PYTHONPATH=src python - <<'PY' ... PY` which validated the regression is fixed and printed `PoC regression check passed` (passed).
- Ran `ruff check src/elspeth/contracts/errors.py tests/unit/contracts/test_errors.py` which succeeded (passed).
- Ran repository checks including `git diff --check` which passed (passed).
- Attempted to run the unit test suite with `uv run --frozen --with hypothesis pytest tests/unit/contracts/test_errors.py -q`, but the environment could not download `hypothesis` from PyPI so the full pytest invocation could not complete (blocked by missing test dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65d4ce64348323b0c9aac4adc99816)